### PR TITLE
[GEN-56] feat: security foundations — EP-10

### DIFF
--- a/app/helpers/AuditLogger.php
+++ b/app/helpers/AuditLogger.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * AuditLogger — Log inmutable de auditoría.
+ *
+ * Registra: login/logout, crear/editar/desactivar registro,
+ * cambios de estado ticket, gestión de usuarios.
+ *
+ * NUNCA se elimina un registro de logs_auditoria.
+ */
+class AuditLogger
+{
+    /**
+     * Registrar una acción en el log de auditoría.
+     *
+     * @param string     $accion          Ej: 'login', 'crear_registro', 'cerrar_ticket'
+     * @param string|null $entidad         Ej: 'registros', 'tickets', 'usuarios'
+     * @param int|null    $entidadId       ID del registro afectado
+     * @param array|null  $datosAnteriores Estado antes del cambio
+     * @param array|null  $datosNuevos     Estado después del cambio
+     */
+    public static function log(
+        string $accion,
+        ?string $entidad = null,
+        ?int $entidadId = null,
+        ?array $datosAnteriores = null,
+        ?array $datosNuevos = null
+    ): void {
+        $db = Database::getInstance();
+
+        $db->execute(
+            "INSERT INTO logs_auditoria
+                (usuario_id, empresa_id, accion, entidad, entidad_id, datos_anteriores, datos_nuevos, ip, user_agent)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                Auth::isLoggedIn() ? Auth::userId() : null,
+                Auth::isLoggedIn() ? (Auth::empresaId() ?: null) : null,
+                $accion,
+                $entidad,
+                $entidadId,
+                $datosAnteriores !== null ? json_encode($datosAnteriores, JSON_UNESCAPED_UNICODE) : null,
+                $datosNuevos !== null ? json_encode($datosNuevos, JSON_UNESCAPED_UNICODE) : null,
+                $_SERVER['REMOTE_ADDR'] ?? null,
+                substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 300),
+            ]
+        );
+    }
+
+    /**
+     * Registrar login exitoso.
+     */
+    public static function logLogin(int $userId): void
+    {
+        $db = Database::getInstance();
+        $db->execute(
+            "INSERT INTO logs_auditoria
+                (usuario_id, accion, ip, user_agent)
+             VALUES (?, 'login', ?, ?)",
+            [
+                $userId,
+                $_SERVER['REMOTE_ADDR'] ?? null,
+                substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 300),
+            ]
+        );
+    }
+
+    /**
+     * Registrar intento de login fallido.
+     */
+    public static function logLoginFailed(string $email): void
+    {
+        $db = Database::getInstance();
+        $db->execute(
+            "INSERT INTO logs_auditoria
+                (accion, entidad, datos_nuevos, ip, user_agent)
+             VALUES ('login_fallido', 'usuarios', ?, ?, ?)",
+            [
+                json_encode(['email' => $email]),
+                $_SERVER['REMOTE_ADDR'] ?? null,
+                substr($_SERVER['HTTP_USER_AGENT'] ?? '', 0, 300),
+            ]
+        );
+    }
+
+    /**
+     * Registrar logout.
+     */
+    public static function logLogout(): void
+    {
+        self::log('logout');
+    }
+
+    /**
+     * Consultar logs con filtros (para vista de Super Admin).
+     *
+     * @param array{
+     *   empresa_id?: int,
+     *   usuario_id?: int,
+     *   accion?: string,
+     *   entidad?: string,
+     *   fecha_desde?: string,
+     *   fecha_hasta?: string,
+     * } $filters
+     * @param int $limit
+     * @param int $offset
+     * @return array{logs: array, total: int}
+     */
+    public static function search(array $filters = [], int $limit = 50, int $offset = 0): array
+    {
+        $db = Database::getInstance();
+        $where = [];
+        $params = [];
+
+        if (!empty($filters['empresa_id'])) {
+            $where[] = 'l.empresa_id = ?';
+            $params[] = $filters['empresa_id'];
+        }
+
+        if (!empty($filters['usuario_id'])) {
+            $where[] = 'l.usuario_id = ?';
+            $params[] = $filters['usuario_id'];
+        }
+
+        if (!empty($filters['accion'])) {
+            $where[] = 'l.accion = ?';
+            $params[] = $filters['accion'];
+        }
+
+        if (!empty($filters['entidad'])) {
+            $where[] = 'l.entidad = ?';
+            $params[] = $filters['entidad'];
+        }
+
+        if (!empty($filters['fecha_desde'])) {
+            $where[] = 'l.timestamp >= ?';
+            $params[] = $filters['fecha_desde'] . ' 00:00:00';
+        }
+
+        if (!empty($filters['fecha_hasta'])) {
+            $where[] = 'l.timestamp <= ?';
+            $params[] = $filters['fecha_hasta'] . ' 23:59:59';
+        }
+
+        $whereClause = $where ? 'WHERE ' . implode(' AND ', $where) : '';
+
+        // Total de resultados
+        $countRow = $db->queryOne(
+            "SELECT COUNT(*) as total FROM logs_auditoria l {$whereClause}",
+            $params
+        );
+        $total = (int) ($countRow['total'] ?? 0);
+
+        // Resultados paginados
+        $paramsWithLimit = array_merge($params, [$limit, $offset]);
+        $logs = $db->query(
+            "SELECT l.*, u.nombre AS usuario_nombre, u.email AS usuario_email
+             FROM logs_auditoria l
+             LEFT JOIN usuarios u ON l.usuario_id = u.id
+             {$whereClause}
+             ORDER BY l.timestamp DESC
+             LIMIT ? OFFSET ?",
+            $paramsWithLimit
+        );
+
+        return ['logs' => $logs, 'total' => $total];
+    }
+}

