### PR TITLE
[GEN-67] feat: database migrations for all SecuriForm tables

### DIFF
--- a/database/migrations/2026_03_30_000001_create_empresas_table.php
+++ b/database/migrations/2026_03_30_000001_create_empresas_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('empresas', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->increments('id');
+            $table->string('ruc', 11)->unique();
+            $table->string('razon_social', 200);
+            $table->string('logo_path', 500)->nullable();
+            $table->string('direccion', 300)->nullable();
+            $table->string('email', 150)->nullable();
+            $table->string('telefono', 30)->nullable();
+            $table->enum('estado', ['activo', 'inactivo'])->default('activo');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('empresas');
+    }
+};

--- a/database/migrations/2026_03_30_000002_add_empresa_fields_to_users_table.php
+++ b/database/migrations/2026_03_30_000002_add_empresa_fields_to_users_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('empresa_id')->nullable()->after('id');
+            $table->enum('rol', [
+                'super_admin',
+                'admin_empresa',
+                'usuario',
+                'agente_helpdesk',
+                'solo_lectura',
+            ])->default('usuario')->after('remember_token');
+            $table->enum('estado', ['activo', 'inactivo'])->default('activo')->after('rol');
+            $table->tinyInteger('intentos_fallidos')->default(0)->after('estado');
+            $table->dateTime('bloqueado_hasta')->nullable()->after('intentos_fallidos');
+            $table->boolean('notif_tickets')->default(true)->after('bloqueado_hasta');
+            $table->boolean('notif_incidencias')->default(true)->after('notif_tickets');
+            $table->dateTime('ultimo_acceso')->nullable()->after('notif_incidencias');
+
+            $table->foreign('empresa_id')
+                  ->references('id')
+                  ->on('empresas')
+                  ->onDelete('set null');
+
+            $table->index('empresa_id');
+            $table->index('rol');
+            $table->index('estado');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['empresa_id']);
+            $table->dropIndex(['empresa_id']);
+            $table->dropIndex(['rol']);
+            $table->dropIndex(['estado']);
+            $table->dropColumn([
+                'empresa_id',
+                'rol',
+                'estado',
+                'intentos_fallidos',
+                'bloqueado_hasta',
+                'notif_tickets',
+                'notif_incidencias',
+                'ultimo_acceso',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_03_30_000003_create_registros_table.php
+++ b/database/migrations/2026_03_30_000003_create_registros_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('registros', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->bigIncrements('id');
+            $table->unsignedInteger('empresa_id');
+            $table->enum('tipo_formato', [
+                'F01', 'F02', 'F03', 'F04', 'F05', 'F06', 'F07',
+                'F08', 'F09', 'F10', 'F11', 'F12', 'F13',
+            ]);
+            $table->string('numero_registro', 20);
+            $table->json('datos');
+            $table->enum('estado', ['activo', 'inactivo'])->default('activo');
+            $table->unsignedBigInteger('creado_por');
+            $table->unsignedBigInteger('modificado_por')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('empresa_id')
+                  ->references('id')
+                  ->on('empresas')
+                  ->onDelete('cascade');
+
+            $table->foreign('creado_por')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('restrict');
+
+            $table->foreign('modificado_por')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('set null');
+
+            $table->unique(['empresa_id', 'numero_registro']);
+            $table->index(['empresa_id', 'tipo_formato']);
+            $table->index(['empresa_id', 'created_at']);
+            $table->index('creado_por');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('registros');
+    }
+};

--- a/database/migrations/2026_03_30_000004_create_secuencias_registro_table.php
+++ b/database/migrations/2026_03_30_000004_create_secuencias_registro_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('secuencias_registro', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->unsignedInteger('empresa_id');
+            $table->string('tipo_formato', 5);
+            $table->smallInteger('anio')->unsigned();
+            $table->integer('ultimo_seq')->default(0);
+
+            $table->primary(['empresa_id', 'tipo_formato', 'anio']);
+
+            $table->foreign('empresa_id')
+                  ->references('id')
+                  ->on('empresas')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('secuencias_registro');
+    }
+};

--- a/database/migrations/2026_03_30_000005_create_tickets_table.php
+++ b/database/migrations/2026_03_30_000005_create_tickets_table.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tickets', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->increments('id');
+            $table->unsignedInteger('empresa_id');
+            $table->string('numero_ticket', 15)->unique();
+            $table->unsignedBigInteger('creado_por');
+            $table->unsignedBigInteger('asignado_a')->nullable();
+            $table->string('asunto', 300);
+            $table->text('descripcion');
+            $table->enum('categoria', [
+                'consulta',
+                'problema_tecnico',
+                'error_registro',
+                'solicitud_acceso',
+                'otro',
+            ])->default('consulta');
+            $table->enum('prioridad', [
+                'baja',
+                'media',
+                'alta',
+                'urgente',
+            ])->default('media');
+            $table->enum('estado', [
+                'nuevo',
+                'en_revision',
+                'esperando_usuario',
+                'resuelto',
+                'cerrado',
+            ])->default('nuevo');
+            $table->dateTime('fecha_ultima_actividad');
+            $table->dateTime('fecha_cierre')->nullable();
+            $table->timestamps();
+
+            $table->foreign('empresa_id')
+                  ->references('id')
+                  ->on('empresas')
+                  ->onDelete('cascade');
+
+            $table->foreign('creado_por')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('restrict');
+
+            $table->foreign('asignado_a')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('set null');
+
+            $table->index('empresa_id');
+            $table->index('estado');
+            $table->index('asignado_a');
+            $table->index('prioridad');
+            $table->index('fecha_ultima_actividad');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tickets');
+    }
+};

