### PR TITLE
[GEN-69] feat: Eloquent models with relations and casts

### DIFF
--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AuditLog extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'usuario_id',
+        'empresa_id',
+        'accion',
+        'entidad',
+        'entidad_id',
+        'datos_anteriores',
+        'datos_nuevos',
+        'ip',
+        'user_agent',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'datos_anteriores' => 'array',
+            'datos_nuevos' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function usuario(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'usuario_id');
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+}

--- a/app/Models/Empresa.php
+++ b/app/Models/Empresa.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Empresa extends Model
+{
+    protected $fillable = [
+        'ruc',
+        'razon_social',
+        'logo_path',
+        'direccion',
+        'email',
+        'telefono',
+        'estado',
+    ];
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class, 'empresa_id');
+    }
+
+    public function registros(): HasMany
+    {
+        return $this->hasMany(Registro::class, 'empresa_id');
+    }
+
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class, 'empresa_id');
+    }
+
+    public function isActivo(): bool
+    {
+        return $this->estado === 'activo';
+    }
+}

--- a/app/Models/NotificacionEmail.php
+++ b/app/Models/NotificacionEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NotificacionEmail extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'notificaciones_email';
+
+    protected $fillable = [
+        'destinatario',
+        'nombre_destino',
+        'asunto',
+        'cuerpo_html',
+        'estado',
+        'intentos',
+        'error_mensaje',
+        'fecha_programada',
+        'fecha_envio',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'fecha_programada' => 'datetime',
+            'fecha_envio' => 'datetime',
+            'created_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Registro.php
+++ b/app/Models/Registro.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Registro extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'empresa_id',
+        'tipo_formato',
+        'numero_registro',
+        'datos',
+        'estado',
+        'creado_por',
+        'modificado_por',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'datos' => 'array',
+        ];
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+
+    public function creador(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'creado_por');
+    }
+
+    public function modificador(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'modificado_por');
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Ticket extends Model
+{
+    protected $fillable = [
+        'empresa_id',
+        'numero_ticket',
+        'creado_por',
+        'asignado_a',
+        'asunto',
+        'descripcion',
+        'categoria',
+        'prioridad',
+        'estado',
+        'fecha_ultima_actividad',
+        'fecha_cierre',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'fecha_ultima_actividad' => 'datetime',
+            'fecha_cierre' => 'datetime',
+        ];
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+
+    public function creador(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'creado_por');
+    }
+
+    public function agente(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'asignado_a');
+    }
+
+    public function mensajes(): HasMany
+    {
+        return $this->hasMany(TicketMensaje::class, 'ticket_id');
+    }
+}

--- a/app/Models/TicketAdjunto.php
+++ b/app/Models/TicketAdjunto.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TicketAdjunto extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'ticket_adjuntos';
+
+    protected $fillable = [
+        'mensaje_id',
+        'nombre_original',
+        'nombre_almacenado',
+        'tipo_mime',
+        'tamano',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function mensaje(): BelongsTo
+    {
+        return $this->belongsTo(TicketMensaje::class, 'mensaje_id');
+    }
+}

--- a/app/Models/TicketMensaje.php
+++ b/app/Models/TicketMensaje.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class TicketMensaje extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'ticket_mensajes';
+
+    protected $fillable = [
+        'ticket_id',
+        'autor_id',
+        'tipo',
+        'contenido',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(Ticket::class, 'ticket_id');
+    }
+
+    public function autor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'autor_id');
+    }
+
+    public function adjuntos(): HasMany
+    {
+        return $this->hasMany(TicketAdjunto::class, 'mensaje_id');
+    }
+
+    public function isInterno(): bool
+    {
+        return $this->tipo === 'interno';
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,8 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -58,5 +60,30 @@ class User extends Authenticatable
             'notif_tickets' => 'boolean',
             'notif_incidencias' => 'boolean',
         ];
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+
+    public function registrosCreados(): HasMany
+    {
+        return $this->hasMany(Registro::class, 'creado_por');
+    }
+
+    public function ticketsCreados(): HasMany
+    {
+        return $this->hasMany(Ticket::class, 'creado_por');
+    }
+
+    public function ticketsAsignados(): HasMany
+    {
+        return $this->hasMany(Ticket::class, 'asignado_a');
+    }
+
+    public function isActivo(): bool
+    {
+        return $this->estado === 'activo';
     }
 }


### PR DESCRIPTION
## Summary
- 8 Eloquent models covering all SecuriForm entities
- Empresa: hasMany users, registros, tickets
- User: belongsTo empresa, hasMany registros/tickets, HasRoles trait
- Registro: belongsTo empresa/creador/modificador, SoftDeletes, JSON datos cast
- Ticket: belongsTo empresa/creador/agente, hasMany mensajes
- TicketMensaje: belongsTo ticket/autor, hasMany adjuntos
- TicketAdjunto: belongsTo mensaje
- AuditLog: belongsTo usuario/empresa, JSON casts for datos_anteriores/nuevos
- NotificacionEmail: datetime casts
- All relations verified via tinker against seeded data

closes GEN-69

## Security checklist
- [x] SQL: Eloquent relations only
- [x] Tenant: empresa_id FK present in tenant-scoped models
- [x] Auth: N/A (models only)

## Functional checklist
- [x] All 8 models load without errors
- [x] Relations resolve correctly (tested with tinker)
- [x] Casts work for JSON, datetime, boolean fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)