### PR TITLE
feat(SEN-12, SEN-66): plantillas de email editables desde panel admin

### DIFF
--- a/app/Filament/Resources/EmailTemplates/EmailTemplateResource.php
+++ b/app/Filament/Resources/EmailTemplates/EmailTemplateResource.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Resources\EmailTemplates;
+
+use App\Filament\Resources\EmailTemplates\Pages\EditEmailTemplate;
+use App\Filament\Resources\EmailTemplates\Pages\ListEmailTemplates;
+use App\Filament\Resources\EmailTemplates\Schemas\EmailTemplateForm;
+use App\Filament\Resources\EmailTemplates\Tables\EmailTemplatesTable;
+use App\Models\EmailTemplate;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class EmailTemplateResource extends Resource
+{
+    protected static ?string $model = EmailTemplate::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedEnvelope;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Administración';
+
+    protected static ?string $modelLabel = 'Plantilla de email';
+
+    protected static ?string $pluralModelLabel = 'Plantillas de email';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static bool $isScopedToTenant = false;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole('super_admin') ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function canDeleteAny(): bool
+    {
+        return false;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return EmailTemplateForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return EmailTemplatesTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListEmailTemplates::route('/'),
+            'edit' => EditEmailTemplate::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/EmailTemplates/Pages/EditEmailTemplate.php
+++ b/app/Filament/Resources/EmailTemplates/Pages/EditEmailTemplate.php
@@ -28,9 +28,19 @@ class EditEmailTemplate extends EditRecord
                     $asunto = $record->renderAsunto($sampleVars);
                     $cuerpo = $record->renderContenido($sampleVars);
 
+                    $htmlPreview = view('emails.securiform', [
+                        'asunto' => $asunto,
+                        'saludo' => 'Hola ' . ($sampleVars['nombre'] ?? 'Usuario') . ',',
+                        'cuerpo' => $cuerpo,
+                        'actionUrl' => '#',
+                        'actionLabel' => 'Ver en SecuriForm',
+                        'piePagina' => 'Vista previa con datos de ejemplo',
+                    ])->render();
+
                     return view('filament.pages.email-preview', [
                         'asunto' => $asunto,
-                        'cuerpo' => $cuerpo,
+                        'para' => $sampleVars['email'] ?? ($sampleVars['nombre'] ?? 'usuario') . '@empresa.com',
+                        'htmlPreview' => $htmlPreview,
                     ]);
                 }),
 