--- a/app/helpers/CsrfHelper.php
+++ b/app/helpers/CsrfHelper.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * CsrfHelper — Protección CSRF para formularios POST.
+ *
+ * Uso en formularios:
+ *   <input type="hidden" name="_csrf_token" value="<?= CsrfHelper::generate() ?>">
+ *
+ * Validación en controlador:
+ *   CsrfHelper::verify($_POST['_csrf_token'] ?? '');
+ */
+class CsrfHelper
+{
+    private const TOKEN_KEY = '_csrf_token';
+
+    /**
+     * Generar token CSRF y almacenarlo en sesión.
+     * Si ya existe uno válido, lo reutiliza (por sesión, no por request).
+     */
+    public static function generate(): string
+    {
+        if (empty($_SESSION[self::TOKEN_KEY])) {
+            $_SESSION[self::TOKEN_KEY] = bin2hex(random_bytes(32));
+        }
+        return $_SESSION[self::TOKEN_KEY];
+    }
+
+    /**
+     * Verificar que el token enviado coincide con el de sesión.
+     * Si falla, retorna 403 y detiene la ejecución.
+     */
+    public static function verify(string $token): void
+    {
+        $sessionToken = $_SESSION[self::TOKEN_KEY] ?? '';
+
+        if ($sessionToken === '' || !hash_equals($sessionToken, $token)) {
+            http_response_code(403);
+            exit('Error de seguridad: token CSRF inválido. Recarga la página e intenta de nuevo.');
+        }
+    }
+
+    /**
+     * Verificar sin detener ejecución. Retorna true/false.
+     */
+    public static function isValid(string $token): bool
+    {
+        $sessionToken = $_SESSION[self::TOKEN_KEY] ?? '';
+        return $sessionToken !== '' && hash_equals($sessionToken, $token);
+    }
+
+    /**
+     * Generar campo HTML hidden listo para insertar en formulario.
+     */
+    public static function field(): string
+    {
+        $token = self::generate();
+        return '<input type="hidden" name="' . self::TOKEN_KEY . '" value="' . htmlspecialchars($token, ENT_QUOTES, 'UTF-8') . '">';
+    }
+
+    /**
+     * Regenerar token (usar después de operaciones sensibles).
+     */
+    public static function regenerate(): string
+    {
+        unset($_SESSION[self::TOKEN_KEY]);
+        return self::generate();
+    }
+}

