### PR TITLE
[GEN-95,96,97,98] feat: PDF and Excel export

### DIFF
--- a/app/Filament/Pages/ReporteIncidencias.php
+++ b/app/Filament/Pages/ReporteIncidencias.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Enums\TipoFormato;
+use App\Models\Registro;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Mpdf\Mpdf;
+
+class ReporteIncidencias extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentChartBar;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
+
+    protected static ?string $navigationLabel = 'Reporte Incidencias';
+
+    protected static ?string $title = 'Reporte Mensual de Incidencias';
+
+    protected string $view = 'filament.pages.reporte-incidencias';
+
+    public ?string $mes = null;
+
+    public ?string $anio = null;
+
+    public function mount(): void
+    {
+        $this->mes = (string) now()->month;
+        $this->anio = (string) now()->year;
+    }
+
+    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse
+    {
+        $tenant = Filament::getTenant();
+        $month = (int) $this->mes;
+        $year = (int) $this->anio;
+
+        $incidencias = Registro::withoutGlobalScopes()
+            ->where('empresa_id', $tenant->id)
+            ->where('tipo_formato', 'F09')
+            ->whereMonth('created_at', $month)
+            ->whereYear('created_at', $year)
+            ->with('creador')
+            ->get();
+
+        $resoluciones = Registro::withoutGlobalScopes()
+            ->where('empresa_id', $tenant->id)
+            ->where('tipo_formato', 'F10')
+            ->whereMonth('created_at', $month)
+            ->whereYear('created_at', $year)
+            ->with('creador')
+            ->get();
+
+        $monthName = now()->setMonth($month)->translatedFormat('F');
+
+        $html = $this->buildReportHtml($tenant, $incidencias, $resoluciones, $monthName, $year);
+
+        $mpdf = new Mpdf([
+            'format' => 'A4',
+            'tempDir' => storage_path('app/temp'),
+        ]);
+        $mpdf->WriteHTML($html);
+
+        $filename = "reporte_incidencias_{$year}_{$month}.pdf";
+
+        return response()->streamDownload(function () use ($mpdf) {
+            echo $mpdf->Output('', 'S');
+        }, $filename, ['Content-Type' => 'application/pdf']);
+    }
+
+    private function buildReportHtml($tenant, $incidencias, $resoluciones, $monthName, $year): string
+    {
+        $incTable = '';
+        foreach ($incidencias as $i) {
+            $datos = $i->datos ?? [];
+            $incTable .= "<tr>
+                <td>{$i->numero_registro}</td>
+                <td>" . ($datos['tipo_incidencia'] ?? '-') . "</td>
+                <td>" . ($datos['severidad'] ?? '-') . "</td>
+                <td>{$i->creador?->name}</td>
+                <td>{$i->created_at->format('d/m/Y')}</td>
+            </tr>";
+        }
+
+        $resTable = '';
+        foreach ($resoluciones as $r) {
+            $datos = $r->datos ?? [];
+            $resTable .= "<tr>
+                <td>{$r->numero_registro}</td>
+                <td>" . ($datos['incidencia_ref'] ?? '-') . "</td>
+                <td>" . ($datos['clasificacion'] ?? '-') . "</td>
+                <td>{$r->created_at->format('d/m/Y')}</td>
+            </tr>";
+        }
+
+        return "
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 10px; }
+            h1 { color: #4338ca; font-size: 16px; }
+            h2 { font-size: 13px; margin-top: 20px; color: #333; }
+            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+            th, td { border: 1px solid #ddd; padding: 5px; text-align: left; }
+            th { background: #f3f4f6; font-weight: bold; }
+            .summary { margin-top: 20px; padding: 10px; background: #f9fafb; border: 1px solid #e5e7eb; }
+        </style>
+        <h1>{$tenant->razon_social}</h1>
+        <p>Reporte Mensual de Incidencias — {$monthName} {$year}</p>
+
+        <h2>Incidencias (F09) — {$incidencias->count()} registros</h2>
+        <table>
+            <tr><th>N°</th><th>Tipo</th><th>Severidad</th><th>Reportó</th><th>Fecha</th></tr>
+            {$incTable}
+        </table>
+
+        <h2>Resoluciones (F10) — {$resoluciones->count()} registros</h2>
+        <table>
+            <tr><th>N°</th><th>Incidencia Ref</th><th>Clasificación</th><th>Fecha</th></tr>
+            {$resTable}
+        </table>
+
+        <div class='summary'>
+            <strong>Resumen:</strong> {$incidencias->count()} incidencias, {$resoluciones->count()} resoluciones.
+            Tasa de resolución: " . ($incidencias->count() > 0 ? round($resoluciones->count() / $incidencias->count() * 100) : 0) . "%
+        </div>
+
+        <p style='margin-top:30px;font-size:9px;color:#888;'>
+            Generado: " . now()->format('d/m/Y H:i') . " | Admin: " . auth()->user()->name . "
+        </p>";
+    }
+}

--- a/app/Filament/Resources/Registros/Tables/RegistrosTable.php
+++ b/app/Filament/Resources/Registros/Tables/RegistrosTable.php
@@ -3,11 +3,15 @@
 namespace App\Filament\Resources\Registros\Tables;
 
 use App\Enums\TipoFormato;
+use App\Services\ExcelExportService;
+use App\Services\PdfExportService;
+use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ForceDeleteBulkAction;
 use Filament\Actions\RestoreBulkAction;
+use Filament\Facades\Filament;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TrashedFilter;
@@ -52,7 +56,30 @@ class RegistrosTable
                 TrashedFilter::make(),
             ])
             ->recordActions([
+                Action::make('exportPdf')
+                    ->label('PDF')
+                    ->icon('heroicon-o-document-arrow-down')
+                    ->color('gray')
+                    ->action(function ($record) {
+                        $path = PdfExportService::exportRegistro($record);
+
+                        return response()->download($path)->deleteFileAfterSend();
+                    }),
                 EditAction::make(),
+            ])
+            ->headerActions([
+                Action::make('exportExcel')
+                    ->label('Exportar Excel')
+                    ->icon('heroicon-o-table-cells')
+                    ->color('success')
+                    ->action(function () use ($table) {
+                        $query = $table->getQuery();
+                        $registros = $query->with('creador')->limit(5000)->get();
+                        $empresa = Filament::getTenant();
+                        $path = ExcelExportService::exportRegistros($registros, $empresa?->razon_social);
+
+                        return response()->download($path)->deleteFileAfterSend();
+                    }),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Services/ExcelExportService.php
+++ b/app/Services/ExcelExportService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TipoFormato;
+use Illuminate\Support\Collection;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+
+class ExcelExportService
+{
+    public static function exportRegistros(Collection $registros, ?string $empresaName = null): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Registros');
+
+        // Header
+        $row = 1;
+        if ($empresaName) {
+            $sheet->setCellValue("A{$row}", $empresaName);
+            $sheet->getStyle("A{$row}")->getFont()->setBold(true)->setSize(14);
+            $row++;
+            $sheet->setCellValue("A{$row}", 'Exportado: ' . now()->format('d/m/Y H:i'));
+            $row += 2;
+        }
+
+        // Column headers
+        $headers = ['N° Registro', 'Formato', 'Estado', 'Creado por', 'Fecha creación'];
+        foreach ($headers as $col => $header) {
+            $cell = chr(65 + $col) . $row;
+            $sheet->setCellValue($cell, $header);
+            $sheet->getStyle($cell)->getFont()->setBold(true);
+        }
+        $row++;
+
+        // Data
+        foreach ($registros as $registro) {
+            $tipo = TipoFormato::tryFrom($registro->tipo_formato);
+            $sheet->setCellValue("A{$row}", $registro->numero_registro);
+            $sheet->setCellValue("B{$row}", $tipo?->label() ?? $registro->tipo_formato);
+            $sheet->setCellValue("C{$row}", $registro->estado);
+            $sheet->setCellValue("D{$row}", $registro->creador?->name ?? '-');
+            $sheet->setCellValue("E{$row}", $registro->created_at?->format('d/m/Y H:i'));
+            $row++;
+        }
+
+        // Auto-width
+        foreach (range('A', 'E') as $col) {
+            $sheet->getColumnDimension($col)->setAutoSize(true);
+        }
+
+        $filename = 'registros_' . now()->format('Ymd_His') . '.xlsx';
+        $path = storage_path("app/temp/{$filename}");
+
+        $writer = new Xlsx($spreadsheet);
+        $writer->save($path);
+
+        return $path;
+    }
+}

--- a/app/Services/PdfExportService.php
+++ b/app/Services/PdfExportService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TipoFormato;
+use App\Models\Registro;
+use Mpdf\Mpdf;
+
+class PdfExportService
+{
+    public static function exportRegistro(Registro $registro): string
+    {
+        $tipo = TipoFormato::from($registro->tipo_formato);
+        $empresa = $registro->empresa;
+        $creador = $registro->creador;
+
+        $html = self::buildRegistroHtml($registro, $tipo, $empresa, $creador);
+
+        $mpdf = new Mpdf([
+            'format' => 'A4',
+            'margin_top' => 20,
+            'margin_bottom' => 20,
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        $mpdf->SetTitle("{$tipo->prefix()}-{$registro->numero_registro}");
+        $mpdf->WriteHTML($html);
+
+        $filename = "registro_{$registro->numero_registro}.pdf";
+        $path = storage_path("app/temp/{$filename}");
+        $mpdf->Output($path, 'F');
+
+        return $path;
+    }
+
+    private static function buildRegistroHtml(Registro $registro, TipoFormato $tipo, $empresa, $creador): string
+    {
+        $datos = $registro->datos ?? [];
+        $fieldsHtml = '';
+
+        foreach ($datos as $key => $value) {
+            $label = ucfirst(str_replace('_', ' ', $key));
+            $displayValue = is_array($value) ? implode(', ', $value) : ($value === true ? 'Sí' : ($value === false ? 'No' : ($value ?? '-')));
+            $fieldsHtml .= "<tr><td style='font-weight:bold;padding:6px;border:1px solid #ddd;width:35%;'>{$label}</td><td style='padding:6px;border:1px solid #ddd;'>{$displayValue}</td></tr>";
+        }
+
+        return "
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 11px; color: #333; }
+            h1 { color: #4338ca; font-size: 18px; margin-bottom: 5px; }
+            h2 { color: #555; font-size: 14px; margin-top: 20px; }
+            .header { border-bottom: 2px solid #4338ca; padding-bottom: 10px; margin-bottom: 20px; }
+            .meta { color: #666; font-size: 10px; }
+            table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+            .footer { margin-top: 30px; border-top: 1px solid #ddd; padding-top: 10px; font-size: 9px; color: #888; }
+        </style>
+        <div class='header'>
+            <h1>{$empresa->razon_social}</h1>
+            <p class='meta'>RUC: {$empresa->ruc} | {$empresa->direccion}</p>
+        </div>
+        <h2>{$tipo->label()}</h2>
+        <p><strong>N° Registro:</strong> {$registro->numero_registro} &nbsp;&nbsp; <strong>Política:</strong> {$tipo->psc()}</p>
+        <table>{$fieldsHtml}</table>
+        <div class='footer'>
+            <p>Creado por: {$creador->name} | Fecha: {$registro->created_at->format('d/m/Y H:i')} | Exportado: " . now()->format('d/m/Y H:i') . "</p>
+        </div>";
+    }
+
+    public static function exportTicket($ticket): string
+    {
+        $empresa = $ticket->empresa;
+        $mensajes = $ticket->mensajes()->with('autor')->orderBy('created_at')->get();
+        $isAgent = auth()->user()->hasRole(['super_admin', 'agente_helpdesk']);
+
+        $mensajesHtml = '';
+        foreach ($mensajes as $msg) {
+            if ($msg->tipo === 'interno' && ! $isAgent) {
+                continue;
+            }
+            $tipoLabel = $msg->tipo === 'interno' ? ' <em>(nota interna)</em>' : '';
+            $mensajesHtml .= "
+            <div style='margin-bottom:10px;padding:8px;border:1px solid #ddd;border-radius:4px;'>
+                <p style='font-weight:bold;margin:0;'>{$msg->autor->name}{$tipoLabel}</p>
+                <p style='font-size:9px;color:#888;margin:2px 0;'>{$msg->created_at->format('d/m/Y H:i')}</p>
+                <p style='margin:5px 0 0;'>{$msg->contenido}</p>
+            </div>";
+        }
+
+        $html = "
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 11px; color: #333; }
+            h1 { color: #4338ca; font-size: 16px; }
+            h2 { font-size: 13px; margin-top: 20px; }
+            .meta { color: #666; font-size: 10px; }
+        </style>
+        <h1>Ticket: {$ticket->numero_ticket}</h1>
+        <p class='meta'>{$empresa->razon_social} | RUC: {$empresa->ruc}</p>
+        <p><strong>Asunto:</strong> {$ticket->asunto}</p>
+        <p><strong>Estado:</strong> {$ticket->estado} | <strong>Prioridad:</strong> {$ticket->prioridad} | <strong>Categoría:</strong> {$ticket->categoria}</p>
+        <p><strong>Descripción:</strong></p>
+        <p>{$ticket->descripcion}</p>
+        <h2>Conversación</h2>
+        {$mensajesHtml}";
+
+        $mpdf = new Mpdf([
+            'format' => 'A4',
+            'tempDir' => storage_path('app/temp'),
+        ]);
+        $mpdf->WriteHTML($html);
+
+        $path = storage_path("app/temp/ticket_{$ticket->numero_ticket}.pdf");
+        $mpdf->Output($path, 'F');
+
+        return $path;
+    }
+}

--- a/resources/views/filament/pages/reporte-incidencias.blade.php
+++ b/resources/views/filament/pages/reporte-incidencias.blade.php
@@ -1,0 +1,25 @@
+<x-filament-panels::page>
+    <form wire:submit="generateReport">
+        <div class="flex items-end gap-4">
+            <div>
+                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Mes</label>
+                <select wire:model="mes" class="mt-1 block rounded-lg border-gray-300 shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+                    @for ($m = 1; $m <= 12; $m++)
+                        <option value="{{ $m }}">{{ \Carbon\Carbon::create()->month($m)->translatedFormat('F') }}</option>
+                    @endfor
+                </select>
+            </div>
+            <div>
+                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Año</label>
+                <select wire:model="anio" class="mt-1 block rounded-lg border-gray-300 shadow-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+                    @for ($y = now()->year; $y >= now()->year - 3; $y--)
+                        <option value="{{ $y }}">{{ $y }}</option>
+                    @endfor
+                </select>
+            </div>
+            <x-filament::button type="submit" icon="heroicon-o-document-arrow-down">
+                Generar PDF
+            </x-filament::button>
+        </div>
+    </form>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- **GEN-95**: PDF export per registro (mPDF, A4, empresa header, all fields, footer)
- **GEN-96**: Excel export of filtered list (PhpSpreadsheet, max 5000 rows)
- **GEN-97**: Ticket PDF export (full thread, internal notes only for agents)
- **GEN-98**: Monthly incident report page (F09+F10, month/year selector, stats)

closes GEN-95
closes GEN-96
closes GEN-97
closes GEN-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)