--- a/app/Filament/Resources/EmailTemplates/Pages/EditEmailTemplate.php
+++ b/app/Filament/Resources/EmailTemplates/Pages/EditEmailTemplate.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Filament\Resources\EmailTemplates\Pages;
+
+use App\Filament\Resources\EmailTemplates\EmailTemplateResource;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+
+class EditEmailTemplate extends EditRecord
+{
+    protected static string $resource = EmailTemplateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('preview')
+                ->label('Vista previa')
+                ->icon('heroicon-o-eye')
+                ->color('info')
+                ->modalHeading('Vista previa del email')
+                ->modalWidth('4xl')
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel('Cerrar')
+                ->modalContent(function () {
+                    $record = $this->record;
+                    $sampleVars = $this->getSampleVariables($record->slug);
+                    $asunto = $record->renderAsunto($sampleVars);
+                    $cuerpo = $record->renderContenido($sampleVars);
+
+                    return view('filament.pages.email-preview', [
+                        'asunto' => $asunto,
+                        'cuerpo' => $cuerpo,
+                    ]);
+                }),
+
+            Action::make('restore_default')
+                ->label('Restaurar por defecto')
+                ->icon('heroicon-o-arrow-path')
+                ->color('warning')
+                ->requiresConfirmation()
+                ->modalHeading('¿Restaurar plantilla por defecto?')
+                ->modalDescription('Se reemplazará el asunto y contenido actual con la plantilla original. Esta acción no se puede deshacer.')
+                ->action(function () {
+                    $this->record->restaurarDefault();
+                    $this->fillForm();
+
+                    Notification::make()
+                        ->title('Plantilla restaurada')
+                        ->body('Se restauró el contenido por defecto correctamente.')
+                        ->success()
+                        ->send();
+                }),
+        ];
+    }
+
+    private function getSampleVariables(string $slug): array
+    {
+        return match ($slug) {
+            'bienvenida' => [
+                'nombre' => 'Juan Pérez',
+                'empresa' => 'Estudio Palacios Abogados S.A.C.',
+                'email' => 'juan.perez@empresa.com',
+                'enlace_login' => '#',
+            ],
+            'reset_password' => [
+                'nombre' => 'Juan Pérez',
+                'enlace_reset' => '#',
+                'minutos_expiracion' => '60',
+            ],
+            'ticket_creado' => [
+                'nombre' => 'Juan Pérez',
+                'numero_ticket' => 'TK-2026-001',
+                'asunto' => 'No puedo acceder al sistema',
+                'enlace_ticket' => '#',
+            ],
+            'respuesta_ticket' => [
+                'nombre' => 'Juan Pérez',
+                'numero_ticket' => 'TK-2026-001',
+                'asunto' => 'No puedo acceder al sistema',
+                'quien_responde' => 'Agente de Soporte',
+                'enlace_ticket' => '#',
+            ],
+            'ticket_resuelto' => [
+                'nombre' => 'Juan Pérez',
+                'numero_ticket' => 'TK-2026-001',
+                'asunto' => 'No puedo acceder al sistema',
+                'enlace_ticket' => '#',
+            ],
+            'nueva_incidencia' => [
+                'nombre' => 'Admin Empresa',
+                'numero_incidencia' => 'INC-2026-004',
+                'tipo' => 'Acceso no autorizado',
+                'severidad' => 'Alta',
+                'enlace_registro' => '#',
+            ],
+            default => [],
+        };
+    }
+}

--- a/app/Filament/Resources/EmailTemplates/Pages/ListEmailTemplates.php
+++ b/app/Filament/Resources/EmailTemplates/Pages/ListEmailTemplates.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\EmailTemplates\Pages;
+
+use App\Filament\Resources\EmailTemplates\EmailTemplateResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListEmailTemplates extends ListRecords
+{
+    protected static string $resource = EmailTemplateResource::class;
+}

--- a/app/Filament/Resources/EmailTemplates/Schemas/EmailTemplateForm.php
+++ b/app/Filament/Resources/EmailTemplates/Schemas/EmailTemplateForm.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Resources\EmailTemplates\Schemas;
+
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class EmailTemplateForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Información de la plantilla')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('nombre')
+                            ->label('Nombre de la plantilla')
+                            ->disabled()
+                            ->columnSpanFull(),
+                        TextInput::make('slug')
+                            ->label('Identificador')
+                            ->disabled(),
+                        Toggle::make('activo')
+                            ->label('Activa')
+                            ->helperText('Si se desactiva, se usará la plantilla por defecto'),
+                    ]),
+                Section::make('Contenido del email')
+                    ->description('Usa las variables disponibles entre llaves dobles, ej: {{nombre}}')
+                    ->schema([
+                        TagsInput::make('variables_disponibles')
+                            ->label('Variables disponibles')
+                            ->disabled()
+                            ->helperText('Estas variables se reemplazan automáticamente al enviar el email'),
+                        TextInput::make('asunto')
+                            ->label('Asunto del email')
+                            ->required()
+                            ->maxLength(300)
+                            ->helperText('Puedes usar variables como {{nombre}}, {{empresa}}, etc.'),
+                        RichEditor::make('contenido')
+                            ->label('Cuerpo del email')
+                            ->required()
+                            ->toolbarButtons([
+                                'bold',
+                                'italic',
+                                'underline',
+                                'strike',
+                                'link',
+                                'orderedList',
+                                'bulletList',
+                                'h2',
+                                'h3',
+                                'blockquote',
+                                'undo',
+                                'redo',
+                            ])
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/EmailTemplates/Tables/EmailTemplatesTable.php
+++ b/app/Filament/Resources/EmailTemplates/Tables/EmailTemplatesTable.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filament\Resources\EmailTemplates\Tables;
+
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class EmailTemplatesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('nombre')
+                    ->label('Plantilla')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->label('Identificador')
+                    ->badge()
+                    ->color('gray'),
+                TextColumn::make('asunto')
+                    ->label('Asunto')
+                    ->limit(50)
+                    ->searchable(),
+                IconColumn::make('activo')
+                    ->label('Activa')
+                    ->boolean()
+                    ->sortable(),
+                TextColumn::make('updated_at')
+                    ->label('Última edición')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->defaultSort('nombre');
+    }
+}