--- a/app/helpers/PasswordHelper.php
+++ b/app/helpers/PasswordHelper.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * PasswordHelper — Gestión segura de contraseñas.
+ *
+ * Reglas:
+ * - password_hash() con PASSWORD_BCRYPT cost 12
+ * - Contraseñas temporales de 12 caracteres
+ * - NUNCA almacenar ni loguear contraseñas en texto plano
+ */
+class PasswordHelper
+{
+    private const BCRYPT_COST = 12;
+    private const TEMP_PASSWORD_LENGTH = 12;
+
+    /**
+     * Hashear contraseña con bcrypt.
+     */
+    public static function hash(string $password): string
+    {
+        return password_hash($password, PASSWORD_BCRYPT, [
+            'cost' => self::BCRYPT_COST,
+        ]);
+    }
+
+    /**
+     * Verificar contraseña contra hash.
+     */
+    public static function verify(string $password, string $hash): bool
+    {
+        return password_verify($password, $hash);
+    }
+
+    /**
+     * Verificar si el hash necesita ser re-hasheado
+     * (por cambio de cost u algoritmo).
+     */
+    public static function needsRehash(string $hash): bool
+    {
+        return password_needs_rehash($hash, PASSWORD_BCRYPT, [
+            'cost' => self::BCRYPT_COST,
+        ]);
+    }
+
+    /**
+     * Generar contraseña temporal segura.
+     * Contiene mayúsculas, minúsculas, números y un carácter especial.
+     */
+    public static function generateTemporary(): string
+    {
+        $upper   = 'ABCDEFGHIJKLMNPQRSTUVWXYZ';
+        $lower   = 'abcdefghijkmnpqrstuvwxyz';
+        $digits  = '23456789';
+        $special = '!@#$%&*';
+
+        // Garantizar al menos uno de cada tipo
+        $password  = $upper[random_int(0, strlen($upper) - 1)];
+        $password .= $lower[random_int(0, strlen($lower) - 1)];
+        $password .= $digits[random_int(0, strlen($digits) - 1)];
+        $password .= $special[random_int(0, strlen($special) - 1)];
+
+        // Rellenar hasta la longitud deseada
+        $all = $upper . $lower . $digits . $special;
+        for ($i = 4; $i < self::TEMP_PASSWORD_LENGTH; $i++) {
+            $password .= $all[random_int(0, strlen($all) - 1)];
+        }
+
+        // Mezclar los caracteres
+        return str_shuffle($password);
+    }
+
+    /**
+     * Validar que una contraseña cumple requisitos mínimos.
+     * Mínimo 8 caracteres, al menos 1 mayúscula, 1 minúscula, 1 número.
+     *
+     * @return string|null Mensaje de error, o null si es válida
+     */
+    public static function validate(string $password): ?string
+    {
+        if (mb_strlen($password) < 8) {
+            return 'La contraseña debe tener al menos 8 caracteres.';
+        }
+        if (!preg_match('/[A-Z]/', $password)) {
+            return 'La contraseña debe contener al menos una letra mayúscula.';
+        }
+        if (!preg_match('/[a-z]/', $password)) {
+            return 'La contraseña debe contener al menos una letra minúscula.';
+        }
+        if (!preg_match('/[0-9]/', $password)) {
+            return 'La contraseña debe contener al menos un número.';
+        }
+        return null;
+    }
+}

