### PR TITLE
[GEN-70] feat: tenant isolation with EmpresaScope

### DIFF
--- a/app/Models/Concerns/BelongsToEmpresa.php
+++ b/app/Models/Concerns/BelongsToEmpresa.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Models\Scopes\EmpresaScope;
+
+trait BelongsToEmpresa
+{
+    protected static function bootBelongsToEmpresa(): void
+    {
+        static::addGlobalScope(new EmpresaScope);
+
+        // Auto-set empresa_id on create from authenticated user
+        static::creating(function ($model) {
+            if (! $model->empresa_id && auth()->check() && auth()->user()->empresa_id) {
+                $model->empresa_id = auth()->user()->empresa_id;
+            }
+        });
+    }
+}

--- a/app/Models/Registro.php
+++ b/app/Models/Registro.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToEmpresa;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Registro extends Model
 {
-    use SoftDeletes;
+    use BelongsToEmpresa, SoftDeletes;
 
     protected $fillable = [
         'empresa_id',

--- a/app/Models/Scopes/EmpresaScope.php
+++ b/app/Models/Scopes/EmpresaScope.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class EmpresaScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return;
+        }
+
+        // Super admin and helpdesk agents see all data
+        if ($user->hasRole(['super_admin', 'agente_helpdesk'])) {
+            return;
+        }
+
+        // Everyone else only sees their company's data
+        if ($user->empresa_id) {
+            $builder->where($model->getTable() . '.empresa_id', $user->empresa_id);
+        }
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToEmpresa;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Ticket extends Model
 {
+    use BelongsToEmpresa;
     protected $fillable = [
         'empresa_id',
         'numero_ticket',


### PR DESCRIPTION
## Summary
- EmpresaScope global scope filters all queries by empresa_id
- super_admin and agente_helpdesk bypass the scope (see all data)
- BelongsToEmpresa trait: applies scope + auto-sets empresa_id on create
- Applied to Registro and Ticket models
- Empresa model NOT scoped (super_admin manages all companies)

closes GEN-70

## Security checklist
- [x] SQL: Eloquent scopes, no raw queries
- [x] Tenant: Global scope enforces empresa_id isolation automatically
- [x] Auth: Role-based bypass for super_admin/agente only

## Functional checklist
- [x] Scope filters correctly for admin_empresa users
- [x] super_admin bypasses scope (sees all)
- [x] agente_helpdesk bypasses scope (sees all tickets)
- [x] empresa_id auto-set on create from auth user

🤖 Generated with [Claude Code](https://claude.com/claude-code)