--- a/app/Jobs/SendEmailJob.php
+++ b/app/Jobs/SendEmailJob.php
@@ -38,15 +38,47 @@ class SendEmailJob implements ShouldQueue
         public ?string $actionUrl = null,
         public ?string $actionLabel = null,
         public ?string $piePagina = null,
+        public ?string $templateSlug = null,
+        public array $templateVariables = [],
     ) {}
+
+    /**
+     * Dispatch a job using a database email template.
+     * The template is resolved at send-time, not at dispatch-time.
+     */
+    public static function fromTemplate(
+        string $destinatario,
+        string $nombreDestino,
+        string $templateSlug,
+        array $templateVariables = [],
+        string $saludo = '',
+        ?string $actionUrl = null,
+        ?string $actionLabel = null,
+        ?string $piePagina = null,
+    ): self {
+        return new self(
+            destinatario: $destinatario,
+            nombreDestino: $nombreDestino,
+            asunto: '',
+            saludo: $saludo,
+            cuerpo: '',
+            actionUrl: $actionUrl,
+            actionLabel: $actionLabel,
+            piePagina: $piePagina,
+            templateSlug: $templateSlug,
+            templateVariables: $templateVariables,
+        );
+    }
 
     public function handle(): void
     {
+        $mailable = $this->buildMailable();
+
         $notificacion = NotificacionEmail::create([
             'destinatario' => $this->destinatario,
             'nombre_destino' => $this->nombreDestino,
-            'asunto' => $this->asunto,
-            'cuerpo_html' => $this->cuerpo,
+            'asunto' => $mailable->asunto,
+            'cuerpo_html' => $mailable->cuerpo,
             'estado' => 'pendiente',
             'intentos' => $this->attempts(),
             'fecha_programada' => now(),
@@ -54,15 +86,6 @@ class SendEmailJob implements ShouldQueue
         ]);
 
         try {
-            $mailable = new SecuriformMail(
-                asunto: $this->asunto,
-                saludo: $this->saludo,
-                cuerpo: $this->cuerpo,
-                actionUrl: $this->actionUrl,
-                actionLabel: $this->actionLabel,
-                piePagina: $this->piePagina,
-            );
-
             Mail::to($this->destinatario, $this->nombreDestino)->send($mailable);
 
             $notificacion->update([
@@ -79,12 +102,12 @@ class SendEmailJob implements ShouldQueue
 
             Log::error('SendEmailJob failed', [
                 'to' => $this->destinatario,
-                'subject' => $this->asunto,
+                'subject' => $mailable->asunto,
                 'attempt' => $this->attempts(),
                 'error' => $e->getMessage(),
             ]);
 
-            throw $e; // Re-throw so Laravel retries
+            throw $e;
         }
     }
 
@@ -98,5 +121,30 @@ class SendEmailJob implements ShouldQueue
             'subject' => $this->asunto,
             'error' => $exception?->getMessage(),
         ]);
+    }
+
+    private function buildMailable(): SecuriformMail
+    {
+        if ($this->templateSlug) {
+            return SecuriformMail::fromTemplate(
+                slug: $this->templateSlug,
+                variables: $this->templateVariables,
+                fallbackAsunto: $this->asunto,
+                fallbackCuerpo: $this->cuerpo,
+                saludo: $this->saludo,
+                actionUrl: $this->actionUrl,
+                actionLabel: $this->actionLabel,
+                piePagina: $this->piePagina,
+            );
+        }
+
+        return new SecuriformMail(
+            asunto: $this->asunto,
+            saludo: $this->saludo,
+            cuerpo: $this->cuerpo,
+            actionUrl: $this->actionUrl,
+            actionLabel: $this->actionLabel,
+            piePagina: $this->piePagina,
+        );
     }
 }

