### PR TITLE
[GEN-78,79,80,81] feat: motor de formatos with dynamic forms and auto-numbering

### DIFF
--- a/app/Enums/TipoFormato.php
+++ b/app/Enums/TipoFormato.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Enums;
+
+enum TipoFormato: string
+{
+    case F01 = 'F01';
+    case F02 = 'F02';
+    case F03 = 'F03';
+    case F04 = 'F04';
+    case F05 = 'F05';
+    case F06 = 'F06';
+    case F07 = 'F07';
+    case F08 = 'F08';
+    case F09 = 'F09';
+    case F10 = 'F10';
+    case F11 = 'F11';
+    case F12 = 'F12';
+    case F13 = 'F13';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::F01 => 'F01 - Auditorías realizadas',
+            self::F02 => 'F02 - Banco de datos inscritos',
+            self::F03 => 'F03 - Prestadores con acceso a datos',
+            self::F04 => 'F04 - Datos sensibles',
+            self::F05 => 'F05 - Personal autorizado al BD',
+            self::F06 => 'F06 - Acceso soporte no autorizado',
+            self::F07 => 'F07 - Inventario de soportes',
+            self::F08 => 'F08 - Ingreso y salida de soportes',
+            self::F09 => 'F09 - Notificación de incidencias',
+            self::F10 => 'F10 - Resolución de incidencias',
+            self::F11 => 'F11 - Recuperación de datos',
+            self::F12 => 'F12 - Copias de seguridad',
+            self::F13 => 'F13 - Destrucción de activos',
+        };
+    }
+
+    public function prefix(): string
+    {
+        return match ($this) {
+            self::F01 => 'AUD',
+            self::F02 => 'BD',
+            self::F03 => 'PRES',
+            self::F04 => 'DS',
+            self::F05 => 'PA',
+            self::F06 => 'AS',
+            self::F07 => 'INV',
+            self::F08 => 'IS',
+            self::F09 => 'INC',
+            self::F10 => 'RES',
+            self::F11 => 'REC',
+            self::F12 => 'BAK',
+            self::F13 => 'DEST',
+        };
+    }
+
+    public function psc(): string
+    {
+        return match ($this) {
+            self::F01 => 'PSC000001',
+            self::F02 => 'PSC000001',
+            self::F03 => 'PSC000001 / PSC000002',
+            self::F04 => 'PSC000001 / PSC000-46',
+            self::F05 => 'PSC000001',
+            self::F06 => 'PSC000001',
+            self::F07 => 'PSC000003 / PSC000004',
+            self::F08 => 'PSC000003',
+            self::F09 => 'PSC000001 / PSC000-25',
+            self::F10 => 'PSC000-25',
+            self::F11 => 'PSC000001 / PSC000-25',
+            self::F12 => 'PSC000003 / PSC000-15',
+            self::F13 => 'PSC000003 / PSC000004',
+        };
+    }
+
+    public static function options(): array
+    {
+        return collect(self::cases())
+            ->mapWithKeys(fn (self $case) => [$case->value => $case->label()])
+            ->all();
+    }
+}

