### PR TITLE
[GEN-75] feat: Filament EmpresaResource (CRUD empresas)

### DIFF
--- a/app/Filament/Resources/Empresas/EmpresaResource.php
+++ b/app/Filament/Resources/Empresas/EmpresaResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources\Empresas;
+
+use App\Filament\Resources\Empresas\Pages\CreateEmpresa;
+use App\Filament\Resources\Empresas\Pages\EditEmpresa;
+use App\Filament\Resources\Empresas\Pages\ListEmpresas;
+use App\Filament\Resources\Empresas\Schemas\EmpresaForm;
+use App\Filament\Resources\Empresas\Tables\EmpresasTable;
+use App\Models\Empresa;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class EmpresaResource extends Resource
+{
+    protected static ?string $model = Empresa::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedBuildingOffice2;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Administración';
+
+    protected static ?string $modelLabel = 'Empresa';
+
+    protected static ?string $pluralModelLabel = 'Empresas';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole('super_admin') ?? false;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return EmpresaForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return EmpresasTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListEmpresas::route('/'),
+            'create' => CreateEmpresa::route('/create'),
+            'edit' => EditEmpresa::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Empresas/Pages/CreateEmpresa.php
+++ b/app/Filament/Resources/Empresas/Pages/CreateEmpresa.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\Pages;
+
+use App\Filament\Resources\Empresas\EmpresaResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateEmpresa extends CreateRecord
+{
+    protected static string $resource = EmpresaResource::class;
+}

--- a/app/Filament/Resources/Empresas/Pages/EditEmpresa.php
+++ b/app/Filament/Resources/Empresas/Pages/EditEmpresa.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\Pages;
+
+use App\Filament\Resources\Empresas\EmpresaResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditEmpresa extends EditRecord
+{
+    protected static string $resource = EmpresaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Empresas/Pages/ListEmpresas.php
+++ b/app/Filament/Resources/Empresas/Pages/ListEmpresas.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\Pages;
+
+use App\Filament\Resources\Empresas\EmpresaResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListEmpresas extends ListRecords
+{
+    protected static string $resource = EmpresaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Empresas/Schemas/EmpresaForm.php
+++ b/app/Filament/Resources/Empresas/Schemas/EmpresaForm.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\Schemas;
+
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class EmpresaForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Datos de la empresa')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('ruc')
+                            ->label('RUC')
+                            ->required()
+                            ->unique(ignoreRecord: true)
+                            ->minLength(11)
+                            ->maxLength(11)
+                            ->regex('/^\d{11}$/')
+                            ->validationMessages([
+                                'regex' => 'El RUC debe contener exactamente 11 dígitos numéricos.',
+                            ]),
+                        TextInput::make('razon_social')
+                            ->label('Razón social')
+                            ->required()
+                            ->maxLength(200),
+                        TextInput::make('email')
+                            ->label('Email')
+                            ->email()
+                            ->maxLength(150),
+                        TextInput::make('telefono')
+                            ->label('Teléfono')
+                            ->tel()
+                            ->maxLength(30),
+                        TextInput::make('direccion')
+                            ->label('Dirección')
+                            ->maxLength(300)
+                            ->columnSpanFull(),
+                    ]),
+                Section::make('Configuración')
+                    ->columns(2)
+                    ->schema([
+                        FileUpload::make('logo_path')
+                            ->label('Logo')
+                            ->image()
+                            ->disk('logos')
+                            ->directory('/')
+                            ->maxSize(2048)
+                            ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/svg+xml']),
+                        Select::make('estado')
+                            ->label('Estado')
+                            ->options([
+                                'activo' => 'Activo',
+                                'inactivo' => 'Inactivo',
+                            ])
+                            ->default('activo')
+                            ->required(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Empresas/Tables/EmpresasTable.php
+++ b/app/Filament/Resources/Empresas/Tables/EmpresasTable.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class EmpresasTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('ruc')
+                    ->label('RUC')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('razon_social')
+                    ->label('Razón social')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(40),
+                TextColumn::make('email')
+                    ->label('Email')
+                    ->searchable(),
+                TextColumn::make('telefono')
+                    ->label('Teléfono'),
+                TextColumn::make('users_count')
+                    ->label('Usuarios')
+                    ->counts('users')
+                    ->sortable(),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'activo' => 'success',
+                        'inactivo' => 'danger',
+                    }),
+                TextColumn::make('created_at')
+                    ->label('Creada')
+                    ->dateTime('d/m/Y')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('estado')
+                    ->options([
+                        'activo' => 'Activo',
+                        'inactivo' => 'Inactivo',
+                    ]),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Full CRUD for empresas via Filament Resource
- Form: RUC (11 digits validated), razon_social, email, telefono, direccion, logo upload, estado
- Table: searchable, sortable, users count, estado badge with colors
- Only visible to super_admin (canAccess guard)
- Logo stored on private 'logos' disk

closes GEN-75

## Security checklist
- [x] SQL: Eloquent only
- [x] Auth: super_admin restricted via canAccess()
- [x] Uploads: FileUpload with MIME validation, private disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)