--- a/app/Mail/SecuriformMail.php
+++ b/app/Mail/SecuriformMail.php
@@ -2,6 +2,7 @@
 
 namespace App\Mail;
 
+use App\Models\EmailTemplate;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
@@ -10,7 +11,8 @@ use Illuminate\Queue\SerializesModels;
 
 /**
  * Base Mailable for SecuriForm.
- * Uses the corporate layout template with customizable subject, greeting, body and action.
+ * Reads subject/body from email_templates table when a slug is provided.
+ * Falls back to constructor values if template is not found or inactive.
  */
 class SecuriformMail extends Mailable
 {
@@ -24,6 +26,40 @@ class SecuriformMail extends Mailable
         public ?string $actionLabel = null,
         public ?string $piePagina = null,
     ) {}
+
+    /**
+     * Create a Mailable from a database template with variable replacement.
+     * Falls back to provided defaults if the template is not found or inactive.
+     */
+    public static function fromTemplate(
+        string $slug,
+        array $variables = [],
+        string $fallbackAsunto = '',
+        string $fallbackCuerpo = '',
+        string $saludo = '',
+        ?string $actionUrl = null,
+        ?string $actionLabel = null,
+        ?string $piePagina = null,
+    ): self {
+        $template = EmailTemplate::findBySlug($slug);
+
+        if ($template) {
+            $asunto = $template->renderAsunto($variables);
+            $cuerpo = $template->renderContenido($variables);
+        } else {
+            $asunto = $fallbackAsunto;
+            $cuerpo = $fallbackCuerpo;
+        }
+
+        return new self(
+            asunto: $asunto,
+            saludo: $saludo,
+            cuerpo: $cuerpo,
+            actionUrl: $actionUrl,
+            actionLabel: $actionLabel,
+            piePagina: $piePagina,
+        );
+    }
 
     public function envelope(): Envelope
     {

--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+class EmailTemplate extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'slug',
+        'nombre',
+        'asunto',
+        'contenido',
+        'variables_disponibles',
+        'plantilla_default_asunto',
+        'plantilla_default_contenido',
+        'activo',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'variables_disponibles' => 'array',
+            'activo' => 'boolean',
+        ];
+    }
+
+    /**
+     * Render the template subject replacing placeholders with actual values.
+     */
+    public function renderAsunto(array $variables = []): string
+    {
+        return $this->replacePlaceholders($this->asunto, $variables);
+    }
+
+    /**
+     * Render the template body replacing placeholders with actual values.
+     */
+    public function renderContenido(array $variables = []): string
+    {
+        return $this->replacePlaceholders($this->contenido, $variables);
+    }
+
+    /**
+     * Restore the template to its default content.
+     */
+    public function restaurarDefault(): void
+    {
+        $this->update([
+            'asunto' => $this->plantilla_default_asunto,
+            'contenido' => $this->plantilla_default_contenido,
+        ]);
+    }
+
+    /**
+     * Find an active template by slug, or null.
+     */
+    public static function findBySlug(string $slug): ?self
+    {
+        return static::where('slug', $slug)->where('activo', true)->first();
+    }
+
+    /**
+     * Replace {{variable}} placeholders with provided values.
+     */
+    private function replacePlaceholders(string $text, array $variables): string
+    {
+        foreach ($variables as $key => $value) {
+            $text = Str::replace("{{{$key}}}", (string) $value, $text);
+        }
+
+        return $text;
+    }
+}

--- a/database/migrations/2026_04_01_100001_create_email_templates_table.php
+++ b/database/migrations/2026_04_01_100001_create_email_templates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('email_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug', 50)->unique();
+            $table->string('nombre', 150);
+            $table->string('asunto', 300);
+            $table->longText('contenido');
+            $table->json('variables_disponibles');
+            $table->longText('plantilla_default_asunto');
+            $table->longText('plantilla_default_contenido');
+            $table->boolean('activo')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('email_templates');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             RolePermissionSeeder::class,
             EmpresaSeeder::class,
             UserSeeder::class,