--- a/app/Filament/Resources/Registros/Pages/CreateRegistro.php
+++ b/app/Filament/Resources/Registros/Pages/CreateRegistro.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\Registros\Pages;
+
+use App\Enums\TipoFormato;
+use App\Filament\Resources\Registros\RegistroResource;
+use App\Services\RegistroNumberService;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRegistro extends CreateRecord
+{
+    protected static string $resource = RegistroResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $tipo = TipoFormato::from($data['tipo_formato']);
+        $tenant = Filament::getTenant();
+
+        $data['empresa_id'] = $tenant->id;
+        $data['creado_por'] = auth()->id();
+        $data['numero_registro'] = RegistroNumberService::generate($tenant->id, $tipo);
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/Registros/Pages/EditRegistro.php
+++ b/app/Filament/Resources/Registros/Pages/EditRegistro.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filament\Resources\Registros\Pages;
+
+use App\Filament\Resources\Registros\RegistroResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRegistro extends EditRecord
+{
+    protected static string $resource = RegistroResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make()->label('Desactivar'),
+            RestoreAction::make()->label('Restaurar'),
+            ForceDeleteAction::make()->label('Eliminar permanente'),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $data['modificado_por'] = auth()->id();
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/Registros/Pages/ListRegistros.php
+++ b/app/Filament/Resources/Registros/Pages/ListRegistros.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Registros\Pages;
+
+use App\Filament\Resources\Registros\RegistroResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRegistros extends ListRecords
+{
+    protected static string $resource = RegistroResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Registros/RegistroResource.php
+++ b/app/Filament/Resources/Registros/RegistroResource.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Filament\Resources\Registros;
+
+use App\Filament\Resources\Registros\Pages\CreateRegistro;
+use App\Filament\Resources\Registros\Pages\EditRegistro;
+use App\Filament\Resources\Registros\Pages\ListRegistros;
+use App\Filament\Resources\Registros\Schemas\RegistroForm;
+use App\Filament\Resources\Registros\Tables\RegistrosTable;
+use App\Models\Registro;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class RegistroResource extends Resource
+{
+    protected static ?string $model = Registro::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Seguridad';
+
+    protected static ?string $modelLabel = 'Registro';
+
+    protected static ?string $pluralModelLabel = 'Registros';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return RegistroForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return RegistrosTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListRegistros::route('/'),
+            'create' => CreateRegistro::route('/create'),
+            'edit' => EditRegistro::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getRecordRouteBindingEloquentQuery(): Builder
+    {
+        return parent::getRecordRouteBindingEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/Registros/Schemas/RegistroForm.php
+++ b/app/Filament/Resources/Registros/Schemas/RegistroForm.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Resources\Registros\Schemas;
+
+use App\Enums\TipoFormato;
+use App\Services\FormatoFieldsService;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class RegistroForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Tipo de registro')
+                    ->schema([
+                        Select::make('tipo_formato')
+                            ->label('Formato de seguridad')
+                            ->options(TipoFormato::options())
+                            ->required()
+                            ->live()
+                            ->disabled(fn (string $operation): bool => $operation === 'edit')
+                            ->helperText(fn (Get $get): ?string => self::getPscText($get('tipo_formato'))),
+                        TextInput::make('numero_registro')
+                            ->label('N° Registro')
+                            ->disabled()
+                            ->dehydrated()
+                            ->helperText('Se genera automáticamente al guardar.'),
+                    ])->columns(2),
+
+                Section::make('Datos del formato')
+                    ->schema(fn (Get $get): array => self::getDynamicFields($get('tipo_formato')))
+                    ->visible(fn (Get $get): bool => filled($get('tipo_formato')))
+                    ->columns(2),
+            ]);
+    }
+
+    private static function getDynamicFields(?string $tipo): array
+    {
+        if (! $tipo) {
+            return [];
+        }
+
+        $tipoEnum = TipoFormato::tryFrom($tipo);
+
+        if (! $tipoEnum) {
+            return [];
+        }
+
+        return FormatoFieldsService::getFields($tipoEnum);
+    }
+
+    private static function getPscText(?string $tipo): ?string
+    {
+        if (! $tipo) {
+            return null;
+        }
+
+        $tipoEnum = TipoFormato::tryFrom($tipo);
+
+        return $tipoEnum ? 'Política: ' . $tipoEnum->psc() : null;
+    }
+}

--- a/app/Filament/Resources/Registros/Tables/RegistrosTable.php
+++ b/app/Filament/Resources/Registros/Tables/RegistrosTable.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Resources\Registros\Tables;
+
+use App\Enums\TipoFormato;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ForceDeleteBulkAction;
+use Filament\Actions\RestoreBulkAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TrashedFilter;
+use Filament\Tables\Table;
+
+class RegistrosTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('numero_registro')
+                    ->label('N° Registro')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('tipo_formato')
+                    ->label('Formato')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => TipoFormato::tryFrom($state)?->label() ?? $state),
+                TextColumn::make('creador.name')
+                    ->label('Creado por')
+                    ->sortable(),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'activo' => 'success',
+                        'inactivo' => 'danger',
+                    }),
+                TextColumn::make('created_at')
+                    ->label('Fecha')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                SelectFilter::make('tipo_formato')
+                    ->label('Formato')
+                    ->options(TipoFormato::options()),
+                SelectFilter::make('estado')
+                    ->options(['activo' => 'Activo', 'inactivo' => 'Inactivo']),
+                TrashedFilter::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    ForceDeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Services/FormatoFieldsService.php
+++ b/app/Services/FormatoFieldsService.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TipoFormato;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
+use Filament\Forms\Components\Toggle;
+
+class FormatoFieldsService
+{
+    public static function getFields(TipoFormato $tipo): array
+    {
+        return match ($tipo) {
+            TipoFormato::F01 => self::f01(),
+            TipoFormato::F02 => self::f02(),
+            TipoFormato::F03 => self::f03(),
+            TipoFormato::F04 => self::f04(),
+            TipoFormato::F05 => self::f05(),
+            TipoFormato::F06 => self::f06(),
+            TipoFormato::F07 => self::f07(),
+            TipoFormato::F08 => self::f08(),
+            TipoFormato::F09 => self::f09(),
+            TipoFormato::F10 => self::f10(),
+            TipoFormato::F11 => self::f11(),
+            TipoFormato::F12 => self::f12(),
+            TipoFormato::F13 => self::f13(),
+        };
+    }
+
+    private static function f01(): array
+    {
+        return [
+            Select::make('datos.tipo')->label('Tipo de auditoría')
+                ->options(['interna' => 'Interna', 'externa' => 'Externa'])->required(),
+            DatePicker::make('datos.fecha')->label('Fecha')->required(),
+            TextInput::make('datos.responsable')->label('Responsable / Proveedor')->required(),
+            Select::make('datos.resultado')->label('Resultado')
+                ->options(['conforme' => 'Conforme', 'no_conforme' => 'No conforme', 'con_observaciones' => 'Con observaciones'])->required(),
+            Select::make('datos.acciones_correctivas')->label('Acciones correctivas')
+                ->options(['si' => 'Sí', 'no' => 'No'])->required(),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3),
+        ];
+    }
+
+    private static function f02(): array
+    {
+        return [
+            TextInput::make('datos.nombre_bd')->label('Nombre del banco de datos')->required(),
+            TextInput::make('datos.codigo_registro')->label('Código / Registro'),
+            Textarea::make('datos.descripcion')->label('Descripción')->rows(3)->required(),
+            TagsInput::make('datos.areas_acceso')->label('Unidades / Áreas con acceso'),
+            Select::make('datos.categoria')->label('Categoría / Nivel')
+                ->options(['publica' => 'Pública', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+        ];
+    }
+
+    private static function f03(): array
+    {
+        return [
+            TextInput::make('datos.prestador')->label('Prestador del servicio')->required(),
+            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2)->required(),
+            TagsInput::make('datos.datos_facilitados')->label('Datos facilitados (tipo)'),
+            DatePicker::make('datos.fecha_contrato')->label('Fecha de contrato'),
+            DatePicker::make('datos.vigencia')->label('Vigencia'),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3),
+        ];
+    }
+
+    private static function f04(): array
+    {
+        return [
+            TextInput::make('datos.nombre')->label('Nombre')->required(),
+            Textarea::make('datos.descripcion')->label('Descripción')->rows(3)->required(),
+            Select::make('datos.ubicacion_tipo')->label('Ubicación tipo')
+                ->options(['fisica' => 'Física', 'digital' => 'Digital', 'mixta' => 'Mixta'])->required(),
+            TextInput::make('datos.ubicacion_detalle')->label('Ubicación detalle'),
+            TagsInput::make('datos.areas_acceso')->label('Usuarios / Áreas con acceso'),
+            Select::make('datos.categoria')->label('Categoría / Nivel')
+                ->options(['publica' => 'Pública', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+        ];
+    }
+
+    private static function f05(): array
+    {
+        return [
+            TextInput::make('datos.usuario')->label('Usuario')->required(),
+            DateTimePicker::make('datos.fecha_asignacion')->label('Fecha y hora de asignación')->required(),
+            TextInput::make('datos.banco_datos')->label('Banco de datos')->required(),
+        ];
+    }
+
+    private static function f06(): array
+    {
+        return [
+            Textarea::make('datos.descripcion_soporte')->label('Descripción del soporte')->rows(3)->required(),
+            TextInput::make('datos.persona_accede')->label('Persona que accede')->required(),
+            DatePicker::make('datos.fecha_acceso')->label('Fecha de acceso')->required(),
+            TimePicker::make('datos.hora_acceso')->label('Hora de acceso')->required(),
+        ];
+    }
+
+    private static function f07(): array
+    {
+        return [
+            Select::make('datos.tipo_soporte')->label('Tipo de soporte')
+                ->options([
+                    'hdd_interno' => 'HDD interno', 'hdd_externo' => 'HDD externo',
+                    'usb' => 'USB', 'servidor' => 'Servidor', 'nube' => 'Nube',
+                    'dvd' => 'DVD', 'expediente_fisico' => 'Expediente físico', 'otro' => 'Otro',
+                ])->required(),
+            TextInput::make('datos.ubicacion')->label('Ubicación')->required(),
+            Textarea::make('datos.contenido')->label('Contenido')->rows(3)->required(),
+            DatePicker::make('datos.fecha_inventariado')->label('Fecha de inventariado')->required(),
+        ];
+    }
+
+    private static function f08(): array
+    {
+        return [
+            TextInput::make('datos.codigo_soporte')->label('Código soporte')->required(),
+            Select::make('datos.tipo_movimiento')->label('Tipo de movimiento')
+                ->options(['ingreso' => 'Ingreso', 'salida' => 'Salida', 'devolucion' => 'Devolución'])->required(),
+            DateTimePicker::make('datos.fecha_hora')->label('Fecha / Hora')->required(),
+            TextInput::make('datos.id_serie')->label('ID / Serie'),
+            Select::make('datos.estado_soporte')->label('Estado')
+                ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])->required(),
+            TextInput::make('datos.banco_datos')->label('Banco de datos'),
+            Textarea::make('datos.contenido')->label('Contenido')->rows(2),
+            TextInput::make('datos.origen_remitente')->label('Origen / Remitente'),
+            TextInput::make('datos.destinatario')->label('Destinatario'),
+            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2),
+            TextInput::make('datos.medio_transporte')->label('Medio de transporte'),
+            Textarea::make('datos.precauciones')->label('Precauciones')->rows(2),
+            TextInput::make('datos.autoriza')->label('Autoriza'),
+            TextInput::make('datos.recibe')->label('Recibe'),
+        ];
+    }
+
+    private static function f09(): array
+    {
+        return [
+            DateTimePicker::make('datos.fecha_evento')->label('Fecha / Hora del evento')->required(),
+            Select::make('datos.tipo_incidencia')->label('Tipo de incidencia')
+                ->options([
+                    'acceso_no_autorizado' => 'Acceso no autorizado', 'perdida_datos' => 'Pérdida de datos',
+                    'fuga_informacion' => 'Fuga de información', 'malware' => 'Malware/Virus',
+                    'fallo_sistema' => 'Fallo de sistema', 'otro' => 'Otro',
+                ])->required(),
+            TextInput::make('datos.sistema_equipo')->label('Sistema / Equipo / Lugar'),
+            TextInput::make('datos.banco_datos')->label('Banco de datos'),
+            RichEditor::make('datos.descripcion')->label('Descripción')->required(),
+            Textarea::make('datos.medidas_inmediatas')->label('Medidas inmediatas')->rows(3),
+            TagsInput::make('datos.personas_notificadas')->label('Personas notificadas'),
+            Textarea::make('datos.impacto_potencial')->label('Impacto potencial')->rows(2),
+            TextInput::make('datos.comunica_nombre')->label('Comunica (nombre y cargo)'),
+            Select::make('datos.severidad')->label('Severidad')
+                ->options(['alta' => 'Alta', 'media' => 'Media', 'baja' => 'Baja'])->required(),
+        ];
+    }
+
+    private static function f10(): array
+    {
+        return [
+            TextInput::make('datos.incidencia_ref')->label('N° Incidencia (referencia F09)')->required(),
+            DateTimePicker::make('datos.fecha_cierre')->label('Fecha / Hora de cierre')->required(),
+            Select::make('datos.clasificacion')->label('Clasificación')
+                ->options(['baja' => 'Baja', 'media' => 'Media', 'alta' => 'Alta'])->required(),
+            Toggle::make('datos.requirio_recuperacion')->label('Requirió recuperación'),
+            Textarea::make('datos.medidas_adoptadas')->label('Medidas adoptadas')->rows(3)->required(),
+            Textarea::make('datos.resultado_verificacion')->label('Resultado / Verificación')->rows(3),
+            TextInput::make('datos.ejecuto')->label('Ejecutó (nombre y cargo)'),
+            TextInput::make('datos.firma_responsable')->label('Firma responsable de seguridad'),
+            Textarea::make('datos.acciones_preventivas')->label('Acciones preventivas')->rows(3),
+        ];
+    }
+
+    private static function f11(): array
+    {
+        return [
+            TextInput::make('datos.incidencia_relacionada')->label('Incidencia relacionada'),
+            DateTimePicker::make('datos.fecha_realizacion')->label('Fecha / Hora de realización')->required(),
+            Toggle::make('datos.autorizacion_escrita')->label('Autorización por escrito'),
+            TextInput::make('datos.responsable_bd')->label('Responsable BD que autoriza'),
+            Textarea::make('datos.proceso_realizado')->label('Proceso realizado')->rows(3)->required(),
+            TextInput::make('datos.persona_ejecutora')->label('Persona ejecutora'),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3),
+        ];
+    }
+
+    private static function f12(): array
+    {
+        return [
+            TextInput::make('datos.nombre_backup')->label('Nombre del backup')->required(),
+            Textarea::make('datos.descripcion_contenido')->label('Descripción del contenido')->rows(3)->required(),
+            DatePicker::make('datos.fecha_copia')->label('Fecha de copia')->required(),
+            Select::make('datos.periodicidad')->label('Periodicidad')
+                ->options([
+                    'diaria' => 'Diaria', 'semanal' => 'Semanal', 'quincenal' => 'Quincenal',
+                    'mensual' => 'Mensual', 'trimestral' => 'Trimestral', 'puntual' => 'Puntual',
+                ])->required(),
+        ];
+    }
+
+    private static function f13(): array
+    {
+        return [
+            DatePicker::make('datos.fecha_destruccion')->label('Fecha de destrucción')->required(),
+            Textarea::make('datos.descripcion_activo')->label('Descripción del activo')->rows(3)->required(),
+            Select::make('datos.metodo')->label('Método de destrucción')
+                ->options([
+                    'borrado_seguro' => 'Borrado seguro', 'destruccion_fisica' => 'Destrucción física',
+                    'desmagnetizacion' => 'Desmagnetización', 'incineracion' => 'Incineración',
+                    'trituracion' => 'Trituración', 'proveedor_certificado' => 'Proveedor certificado',
+                ])->required(),
+            TextInput::make('datos.responsable')->label('Responsable')->required(),
+            TextInput::make('datos.autoriza')->label('Autoriza')->required(),
+            DatePicker::make('datos.proxima_revision')->label('Próxima revisión'),
+        ];
+    }
+}