--- a/database/migrations/2026_03_30_000006_create_ticket_mensajes_table.php
+++ b/database/migrations/2026_03_30_000006_create_ticket_mensajes_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ticket_mensajes', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->increments('id');
+            $table->unsignedInteger('ticket_id');
+            $table->unsignedBigInteger('autor_id');
+            $table->enum('tipo', ['publico', 'interno'])->default('publico');
+            $table->text('contenido');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->foreign('ticket_id')
+                  ->references('id')
+                  ->on('tickets')
+                  ->onDelete('cascade');
+
+            $table->foreign('autor_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('restrict');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_mensajes');
+    }
+};

--- a/database/migrations/2026_03_30_000007_create_ticket_adjuntos_table.php
+++ b/database/migrations/2026_03_30_000007_create_ticket_adjuntos_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ticket_adjuntos', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->increments('id');
+            $table->unsignedInteger('mensaje_id');
+            $table->string('nombre_original', 255);
+            $table->string('nombre_almacenado', 255);
+            $table->string('tipo_mime', 100);
+            $table->unsignedInteger('tamano');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->foreign('mensaje_id')
+                  ->references('id')
+                  ->on('ticket_mensajes')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_adjuntos');
+    }
+};

--- a/database/migrations/2026_03_30_000008_create_secuencias_ticket_table.php
+++ b/database/migrations/2026_03_30_000008_create_secuencias_ticket_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('secuencias_ticket', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->tinyInteger('id')->primary();
+            $table->integer('ultimo_seq')->default(0);
+        });
+
+        DB::table('secuencias_ticket')->insert([
+            'id'         => 1,
+            'ultimo_seq' => 0,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('secuencias_ticket');
+    }
+};

--- a/database/migrations/2026_03_30_000009_create_notificaciones_email_table.php
+++ b/database/migrations/2026_03_30_000009_create_notificaciones_email_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notificaciones_email', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->bigIncrements('id');
+            $table->string('destinatario', 150);
+            $table->string('nombre_destino', 150)->nullable();
+            $table->string('asunto', 300);
+            $table->longText('cuerpo_html');
+            $table->enum('estado', ['pendiente', 'enviado', 'error'])->default('pendiente');
+            $table->tinyInteger('intentos')->default(0);
+            $table->text('error_mensaje')->nullable();
+            $table->dateTime('fecha_programada')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->dateTime('fecha_envio')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['estado', 'fecha_programada']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notificaciones_email');
+    }
+};

--- a/database/migrations/2026_03_30_000010_create_audit_logs_table.php
+++ b/database/migrations/2026_03_30_000010_create_audit_logs_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('usuario_id')->nullable();
+            $table->unsignedInteger('empresa_id')->nullable();
+            $table->string('accion', 100);
+            $table->string('entidad', 50)->nullable();
+            $table->unsignedBigInteger('entidad_id')->nullable();
+            $table->json('datos_anteriores')->nullable();
+            $table->json('datos_nuevos')->nullable();
+            $table->string('ip', 45)->nullable();
+            $table->string('user_agent', 300)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            // Indexes only — NO foreign keys (audit log should never cascade delete)
+            $table->index('usuario_id');
+            $table->index('empresa_id');
+            $table->index('accion');
+            $table->index('created_at');
+            $table->index(['entidad', 'entidad_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};


### PR DESCRIPTION
## Summary
- 10 Laravel migrations covering all SecuriForm tables based on install.sql reference
- empresas (tenants), extended users (empresa_id, rol, estado, login tracking)
- registros (13 formats with JSON datos + softDeletes), secuencias_registro
- tickets + ticket_mensajes + ticket_adjuntos + secuencias_ticket
- notificaciones_email (queue), audit_logs (immutable, no FK cascades)
- All verified against MariaDB 10.11 in Docker (18 tables total)

closes GEN-67

## Security checklist
- [x] SQL: Eloquent migrations with proper column types
- [x] CSRF: N/A (migrations only)
- [x] XSS: N/A
- [x] Auth: N/A
- [x] Tenant: empresa_id FK present in all tenant-scoped tables
- [x] Uploads: N/A

## Functional checklist
- [x] All 10 migrations run successfully
- [x] All 18 tables created with correct schema
- [x] Foreign keys and indexes match install.sql spec
- [x] down() methods properly reverse each migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)