+            EmailTemplateSeeder::class,
         ]);
     }
 }

--- a/database/seeders/EmailTemplateSeeder.php
+++ b/database/seeders/EmailTemplateSeeder.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\EmailTemplate;
+use Illuminate\Database\Seeder;
+
+class EmailTemplateSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $templates = $this->getTemplates();
+
+        foreach ($templates as $template) {
+            EmailTemplate::updateOrCreate(
+                ['slug' => $template['slug']],
+                [
+                    'nombre' => $template['nombre'],
+                    'asunto' => $template['asunto'],
+                    'contenido' => $template['contenido'],
+                    'variables_disponibles' => $template['variables_disponibles'],
+                    'plantilla_default_asunto' => $template['asunto'],
+                    'plantilla_default_contenido' => $template['contenido'],
+                    'activo' => true,
+                ]
+            );
+        }
+    }
+
+    private function getTemplates(): array
+    {
+        return [
+            [
+                'slug' => 'bienvenida',
+                'nombre' => 'Bienvenida (nuevo usuario)',
+                'asunto' => 'Bienvenido a SecuriForm, {{nombre}}',
+                'variables_disponibles' => ['nombre', 'empresa', 'email', 'enlace_login'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>Tu cuenta en SecuriForm ha sido creada exitosamente para la empresa <strong>{{empresa}}</strong>.</p>
+<p>Tus datos de acceso son:</p>
+<ul>
+    <li><strong>Email:</strong> {{email}}</li>
+    <li><strong>Contrasena:</strong> La proporcionada por tu administrador</li>
+</ul>
+<p>Para ingresar al sistema, haz clic en el siguiente enlace:</p>
+<p><a href="{{enlace_login}}">Iniciar sesion</a></p>
+<p>Te recomendamos cambiar tu contrasena en tu primer inicio de sesion desde la seccion de perfil.</p>
+HTML,
+            ],
+            [
+                'slug' => 'reset_password',
+                'nombre' => 'Recuperacion de contrasena',
+                'asunto' => 'Restablecer contrasena - SecuriForm',
+                'variables_disponibles' => ['nombre', 'enlace_reset', 'minutos_expiracion'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>Recibimos una solicitud para restablecer la contrasena de tu cuenta en SecuriForm.</p>
+<p>Haz clic en el siguiente enlace para crear una nueva contrasena:</p>
+<p><a href="{{enlace_reset}}">Restablecer contrasena</a></p>
+<p>Este enlace expirara en <strong>{{minutos_expiracion}} minutos</strong>.</p>
+<p>Si no solicitaste este cambio, puedes ignorar este correo. Tu contrasena actual seguira siendo la misma.</p>
+HTML,
+            ],
+            [
+                'slug' => 'ticket_creado',
+                'nombre' => 'Ticket creado',
+                'asunto' => 'Ticket {{numero_ticket}} creado: {{asunto}}',
+                'variables_disponibles' => ['nombre', 'numero_ticket', 'asunto', 'enlace_ticket'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>Tu ticket de soporte ha sido creado exitosamente.</p>
+<p><strong>Numero de ticket:</strong> {{numero_ticket}}<br>
+<strong>Asunto:</strong> {{asunto}}</p>
+<p>Nuestro equipo de soporte revisara tu solicitud y te responderemos a la brevedad posible.</p>
+<p>Puedes seguir el estado de tu ticket en el siguiente enlace:</p>
+<p><a href="{{enlace_ticket}}">Ver ticket</a></p>
+HTML,
+            ],
+            [
+                'slug' => 'respuesta_ticket',
+                'nombre' => 'Respuesta en ticket',
+                'asunto' => 'Nueva respuesta en ticket {{numero_ticket}}: {{asunto}}',
+                'variables_disponibles' => ['nombre', 'numero_ticket', 'asunto', 'quien_responde', 'enlace_ticket'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p><strong>{{quien_responde}}</strong> ha respondido en tu ticket de soporte.</p>
+<p><strong>Numero de ticket:</strong> {{numero_ticket}}<br>
+<strong>Asunto:</strong> {{asunto}}</p>
+<p>Para ver la respuesta completa y continuar la conversacion:</p>
+<p><a href="{{enlace_ticket}}">Ver conversacion</a></p>
+HTML,
+            ],
+            [
+                'slug' => 'ticket_resuelto',
+                'nombre' => 'Ticket resuelto',
+                'asunto' => 'Ticket {{numero_ticket}} resuelto: {{asunto}}',
+                'variables_disponibles' => ['nombre', 'numero_ticket', 'asunto', 'enlace_ticket'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>Tu ticket de soporte ha sido marcado como <strong>resuelto</strong>.</p>
+<p><strong>Numero de ticket:</strong> {{numero_ticket}}<br>
+<strong>Asunto:</strong> {{asunto}}</p>
+<p>Si consideras que el problema no fue resuelto, puedes reabrir el ticket dentro de los proximos 7 dias desde el siguiente enlace:</p>
+<p><a href="{{enlace_ticket}}">Ver ticket</a></p>
+<p>Gracias por contactarnos.</p>
+HTML,
+            ],
+            [
+                'slug' => 'nueva_incidencia',
+                'nombre' => 'Nueva incidencia (F09)',
+                'asunto' => '[{{severidad}}] Nueva incidencia {{numero_incidencia}}: {{tipo}}',
+                'variables_disponibles' => ['nombre', 'numero_incidencia', 'tipo', 'severidad', 'enlace_registro'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>Se ha registrado una nueva incidencia de seguridad en el sistema.</p>
+<p><strong>Numero:</strong> {{numero_incidencia}}<br>
+<strong>Tipo:</strong> {{tipo}}<br>
+<strong>Severidad:</strong> {{severidad}}</p>
+<p>Por favor revisa los detalles de la incidencia y toma las acciones correspondientes:</p>
+<p><a href="{{enlace_registro}}">Ver incidencia</a></p>
+<p>Recuerda que las incidencias de severidad Alta requieren atencion inmediata segun la politica PSC000-25.</p>
+HTML,
+            ],
+        ];
+    }
+}

--- a/resources/views/filament/pages/email-preview.blade.php
+++ b/resources/views/filament/pages/email-preview.blade.php
@@ -1,0 +1,15 @@
+<div class="space-y-4">
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+        <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Asunto:</p>
+        <p class="text-base font-semibold text-gray-900 dark:text-white">{{ $asunto }}</p>
+    </div>
+
+    <div class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+        <iframe
+            srcdoc="@include('emails.securiform', ['saludo' => 'Hola Juan Pérez,', 'cuerpo' => $cuerpo, 'actionUrl' => '#', 'actionLabel' => 'Ver en SecuriForm', 'piePagina' => 'Vista previa con datos de ejemplo', 'asunto' => $asunto])"
+            class="w-full rounded-lg"
+            style="height: 500px; border: none;"
+            sandbox="allow-same-origin"
+        ></iframe>
+    </div>
+</div>

--- a/resources/views/filament/pages/email-preview.blade.php
+++ b/resources/views/filament/pages/email-preview.blade.php
@@ -1,15 +1,40 @@
-<div class="space-y-4">
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
-        <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Asunto:</p>
-        <p class="text-base font-semibold text-gray-900 dark:text-white">{{ $asunto }}</p>
+<div style="border-radius: 12px; overflow: hidden; border: 1px solid #e5e7eb; box-shadow: 0 1px 3px rgba(0,0,0,.1);">
+
+    {{-- Toolbar --}}
+    <div style="background: #1f2937; padding: 12px 20px; display: flex; align-items: center; gap: 8px;">
+        <span style="width: 12px; height: 12px; border-radius: 50%; background: #ef4444; display: inline-block;"></span>
+        <span style="width: 12px; height: 12px; border-radius: 50%; background: #f59e0b; display: inline-block;"></span>
+        <span style="width: 12px; height: 12px; border-radius: 50%; background: #22c55e; display: inline-block;"></span>
+        <span style="margin-left: 12px; font-size: 12px; color: #9ca3af;">Vista previa del email</span>
     </div>
 
-    <div class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
-        <iframe
-            srcdoc="@include('emails.securiform', ['saludo' => 'Hola Juan Pérez,', 'cuerpo' => $cuerpo, 'actionUrl' => '#', 'actionLabel' => 'Ver en SecuriForm', 'piePagina' => 'Vista previa con datos de ejemplo', 'asunto' => $asunto])"
-            class="w-full rounded-lg"
-            style="height: 500px; border: none;"
-            sandbox="allow-same-origin"
-        ></iframe>
+    {{-- Email header --}}
+    <div style="background: #f9fafb; padding: 20px 24px; border-bottom: 1px solid #e5e7eb;">
+        <div style="display: flex; align-items: center; gap: 14px; margin-bottom: 16px;">
+            <div style="width: 44px; height: 44px; border-radius: 50%; background: linear-gradient(135deg, #4338ca, #6366f1); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+                <span style="color: #fff; font-weight: 700; font-size: 14px;">SF</span>
+            </div>
+            <div>
+                <div style="font-size: 14px; font-weight: 600; color: #111827;">SecuriForm</div>
+                <div style="font-size: 12px; color: #6b7280;">noreply@securiform.local</div>
+            </div>
+        </div>
+
+        <table style="width: 100%; font-size: 13px; border-collapse: collapse;">
+            <tr>
+                <td style="padding: 4px 0; color: #9ca3af; width: 60px; vertical-align: top;">Para:</td>
+                <td style="padding: 4px 0; color: #374151;">{{ $para }}</td>
+            </tr>
+            <tr>
+                <td style="padding: 4px 0; color: #9ca3af; vertical-align: top;">Asunto:</td>
+                <td style="padding: 4px 0; color: #111827; font-weight: 600;">{{ $asunto }}</td>
+            </tr>
+        </table>
     </div>
+
+    {{-- Email body --}}
+    <div style="background: #f3f4f6; padding: 0; max-height: 460px; overflow-y: auto;">
+        {!! $htmlPreview !!}
+    </div>
+
 </div>


### PR DESCRIPTION
## Summary
- Tabla `email_templates` con plantillas editables desde BD (migración + modelo + seeder)
- 6 plantillas por defecto: bienvenida, reset password, ticket creado/respuesta/resuelto, nueva incidencia
- `EmailTemplateResource` en Filament (solo super_admin): edición de asunto y contenido con RichEditor
- Vista previa del email renderizado con datos de ejemplo
- Acción "Restaurar por defecto" con confirmación
- `SecuriformMail::fromTemplate()` y `SendEmailJob::fromTemplate()` para envío basado en plantillas de BD
- Backward compatible: el uso directo por constructor sigue funcionando

## Archivos nuevos
- `database/migrations/2026_04_01_100001_create_email_templates_table.php`
- `app/Models/EmailTemplate.php`
- `database/seeders/EmailTemplateSeeder.php`
- `app/Filament/Resources/EmailTemplates/` (Resource, Form, Table, Pages)
- `resources/views/filament/pages/email-preview.blade.php`

## Archivos modificados
- `app/Mail/SecuriformMail.php` — factory method `fromTemplate()`
- `app/Jobs/SendEmailJob.php` — factory method `fromTemplate()` + template resolution
- `database/seeders/DatabaseSeeder.php` — registra EmailTemplateSeeder

## Test plan
- [ ] `php artisan migrate` crea tabla `email_templates` correctamente
- [ ] `php artisan db:seed --class=EmailTemplateSeeder` puebla las 6 plantillas
- [ ] Super admin ve "Plantillas de email" en sidebar bajo Administración
- [ ] Otros roles NO ven el recurso
- [ ] Editar asunto/contenido persiste cambios
- [ ] Preview muestra email renderizado con variables de ejemplo
- [ ] "Restaurar por defecto" revierte al contenido original
- [ ] `SendEmailJob::fromTemplate('ticket_creado', [...])` resuelve plantilla de BD
- [ ] Plantilla inactiva cae al fallback correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)