### PR TITLE
[GEN-73] feat: Filament UserResource (CRUD usuarios)

### DIFF
--- a/app/Filament/Resources/Users/Pages/CreateUser.php
+++ b/app/Filament/Resources/Users/Pages/CreateUser.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Filament\Resources\Users\UserResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUser extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function afterCreate(): void
+    {
+        $this->record->syncRoles($this->record->rol);
+    }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        // admin_empresa auto-assigns their own empresa
+        if (! auth()->user()->hasRole('super_admin') && auth()->user()->empresa_id) {
+            $data['empresa_id'] = auth()->user()->empresa_id;
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/Users/Pages/EditUser.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Filament\Resources\Users\UserResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+
+    protected function afterSave(): void
+    {
+        $this->record->syncRoles($this->record->rol);
+    }
+}

--- a/app/Filament/Resources/Users/Pages/ListUsers.php
+++ b/app/Filament/Resources/Users/Pages/ListUsers.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Filament\Resources\Users\UserResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Filament\Resources\Users\Schemas;
+
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
+
+class UserForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        $isSuperAdmin = auth()->user()?->hasRole('super_admin');
+
+        return $schema
+            ->components([
+                Section::make('Datos del usuario')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('name')
+                            ->label('Nombre completo')
+                            ->required()
+                            ->maxLength(150),
+                        TextInput::make('email')
+                            ->label('Email')
+                            ->email()
+                            ->required()
+                            ->unique(ignoreRecord: true)
+                            ->maxLength(150),
+                        TextInput::make('password')
+                            ->label('Contraseña')
+                            ->password()
+                            ->revealable()
+                            ->required(fn (string $operation): bool => $operation === 'create')
+                            ->dehydrated(fn (?string $state): bool => filled($state))
+                            ->minLength(8)
+                            ->default(fn (string $operation): ?string => $operation === 'create' ? Str::random(12) : null)
+                            ->helperText(fn (string $operation): ?string => $operation === 'create' ? 'Se genera una contraseña temporal.' : 'Dejar vacío para mantener la actual.'),
+                        Select::make('empresa_id')
+                            ->label('Empresa')
+                            ->relationship('empresa', 'razon_social')
+                            ->searchable()
+                            ->preload()
+                            ->visible($isSuperAdmin)
+                            ->default(fn () => auth()->user()?->empresa_id),
+                    ]),
+                Section::make('Rol y estado')
+                    ->columns(2)
+                    ->schema([
+                        Select::make('rol')
+                            ->label('Rol')
+                            ->options(function () use ($isSuperAdmin) {
+                                $roles = [
+                                    'admin_empresa' => 'Admin Empresa',
+                                    'usuario' => 'Usuario',
+                                    'solo_lectura' => 'Solo Lectura',
+                                ];
+                                if ($isSuperAdmin) {
+                                    $roles = [
+                                        'super_admin' => 'Super Admin',
+                                        'agente_helpdesk' => 'Agente Helpdesk',
+                                    ] + $roles;
+                                }
+                                return $roles;
+                            })
+                            ->required()
+                            ->default('usuario'),
+                        Select::make('estado')
+                            ->label('Estado')
+                            ->options([
+                                'activo' => 'Activo',
+                                'inactivo' => 'Inactivo',
+                            ])
+                            ->default('activo')
+                            ->required(),
+                    ]),
+                Section::make('Notificaciones')
+                    ->columns(2)
+                    ->schema([
+                        Toggle::make('notif_tickets')
+                            ->label('Notificaciones de tickets')
+                            ->default(true),
+                        Toggle::make('notif_incidencias')
+                            ->label('Notificaciones de incidencias')
+                            ->default(true),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Users/Tables/UsersTable.php
+++ b/app/Filament/Resources/Users/Tables/UsersTable.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources\Users\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class UsersTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Nombre')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->label('Email')
+                    ->searchable(),
+                TextColumn::make('empresa.razon_social')
+                    ->label('Empresa')
+                    ->sortable()
+                    ->limit(30)
+                    ->visible(fn () => auth()->user()?->hasRole('super_admin')),
+                TextColumn::make('rol')
+                    ->label('Rol')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'super_admin' => 'danger',
+                        'admin_empresa' => 'warning',
+                        'usuario' => 'info',
+                        'agente_helpdesk' => 'primary',
+                        'solo_lectura' => 'gray',
+                        default => 'gray',
+                    }),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'activo' => 'success',
+                        'inactivo' => 'danger',
+                    }),
+                TextColumn::make('ultimo_acceso')
+                    ->label('Último acceso')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->placeholder('Nunca'),
+                TextColumn::make('created_at')
+                    ->label('Creado')
+                    ->dateTime('d/m/Y')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('rol')
+                    ->options([
+                        'super_admin' => 'Super Admin',
+                        'admin_empresa' => 'Admin Empresa',
+                        'usuario' => 'Usuario',
+                        'agente_helpdesk' => 'Agente Helpdesk',
+                        'solo_lectura' => 'Solo Lectura',
+                    ]),
+                SelectFilter::make('estado')
+                    ->options([
+                        'activo' => 'Activo',
+                        'inactivo' => 'Inactivo',
+                    ]),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Resources\Users;
+
+use App\Filament\Resources\Users\Pages\CreateUser;
+use App\Filament\Resources\Users\Pages\EditUser;
+use App\Filament\Resources\Users\Pages\ListUsers;
+use App\Filament\Resources\Users\Schemas\UserForm;
+use App\Filament\Resources\Users\Tables\UsersTable;
+use App\Models\User;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Administración';
+
+    protected static ?string $modelLabel = 'Usuario';
+
+    protected static ?string $pluralModelLabel = 'Usuarios';
+
+    protected static ?int $navigationSort = 2;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+        $user = auth()->user();
+
+        // admin_empresa only sees users from their company
+        if ($user && $user->hasRole('admin_empresa') && $user->empresa_id) {
+            $query->where('empresa_id', $user->empresa_id);
+        }
+
+        return $query;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return UserForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return UsersTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+            'create' => CreateUser::route('/create'),
+            'edit' => EditUser::route('/{record}/edit'),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Full CRUD for users via Filament Resource
- Form: name, email, password (auto-gen on create), empresa, rol, estado, notifications
- Table: searchable/sortable, rol/estado badges with colors, empresa column (super_admin only)
- super_admin sees all users, admin_empresa only sees their company
- Spatie role sync on create/edit
- admin_empresa cannot create super_admin or agente_helpdesk roles

closes GEN-73

## Security checklist
- [x] Auth: canAccess restricted to super_admin + admin_empresa
- [x] Tenant: admin_empresa filtered by empresa_id in getEloquentQuery
- [x] Roles: filtered options prevent privilege escalation

🤖 Generated with [Claude Code](https://claude.com/claude-code)