### PR TITLE
[GEN-68] feat: seeders for roles, permissions and test data

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,11 +7,12 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -22,6 +23,14 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'empresa_id',
+        'rol',
+        'estado',
+        'intentos_fallidos',
+        'bloqueado_hasta',
+        'notif_tickets',
+        'notif_incidencias',
+        'ultimo_acceso',
     ];
 
     /**
@@ -44,6 +53,10 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'bloqueado_hasta' => 'datetime',
+            'ultimo_acceso' => 'datetime',
+            'notif_tickets' => 'boolean',
+            'notif_incidencias' => 'boolean',
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if (str_contains(request()->getHost(), 'tunnelmole.net')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,206 @@
+<?php
+
+use Spatie\Permission\DefaultTeamResolver;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2026_03_30_200100_create_permission_tables.php
+++ b/database/migrations/2026_03_30_200100_create_permission_tables.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(empty($tableNames), Exception::class, 'Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        throw_if($teams && empty($columnNames['team_foreign_key'] ?? null), Exception::class, 'Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        throw_if(empty($tableNames), Exception::class, 'Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,11 +15,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            RolePermissionSeeder::class,
+            EmpresaSeeder::class,
+            UserSeeder::class,
         ]);
     }
 }

--- a/database/seeders/EmpresaSeeder.php
+++ b/database/seeders/EmpresaSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class EmpresaSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('empresas')->insertOrIgnore([
+            [
+                'id' => 1,
+                'ruc' => '20601234567',
+                'razon_social' => 'Estudio Palacios Abogados S.A.C.',
+                'direccion' => 'Av. Principal 123, Lima',
+                'email' => 'admin@palacios.pe',
+                'telefono' => '+51 1 234-5678',
+                'estado' => 'activo',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => 2,
+                'ruc' => '20509876543',
+                'razon_social' => 'Consultora TechSoft S.A.C.',
+                'direccion' => 'Jr. Tecnología 456, Lima',
+                'email' => 'admin@techsoft.pe',
+                'telefono' => '+51 1 987-6543',
+                'estado' => 'activo',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class RolePermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
+
+        // Permissions per resource
+        $resources = [
+            'empresas',
+            'usuarios',
+            'registros',
+            'tickets',
+            'helpdesk',
+            'auditoria',
+            'exportar',
+        ];
+
+        $actions = ['ver', 'crear', 'editar', 'eliminar'];
+
+        foreach ($resources as $resource) {
+            foreach ($actions as $action) {
+                Permission::firstOrCreate(['name' => "{$action}_{$resource}"]);
+            }
+        }
+
+        // Extra permissions
+        Permission::firstOrCreate(['name' => 'gestionar_empresa_propia']);
+        Permission::firstOrCreate(['name' => 'ver_notas_internas']);
+        Permission::firstOrCreate(['name' => 'asignar_tickets']);
+
+        // Roles
+        $superAdmin = Role::firstOrCreate(['name' => 'super_admin']);
+        $superAdmin->syncPermissions(Permission::all());
+
+        $adminEmpresa = Role::firstOrCreate(['name' => 'admin_empresa']);
+        $adminEmpresa->syncPermissions([
+            'ver_usuarios', 'crear_usuarios', 'editar_usuarios', 'eliminar_usuarios',
+            'ver_registros', 'crear_registros', 'editar_registros', 'eliminar_registros',
+            'ver_tickets', 'crear_tickets',
+            'ver_exportar', 'crear_exportar',
+            'gestionar_empresa_propia',
+        ]);
+
+        $usuario = Role::firstOrCreate(['name' => 'usuario']);
+        $usuario->syncPermissions([
+            'ver_registros', 'crear_registros', 'editar_registros',
+            'ver_tickets', 'crear_tickets',
+            'ver_exportar', 'crear_exportar',
+        ]);
+
+        $agente = Role::firstOrCreate(['name' => 'agente_helpdesk']);
+        $agente->syncPermissions([
+            'ver_tickets', 'editar_tickets',
+            'ver_helpdesk', 'crear_helpdesk', 'editar_helpdesk',
+            'ver_notas_internas', 'asignar_tickets',
+            'ver_exportar', 'crear_exportar',
+        ]);
+
+        $soloLectura = Role::firstOrCreate(['name' => 'solo_lectura']);
+        $soloLectura->syncPermissions([
+            'ver_registros',
+            'ver_tickets',
+            'ver_exportar',
+        ]);
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $users = [
+            [
+                'name' => 'Super Administrador',
+                'email' => 'admin@securiform.local',
+                'password' => 'Admin2024!',
+                'empresa_id' => null,
+                'rol' => 'super_admin',
+                'estado' => 'activo',
+            ],
+            [
+                'name' => 'Carlos Palacios',
+                'email' => 'carlos@palacios.pe',
+                'password' => 'Test2024!',
+                'empresa_id' => 1,
+                'rol' => 'admin_empresa',
+                'estado' => 'activo',
+            ],
+            [
+                'name' => 'María García',
+                'email' => 'maria@palacios.pe',
+                'password' => 'Test2024!',
+                'empresa_id' => 1,
+                'rol' => 'usuario',
+                'estado' => 'activo',
+            ],
+            [
+                'name' => 'Pedro López',
+                'email' => 'pedro@palacios.pe',
+                'password' => 'Test2024!',
+                'empresa_id' => 1,
+                'rol' => 'solo_lectura',
+                'estado' => 'activo',
+            ],
+            [
+                'name' => 'Ana Soporte',
+                'email' => 'ana@securiform.local',
+                'password' => 'Test2024!',
+                'empresa_id' => null,
+                'rol' => 'agente_helpdesk',
+                'estado' => 'activo',
+            ],
+            [
+                'name' => 'Luis Torres',
+                'email' => 'luis@techsoft.pe',
+                'password' => 'Test2024!',
+                'empresa_id' => 2,
+                'rol' => 'admin_empresa',
+                'estado' => 'activo',
+            ],
+            [
+                'name' => 'Rosa Mendoza',
+                'email' => 'rosa@techsoft.pe',
+                'password' => 'Test2024!',
+                'empresa_id' => 2,
+                'rol' => 'usuario',
+                'estado' => 'activo',
+            ],
+        ];
+
+        foreach ($users as $data) {
+            $user = User::updateOrCreate(
+                ['email' => $data['email']],
+                $data,
+            );
+
+            $user->syncRoles($data['rol']);
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,11 +91,15 @@ services:
       - db
     restart: unless-stopped
 
-  # ── Cloudflare Tunnel: expone la app publicamente ────────────
+  # ── Tunnelmole: expone la app publicamente ───────────────────
   tunnel:
-    image: cloudflare/cloudflared:latest
+    image: node:20-alpine
     container_name: securiform-tunnel
-    command: tunnel --no-autoupdate --url http://app:80
+    command: >
+      sh -c "apk add --no-cache socat &&
+             socat TCP-LISTEN:80,fork,reuseaddr TCP:app:80 &
+             npm install -g tunnelmole &&
+             tmole 80"
     depends_on:
       - app
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- spatie/laravel-permission published (config + migration)
- HasRoles trait added to User model with extended fillable/casts
- RolePermissionSeeder: 5 roles + 31 granular permissions
- EmpresaSeeder: 2 test companies (Palacios, TechSoft)
- UserSeeder: 7 users (super_admin, 2x admin_empresa, 2x usuario, solo_lectura, agente_helpdesk)
- All passwords: Test2024! (super admin: Admin2024!)
- Tunnelmole replaces cloudflared in docker-compose
- HTTPS forced for tunnel domains in AppServiceProvider

closes GEN-68

## Security checklist
- [x] SQL: Eloquent seeders only
- [x] CSRF: N/A
- [x] XSS: N/A
- [x] Auth: Roles and permissions properly scoped
- [x] Tenant: empresa_id correctly set per user
- [x] Uploads: N/A

## Functional checklist
- [x] `php artisan db:seed` runs clean
- [x] `php artisan migrate:fresh --seed` works end-to-end
- [x] 7 users created with correct roles (verified via tinker)
- [x] Filament admin login works with admin@securiform.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)