--- a/app/Services/RegistroNumberService.php
+++ b/app/Services/RegistroNumberService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TipoFormato;
+use Illuminate\Support\Facades\DB;
+
+class RegistroNumberService
+{
+    /**
+     * Generate the next registro number: PREFIJO-AÑO-SEQ (e.g. INC-2026-004)
+     * Atomic via SELECT ... FOR UPDATE on secuencias_registro.
+     */
+    public static function generate(int $empresaId, TipoFormato $tipo): string
+    {
+        $prefix = $tipo->prefix();
+        $year = now()->year;
+
+        return DB::transaction(function () use ($empresaId, $tipo, $prefix, $year) {
+            $seq = DB::table('secuencias_registro')
+                ->where('empresa_id', $empresaId)
+                ->where('tipo_formato', $tipo->value)
+                ->where('anio', $year)
+                ->lockForUpdate()
+                ->first();
+
+            if ($seq) {
+                $next = $seq->ultimo_seq + 1;
+                DB::table('secuencias_registro')
+                    ->where('empresa_id', $empresaId)
+                    ->where('tipo_formato', $tipo->value)
+                    ->where('anio', $year)
+                    ->update(['ultimo_seq' => $next]);
+            } else {
+                $next = 1;
+                DB::table('secuencias_registro')->insert([
+                    'empresa_id' => $empresaId,
+                    'tipo_formato' => $tipo->value,
+                    'anio' => $year,
+                    'ultimo_seq' => $next,
+                ]);
+            }
+
+            return sprintf('%s-%d-%03d', $prefix, $year, $next);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- **GEN-78**: RegistroResource (table, filters, search, soft delete support)
- **GEN-79**: Dynamic form — fields change based on tipo_formato selection. All 13 formats defined in FormatoFieldsService with proper Filament components (DatePicker, Select, RichEditor, TagsInput, Toggle, etc.)
- **GEN-80**: Auto-numbering via RegistroNumberService (PREFIJO-AÑO-SEQ, atomic with lockForUpdate)
- **GEN-81**: SoftDeletes + Desactivar/Restaurar actions, modificado_por tracking
- TipoFormato enum with labels, prefixes, PSC policies
- Verified all 13 formats render correctly via Chrome DevTools

closes GEN-78
closes GEN-79
closes GEN-80
closes GEN-81

## Security checklist
- [x] SQL: Eloquent + lockForUpdate for atomicity
- [x] Tenant: empresa_id from Filament tenant, not user input
- [x] Auth: creado_por/modificado_por from auth()->id()

🤖 Generated with [Claude Code](https://claude.com/claude-code)