### PR TITLE
[GEN-74, GEN-76, GEN-77] feat: profile, empresa detail and multi-tenancy

### DIFF
--- a/app/Filament/Resources/Empresas/EmpresaResource.php
+++ b/app/Filament/Resources/Empresas/EmpresaResource.php
@@ -28,6 +28,8 @@ class EmpresaResource extends Resource
 
     protected static ?int $navigationSort = 1;
 
+    protected static bool $isScopedToTenant = false;
+
     public static function canAccess(): bool
     {
         return auth()->user()?->hasRole('super_admin') ?? false;
@@ -46,7 +48,7 @@ class EmpresaResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RelationManagers\UsersRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/Empresas/RelationManagers/UsersRelationManager.php
+++ b/app/Filament/Resources/Empresas/RelationManagers/UsersRelationManager.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class UsersRelationManager extends RelationManager
+{
+    protected static string $relationship = 'users';
+
+    protected static ?string $title = 'Usuarios';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Nombre')
+                    ->searchable(),
+                TextColumn::make('email')
+                    ->label('Email')
+                    ->searchable(),
+                TextColumn::make('rol')
+                    ->label('Rol')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'super_admin' => 'danger',
+                        'admin_empresa' => 'warning',
+                        'usuario' => 'info',
+                        'agente_helpdesk' => 'primary',
+                        'solo_lectura' => 'gray',
+                        default => 'gray',
+                    }),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'activo' => 'success',
+                        'inactivo' => 'danger',
+                    }),
+                TextColumn::make('ultimo_acceso')
+                    ->label('Último acceso')
+                    ->dateTime('d/m/Y H:i')
+                    ->placeholder('Nunca'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Empresas/Schemas/EmpresaForm.php
+++ b/app/Filament/Resources/Empresas/Schemas/EmpresaForm.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\Empresas\Schemas;
 
 use Filament\Forms\Components\FileUpload;
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\Resources\Users\Schemas;
 
-use Filament\Forms\Components\Section;
+use Filament\Schemas\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;

--- a/app/Models/Empresa.php
+++ b/app/Models/Empresa.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
+use Filament\Models\Contracts\HasName;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class Empresa extends Model
+class Empresa extends Model implements HasName
 {
     protected $fillable = [
         'ruc',
@@ -35,5 +36,10 @@ class Empresa extends Model
     public function isActivo(): bool
     {
         return $this->estado === 'activo';
+    }
+
+    public function getFilamentName(): string
+    {
+        return $this->razon_social;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,14 +4,18 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Models\Contracts\HasTenants;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser, HasTenants
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, HasRoles, Notifiable;
@@ -85,5 +89,34 @@ class User extends Authenticatable
     public function isActivo(): bool
     {
         return $this->estado === 'activo';
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $this->isActivo();
+    }
+
+    public function getTenants(Panel $panel): Collection
+    {
+        // Super admin and agents can see all companies
+        if ($this->hasRole(['super_admin', 'agente_helpdesk'])) {
+            return Empresa::where('estado', 'activo')->get();
+        }
+
+        // Regular users only see their own company
+        if ($this->empresa_id) {
+            return Empresa::where('id', $this->empresa_id)->get();
+        }
+
+        return collect();
+    }
+
+    public function canAccessTenant(\Illuminate\Database\Eloquent\Model $tenant): bool
+    {
+        if ($this->hasRole(['super_admin', 'agente_helpdesk'])) {
+            return true;
+        }
+
+        return $this->empresa_id === $tenant->getKey();
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Models\Empresa;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -30,6 +31,9 @@ class AdminPanelProvider extends PanelProvider
             ->login()
             ->passwordReset()
             ->brandName('SecuriForm')
+            ->profile()
+            ->tenant(Empresa::class, slugAttribute: 'ruc')
+            ->tenantRegistration(false)
             ->colors([
                 'primary' => Color::Indigo,
             ])


### PR DESCRIPTION
## Summary
- **GEN-74**: Filament profile page enabled (edit name, email, password)
- **GEN-76**: UsersRelationManager on EmpresaResource (users list with rol/estado badges)
- **GEN-77**: Filament multi-tenancy configured:
  - Empresa as tenant model (slug = RUC)
  - User implements HasTenants + FilamentUser
  - super_admin/agente see all empresas in tenant switcher
  - Regular users scoped to their own empresa
  - EmpresaResource exempt from tenant scoping
  - Tenant registration disabled

closes GEN-74
closes GEN-76
closes GEN-77

## Security checklist
- [x] Tenant: canAccessTenant validates empresa_id for regular users
- [x] Auth: FilamentUser.canAccessPanel checks estado=activo
- [x] Tenant: EmpresaResource exempt (super_admin manages all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)