--- a/app/helpers/UploadHelper.php
+++ b/app/helpers/UploadHelper.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * UploadHelper — Manejo seguro de archivos subidos.
+ *
+ * Reglas:
+ * - Validar MIME type + extensión en servidor (no solo cliente)
+ * - Renombrar a UUID
+ * - Almacenar en UPLOAD_PATH con .htaccess que bloquea ejecución
+ */
+class UploadHelper
+{
+    /** Extensiones permitidas por categoría */
+    private const ALLOWED = [
+        'images' => [
+            'extensions' => ['jpg', 'jpeg', 'png', 'gif', 'webp'],
+            'mimes'      => ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+        ],
+        'documents' => [
+            'extensions' => ['pdf', 'doc', 'docx', 'xls', 'xlsx'],
+            'mimes'      => [
+                'application/pdf',
+                'application/msword',
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                'application/vnd.ms-excel',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ],
+        ],
+        'archives' => [
+            'extensions' => ['zip'],
+            'mimes'      => ['application/zip', 'application/x-zip-compressed'],
+        ],
+    ];
+
+    /**
+     * Subir archivo de forma segura.
+     *
+     * @param array  $file       Elemento de $_FILES (ej: $_FILES['adjunto'])
+     * @param string $subdir     Subdirectorio dentro de uploads (ej: 'logos', 'tickets')
+     * @param string[] $categories Categorías permitidas: 'images', 'documents', 'archives'
+     * @return array{success: bool, filename?: string, original_name?: string, mime?: string, size?: int, error?: string}
+     */
+    public static function upload(array $file, string $subdir, array $categories = ['images', 'documents']): array
+    {
+        // Verificar errores de PHP
+        if ($file['error'] !== UPLOAD_ERR_OK) {
+            return ['success' => false, 'error' => self::getUploadError($file['error'])];
+        }
+
+        // Verificar tamaño
+        if ($file['size'] > MAX_UPLOAD_SIZE) {
+            $maxMb = round(MAX_UPLOAD_SIZE / 1048576, 1);
+            return ['success' => false, 'error' => "El archivo excede el tamaño máximo permitido ({$maxMb} MB)."];
+        }
+
+        // Obtener extensión del nombre original
+        $originalName = basename($file['name']);
+        $extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+
+        // Validar extensión contra categorías permitidas
+        $allowedExtensions = [];
+        $allowedMimes = [];
+        foreach ($categories as $cat) {
+            if (isset(self::ALLOWED[$cat])) {
+                $allowedExtensions = array_merge($allowedExtensions, self::ALLOWED[$cat]['extensions']);
+                $allowedMimes = array_merge($allowedMimes, self::ALLOWED[$cat]['mimes']);
+            }
+        }
+
+        if (!in_array($extension, $allowedExtensions, true)) {
+            return ['success' => false, 'error' => 'Tipo de archivo no permitido.'];
+        }
+
+        // Validar MIME type real del archivo (no confiar en el Content-Type del request)
+        $detectedMime = mime_content_type($file['tmp_name']);
+        if ($detectedMime === false || !in_array($detectedMime, $allowedMimes, true)) {
+            return ['success' => false, 'error' => 'El tipo MIME del archivo no coincide con la extensión.'];
+        }
+
+        // Generar nombre UUID
+        $uuid = self::generateUuid();
+        $newFilename = $uuid . '.' . $extension;
+
+        // Asegurar que el directorio destino existe
+        $destDir = rtrim(UPLOAD_PATH, '/\\') . '/' . $subdir;
+        if (!is_dir($destDir)) {
+            mkdir($destDir, 0755, true);
+        }
+
+        $destPath = $destDir . '/' . $newFilename;
+
+        // Mover archivo
+        if (!move_uploaded_file($file['tmp_name'], $destPath)) {
+            return ['success' => false, 'error' => 'Error al guardar el archivo en el servidor.'];
+        }
+
+        return [
+            'success'       => true,
+            'filename'      => $newFilename,
+            'original_name' => $originalName,
+            'mime'          => $detectedMime,
+            'size'          => $file['size'],
+        ];
+    }
+
+    /**
+     * Eliminar archivo de uploads.
+     */
+    public static function delete(string $subdir, string $filename): bool
+    {
+        $path = rtrim(UPLOAD_PATH, '/\\') . '/' . $subdir . '/' . basename($filename);
+        if (file_exists($path)) {
+            return unlink($path);
+        }
+        return false;
+    }
+
+    /**
+     * Generar UUID v4.
+     */
+    private static function generateUuid(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // version 4
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // variant
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+
+    /**
+     * Traducir código de error de upload a mensaje.
+     */
+    private static function getUploadError(int $code): string
+    {
+        return match ($code) {
+            UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE => 'El archivo excede el tamaño máximo permitido.',
+            UPLOAD_ERR_PARTIAL    => 'El archivo se subió parcialmente.',
+            UPLOAD_ERR_NO_FILE    => 'No se seleccionó ningún archivo.',
+            UPLOAD_ERR_NO_TMP_DIR => 'Falta la carpeta temporal del servidor.',
+            UPLOAD_ERR_CANT_WRITE => 'Error de escritura en disco.',
+            UPLOAD_ERR_EXTENSION  => 'Una extensión de PHP detuvo la subida.',
+            default               => 'Error desconocido al subir el archivo.',
+        };
+    }
+}

--- a/app/helpers/Validator.php
+++ b/app/helpers/Validator.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Validator — Validación y sanitización de entradas.
+ *
+ * Reglas:
+ * - htmlspecialchars() en toda salida HTML
+ * - Validar fechas, castear numéricos
+ * - Validar selects contra whitelist en servidor
+ */
+class Validator
+{
+    /** @var array<string, string> Errores acumulados */
+    private array $errors = [];
+
+    /** @var array<string, mixed> Datos validados y limpios */
+    private array $clean = [];
+
+    /** @var array<string, mixed> Datos de entrada */
+    private array $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Validar campo string requerido.
+     */
+    public function required(string $field, string $label): self
+    {
+        $value = trim((string) ($this->data[$field] ?? ''));
+        if ($value === '') {
+            $this->errors[$field] = "{$label} es obligatorio.";
+        } else {
+            $this->clean[$field] = $value;
+        }
+        return $this;
+    }
+
+    /**
+     * Validar campo string opcional (si está presente, se limpia).
+     */
+    public function optional(string $field): self
+    {
+        $value = trim((string) ($this->data[$field] ?? ''));
+        $this->clean[$field] = $value !== '' ? $value : null;
+        return $this;
+    }
+
+    /**
+     * Validar email.
+     */
+    public function email(string $field, string $label): self
+    {
+        $value = trim((string) ($this->data[$field] ?? ''));
+        if ($value === '') {
+            $this->errors[$field] = "{$label} es obligatorio.";
+        } elseif (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            $this->errors[$field] = "{$label} no es un email válido.";
+        } else {
+            $this->clean[$field] = strtolower($value);
+        }
+        return $this;
+    }
+
+    /**
+     * Validar entero positivo.
+     */
+    public function integer(string $field, string $label, bool $required = true): self
+    {
+        $value = $this->data[$field] ?? null;
+        if ($value === null || $value === '') {
+            if ($required) {
+                $this->errors[$field] = "{$label} es obligatorio.";
+            } else {
+                $this->clean[$field] = null;
+            }
+        } else {
+            $intVal = filter_var($value, FILTER_VALIDATE_INT);
+            if ($intVal === false) {
+                $this->errors[$field] = "{$label} debe ser un número entero.";
+            } else {
+                $this->clean[$field] = $intVal;
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Validar fecha (formato Y-m-d).
+     */
+    public function date(string $field, string $label, bool $required = true): self
+    {
+        $value = trim((string) ($this->data[$field] ?? ''));
+        if ($value === '') {
+            if ($required) {
+                $this->errors[$field] = "{$label} es obligatorio.";
+            } else {
+                $this->clean[$field] = null;
+            }
+        } else {
+            $dt = \DateTimeImmutable::createFromFormat('Y-m-d', $value);
+            if (!$dt || $dt->format('Y-m-d') !== $value) {
+                $this->errors[$field] = "{$label} no tiene un formato de fecha válido (AAAA-MM-DD).";
+            } else {
+                $this->clean[$field] = $value;
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Validar que el valor está en una lista permitida (whitelist).
+     *
+     * @param string[] $allowed Valores válidos
+     */
+    public function inList(string $field, string $label, array $allowed, bool $required = true): self
+    {
+        $value = trim((string) ($this->data[$field] ?? ''));
+        if ($value === '') {
+            if ($required) {
+                $this->errors[$field] = "{$label} es obligatorio.";
+            } else {
+                $this->clean[$field] = null;
+            }
+        } elseif (!in_array($value, $allowed, true)) {
+            $this->errors[$field] = "{$label} contiene un valor no permitido.";
+        } else {
+            $this->clean[$field] = $value;
+        }
+        return $this;
+    }
+
+    /**
+     * Validar longitud mínima y máxima.
+     */
+    public function length(string $field, string $label, int $min, int $max): self
+    {
+        $value = $this->clean[$field] ?? trim((string) ($this->data[$field] ?? ''));
+        $len = mb_strlen($value);
+        if ($len < $min || $len > $max) {
+            $this->errors[$field] = "{$label} debe tener entre {$min} y {$max} caracteres.";
+        }
+        return $this;
+    }
+
+    /**
+     * Verificar si la validación pasó sin errores.
+     */
+    public function passes(): bool
+    {
+        return empty($this->errors);
+    }
+
+    /**
+     * Obtener errores de validación.
+     *
+     * @return array<string, string>
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Obtener datos validados y limpios.
+     *
+     * @return array<string, mixed>
+     */
+    public function validated(): array
+    {
+        return $this->clean;
+    }
+
+    // ============================================================
+    // SANITIZACIÓN DE SALIDA (métodos estáticos)
+    // ============================================================
+
+    /**
+     * Escapar para salida HTML.
+     * Usar SIEMPRE al renderizar variables en vistas.
+     */
+    public static function e(mixed $value): string
+    {
+        return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -20,10 +20,26 @@ if (session_status() === PHP_SESSION_NONE) {
     ]);
 }
 
-// Headers de seguridad básicos
+// Headers de seguridad
 header('X-Frame-Options: DENY');
 header('X-Content-Type-Options: nosniff');
 header('Referrer-Policy: strict-origin-when-cross-origin');
+header('X-XSS-Protection: 1; mode=block');
+header('Permissions-Policy: camera=(), microphone=(), geolocation=()');
+
+// Content Security Policy — permite Bootstrap CDN, Chart.js CDN y estilos inline de Bootstrap
+$csp = implode('; ', [
+    "default-src 'self'",
+    "script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+    "font-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+]);
+header('Content-Security-Policy: ' . $csp);
 
 // Obtener URI limpia
 $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,0 +1,17 @@
+# Bloquear ejecución de scripts en directorio de uploads
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteRule \.(php|phtml|php3|php4|php5|phps|cgi|pl|py|sh|bash)$ - [F,L]
+</IfModule>
+
+# Deshabilitar ejecución de PHP
+<IfModule mod_php.c>
+    php_flag engine off
+</IfModule>
+
+# Solo permitir tipos de archivo seguros
+<FilesMatch "\.(?!jpg|jpeg|png|gif|pdf|xlsx|docx|zip)$">
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+</FilesMatch>


### PR DESCRIPTION
## Summary
- CsrfHelper — generate/verify tokens with hash_equals(), HTML field helper
- Security headers — X-Frame-Options, CSP (Bootstrap/Chart.js CDN whitelisted), Permissions-Policy
- UploadHelper — MIME type + extension validation, UUID rename, uploads/.htaccess blocks execution
- AuditLogger — immutable log with search/pagination for Super Admin
- Validator — input validation (required, email, date, inList) + e() for HTML output escaping
- PasswordHelper — bcrypt cost 12, temporary password generation, validation rules

closes GEN-56
closes GEN-57
closes GEN-58
closes GEN-59
closes GEN-60
closes GEN-61

## Security checklist
- [x] SQL: 100% prepared statements (AuditLogger queries)
- [x] CSRF: CsrfHelper with generate() and verify()
- [x] XSS: Validator::e() wraps htmlspecialchars(ENT_QUOTES, UTF-8)
- [x] Auth: N/A (helpers, not controllers)
- [x] Tenant: AuditLogger filters by empresa_id
- [x] Uploads: UploadHelper validates MIME + extension, renames to UUID

## Functional checklist
- [x] All 6 security helpers implemented per user stories
- [x] CSP allows Bootstrap 5 CDN and Chart.js CDN
- [x] uploads/.htaccess blocks PHP execution
- [x] AuditLogger.search() supports filters and pagination

> ⚠️ Stacked PR — merge [EP-01](#1) first, then retarget this to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)