### PR TITLE
fix(SEN-17, SEN-65): code review fixes + UI improvements for Panel de Agente

### DIFF
--- a/app/Filament/Pages/PanelAgente.php
+++ b/app/Filament/Pages/PanelAgente.php
@@ -12,6 +12,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\HtmlString;
 use Livewire\Attributes\Url;
 
 class PanelAgente extends Page implements HasForms
@@ -29,6 +30,11 @@ class PanelAgente extends Page implements HasForms
     protected static ?int $navigationSort = -1;
 
     protected string $view = 'filament.pages.panel-agente';
+
+    public function getMaxContentWidth(): ?string
+    {
+        return 'full';
+    }
 
     // Filters
     #[Url]
@@ -114,7 +120,52 @@ class PanelAgente extends Page implements HasForms
             'esperando' => (clone $base)->where('estado', 'esperando_usuario')->count(),
             'mis_tickets' => (clone $base)->where('asignado_a', auth()->id())->whereNotIn('estado', ['cerrado', 'resuelto'])->count(),
             'total_abiertos' => (clone $base)->whereNotIn('estado', ['cerrado', 'resuelto'])->count(),
+            'total' => (clone $base)->count(),
         ];
+    }
+
+    public function getCounterTrendsProperty(): array
+    {
+        $days = 7;
+        $trends = [
+            'sin_asignar' => [],
+            'nuevos_hoy' => [],
+            'mis_tickets' => [],
+            'en_revision' => [],
+            'esperando' => [],
+            'total_abiertos' => [],
+            'total' => [],
+        ];
+
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $date = now()->subDays($i);
+
+            $trends['sin_asignar'][] = Ticket::withoutGlobalScopes()
+                ->whereNull('asignado_a')->whereNotIn('estado', ['cerrado', 'resuelto'])
+                ->whereDate('created_at', '<=', $date)->count();
+
+            $trends['nuevos_hoy'][] = Ticket::withoutGlobalScopes()
+                ->where('estado', 'nuevo')->whereDate('created_at', $date)->count();
+
+            $trends['mis_tickets'][] = Ticket::withoutGlobalScopes()
+                ->where('asignado_a', auth()->id())->whereNotIn('estado', ['cerrado', 'resuelto'])
+                ->whereDate('created_at', '<=', $date)->count();
+
+            $trends['en_revision'][] = Ticket::withoutGlobalScopes()
+                ->where('estado', 'en_revision')->whereDate('fecha_ultima_actividad', '<=', $date)->count();
+
+            $trends['esperando'][] = Ticket::withoutGlobalScopes()
+                ->where('estado', 'esperando_usuario')->whereDate('fecha_ultima_actividad', '<=', $date)->count();
+
+            $trends['total_abiertos'][] = Ticket::withoutGlobalScopes()
+                ->whereNotIn('estado', ['cerrado', 'resuelto'])
+                ->whereDate('created_at', '<=', $date)->count();
+
+            $trends['total'][] = Ticket::withoutGlobalScopes()
+                ->whereDate('created_at', '<=', $date)->count();
+        }
+
+        return $trends;
     }
 
     public function getSelectedTicketProperty(): ?Ticket
@@ -154,7 +205,7 @@ class PanelAgente extends Page implements HasForms
 
     public function enviarRespuesta(): void
     {
-        if (! $this->selectedTicket || ! trim($this->respuestaContenido)) {
+        if (! $this->selectedTicket || ! trim($this->respuestaContenido) || ! auth()->user()->can('editar_tickets')) {
             return;
         }
 
@@ -182,7 +233,7 @@ class PanelAgente extends Page implements HasForms
 
     public function asignarAMi(): void
     {
-        if (! $this->selectedTicket) {
+        if (! $this->selectedTicket || ! auth()->user()->can('editar_tickets')) {
             return;
         }
 
@@ -264,24 +315,24 @@ class PanelAgente extends Page implements HasForms
 
         $sugeridos = match ($categoria) {
             'problema_tecnico' => [
-                TipoFormato::F09 => 'F09 - Notificacion de incidencias',
-                TipoFormato::F10 => 'F10 - Resolucion de incidencias',
+                TipoFormato::F09->value => 'F09 - Notificacion de incidencias',
+                TipoFormato::F10->value => 'F10 - Resolucion de incidencias',
             ],
             'error_registro' => [
-                TipoFormato::F09 => 'F09 - Notificacion de incidencias',
-                TipoFormato::F10 => 'F10 - Resolucion de incidencias',
+                TipoFormato::F09->value => 'F09 - Notificacion de incidencias',
+                TipoFormato::F10->value => 'F10 - Resolucion de incidencias',
             ],
             'solicitud_acceso' => [
-                TipoFormato::F05 => 'F05 - Personal autorizado al BD',
-                TipoFormato::F06 => 'F06 - Acceso soporte no autorizado',
+                TipoFormato::F05->value => 'F05 - Personal autorizado al BD',
+                TipoFormato::F06->value => 'F06 - Acceso soporte no autorizado',
             ],
             default => [
-                TipoFormato::F09 => 'F09 - Notificacion de incidencias',
+                TipoFormato::F09->value => 'F09 - Notificacion de incidencias',
             ],
         };
 
         // Always offer F11 as option (recovery can happen in any context)
-        $sugeridos[TipoFormato::F11] = 'F11 - Recuperacion de datos';
+        $sugeridos[TipoFormato::F11->value] = 'F11 - Recuperacion de datos';
 
         return $sugeridos;
     }
@@ -293,7 +344,11 @@ class PanelAgente extends Page implements HasForms
     {
         $ticket = $this->selectedTicket;
 
-        if (! $ticket) {
+        if (! $ticket || ! auth()->user()->can('crear_registros')) {
+            return;
+        }
+
+        if (! in_array($ticket->estado, ['resuelto', 'cerrado', 'en_revision'])) {
             return;
         }
 
@@ -303,6 +358,24 @@ class PanelAgente extends Page implements HasForms
         }
 
         $empresaId = $ticket->empresa_id;
+
+        // Prevent duplicate: only one registro per ticket (any format)
+        $existente = Registro::withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->whereJsonContains('datos->ticket_referencia', $ticket->numero_ticket)
+            ->first();
+
+        if ($existente) {
+            $tipoExistente = TipoFormato::tryFrom($existente->tipo_formato);
+
+            Notification::make()
+                ->title('Este ticket ya tiene un registro')
+                ->body("Ya existe el registro {$existente->numero_registro} ({$tipoExistente?->label()}) vinculado al ticket {$ticket->numero_ticket}")
+                ->warning()
+                ->send();
+
+            return;
+        }
         $numero = RegistroNumberService::generate($empresaId, $tipo);
         $datos = $this->buildDatosFromTicket($ticket, $tipo);
 
@@ -322,7 +395,7 @@ class PanelAgente extends Page implements HasForms
             ->body("Se creo el registro {$tipo->label()} desde el ticket {$ticket->numero_ticket}")
             ->success()
             ->actions([
-                \Filament\Notifications\Actions\Action::make('ver_registro')
+                \Filament\Actions\Action::make('ver_registro')
                     ->label('Ver registro')
                     ->url($registroUrl)
                     ->openUrlInNewTab(),
@@ -339,15 +412,25 @@ class PanelAgente extends Page implements HasForms
         $descripcionPlana = strip_tags($ticket->descripcion);
         $agenteName = $ticket->agente?->name ?? auth()->user()->name;
         $creadorName = $ticket->creador?->name ?? 'Usuario';
+        $empresaNombre = $ticket->empresa?->razon_social ?? '';
+        $resumenMensajes = $this->extractResumenMensajes($ticket);
+        $impacto = $this->buildImpactoFromTicket($ticket);
+        $ticketUrl = url("admin/{$ticket->empresa?->ruc}/tickets/{$ticket->id}");
+        $observacion = "Registro generado automaticamente desde el ticket {$ticket->numero_ticket} ({$ticket->asunto}). Ver ticket: {$ticketUrl}";
 
         return match ($tipo) {
             TipoFormato::F09 => [
                 'fecha_evento' => $ticket->created_at->format('Y-m-d H:i:s'),
                 'tipo_incidencia' => $this->mapCategoriaTipoIncidencia($ticket->categoria),
-                'descripcion' => $ticket->descripcion,
-                'severidad' => $this->mapPrioridadSeveridad($ticket->prioridad),
+                'sistema_equipo' => "Ticket {$ticket->numero_ticket} - {$empresaNombre}",
+                'banco_datos' => '',
+                'descripcion' => $descripcionPlana ?: $ticket->asunto,
+                'medidas_inmediatas' => $resumenMensajes,
+                'personas_notificadas' => array_filter([$creadorName, $agenteName]),
+                'impacto_potencial' => $impacto,
                 'comunica_nombre' => $creadorName,
-                'medidas_inmediatas' => $this->extractResumenMensajes($ticket),
+                'severidad' => $this->mapPrioridadSeveridad($ticket->prioridad),
+                'observaciones' => $observacion,
                 'ticket_referencia' => $ticket->numero_ticket,
             ],
 
@@ -355,9 +438,13 @@ class PanelAgente extends Page implements HasForms
                 'incidencia_ref' => $this->findIncidenciaRefParaTicket($ticket),
                 'fecha_cierre' => ($ticket->fecha_cierre ?? now())->format('Y-m-d H:i:s'),
                 'clasificacion' => $this->mapPrioridadSeveridad($ticket->prioridad),
-                'medidas_adoptadas' => $this->extractResumenMensajes($ticket),
+                'requirio_recuperacion' => false,
+                'medidas_adoptadas' => $resumenMensajes ?: $descripcionPlana,
+                'resultado_verificacion' => $ticket->estado === 'resuelto' ? 'Ticket resuelto satisfactoriamente' : 'Ticket cerrado',
                 'ejecuto' => $agenteName,
+                'firma_responsable' => $agenteName,
                 'acciones_preventivas' => '',
+                'observaciones' => $observacion,
                 'ticket_referencia' => $ticket->numero_ticket,
             ],
 
@@ -365,29 +452,47 @@ class PanelAgente extends Page implements HasForms
                 'usuario' => $creadorName,
                 'fecha_asignacion' => ($ticket->fecha_cierre ?? now())->format('Y-m-d H:i:s'),
                 'banco_datos' => '',
+                'observaciones' => $observacion,
                 'ticket_referencia' => $ticket->numero_ticket,
             ],
 
             TipoFormato::F06 => [
-                'descripcion_soporte' => $descripcionPlana,
+                'descripcion_soporte' => $descripcionPlana ?: $ticket->asunto,
                 'persona_accede' => $creadorName,
                 'fecha_acceso' => $ticket->created_at->format('Y-m-d'),
                 'hora_acceso' => $ticket->created_at->format('H:i'),
+                'observaciones' => $observacion,
                 'ticket_referencia' => $ticket->numero_ticket,
             ],
 
             TipoFormato::F11 => [
                 'incidencia_relacionada' => $this->findIncidenciaRefParaTicket($ticket),
                 'fecha_realizacion' => ($ticket->fecha_cierre ?? now())->format('Y-m-d H:i:s'),
-                'proceso_realizado' => $this->extractResumenMensajes($ticket),
+                'autorizacion_escrita' => false,
+                'responsable_bd' => $agenteName,
+                'proceso_realizado' => $resumenMensajes ?: $descripcionPlana ?: $ticket->asunto,
                 'persona_ejecutora' => $agenteName,
+                'observaciones' => $observacion,
                 'ticket_referencia' => $ticket->numero_ticket,
             ],
 
             default => [
+                'observaciones' => $observacion,
                 'ticket_referencia' => $ticket->numero_ticket,
             ],
         };
+    }
+
+    private function buildImpactoFromTicket(Ticket $ticket): string
+    {
+        $nivel = match ($ticket->prioridad) {
+            'urgente' => 'Impacto critico',
+            'alta' => 'Impacto alto',
+            'media' => 'Impacto moderado',
+            default => 'Impacto bajo',
+        };
+
+        return "{$nivel} - {$ticket->asunto} ({$ticket->empresa?->razon_social})";
     }
 
     private function mapCategoriaTipoIncidencia(string $categoria): string
@@ -440,5 +545,35 @@ class PanelAgente extends Page implements HasForms
             ->first();
 
         return $registro?->numero_registro ?? '';
+    }
+
+    /**
+     * Sanitize HTML content: allow only safe tags with safe attributes.
+     * Images are rendered safely with src validated against local storage.
+     */
+    public function sanitizeHtml(string $html): HtmlString
+    {
+        // Strip all tags except safe formatting and images
+        $clean = strip_tags($html, '<p><br><strong><em><u><ul><ol><li><img>');
+
+        // Remove all attributes from tags except src on img (and only allow local URLs)
+        $clean = preg_replace_callback('/<img\s[^>]*>/i', function ($match) {
+            if (preg_match('/src=["\']([^"\']+)["\']/i', $match[0], $srcMatch)) {
+                $src = $srcMatch[1];
+                // Only allow local storage URLs
+                if (str_starts_with($src, '/storage/') || str_starts_with($src, url('/storage/'))) {
+                    $safeSrc = e($src);
+
+                    return '<img src="' . $safeSrc . '" style="max-width:320px;height:auto;border-radius:8px;margin:4px 0;" loading="lazy">';
+                }
+            }
+
+            return '';
+        }, $clean);
+
+        // Remove all attributes from non-img tags
+        $clean = preg_replace('/<(p|br|strong|em|u|ul|ol|li)\s[^>]*>/i', '<$1>', $clean);
+
+        return new HtmlString($clean);
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -50,6 +50,7 @@ class AdminPanelProvider extends PanelProvider
             ->colors([
                 'primary' => Color::Indigo,
             ])
+            ->viteTheme('resources/css/filament/admin/theme.css')
             ->tenantMiddleware([
                 ApplyTenantBranding::class,
             ], isPersistent: true)
@@ -86,6 +87,9 @@ class AdminPanelProvider extends PanelProvider
                     </style>"
                 );
             })
+            ->renderHook('panels::head.end', fn () => new \Illuminate\Support\HtmlString(
+                '<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js" defer></script>'
+            ))
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\Filament\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\Filament\Pages')
             ->pages([

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -62,6 +62,7 @@ class RolePermissionSeeder extends Seeder
             'ver_helpdesk', 'crear_helpdesk', 'editar_helpdesk',
             'ver_notas_internas', 'asignar_tickets',
             'ver_exportar', 'crear_exportar',
+            'crear_registros',
         ]);
 
         $soloLectura = Role::firstOrCreate(['name' => 'solo_lectura']);

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -1,0 +1,4 @@
+@import '../../../../vendor/filament/filament/resources/css/theme.css';
+
+@source '../../../../app/Filament/**/*.php';
+@source '../../../../resources/views/filament/**/*.blade.php';

--- a/resources/views/filament/pages/panel-agente.blade.php
+++ b/resources/views/filament/pages/panel-agente.blade.php
@@ -1,44 +1,22 @@
 <x-filament-panels::page>
-    {{-- Counters --}}
-    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-        <button wire:click="$set('filtroAgente', 'sin_asignar')"
-                class="fi-wi-stats-overview-stat relative rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left transition hover:ring-primary-500/50 {{ $filtroAgente === 'sin_asignar' ? 'ring-primary-500 ring-2' : '' }}">
-            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Sin asignar</span>
-            <span class="mt-1 block text-2xl font-bold text-danger-600 dark:text-danger-400">{{ $this->counters['sin_asignar'] }}</span>
-        </button>
+    <div>@php
+        $trends = $this->counterTrends;
+        $cards = [
+            ['key' => 'total', 'label' => 'Total tickets', 'value' => $this->counters['total'], 'color' => '#22d3ee', 'wire' => "limpiarFiltros", 'active' => !$filtroEstado && !$filtroAgente && !$filtroEmpresa && !$busqueda],
+            ['key' => 'sin_asignar', 'label' => 'Sin asignar', 'value' => $this->counters['sin_asignar'], 'color' => '#ef4444', 'wire' => "\$set('filtroAgente', 'sin_asignar')", 'active' => $filtroAgente === 'sin_asignar'],
+            ['key' => 'nuevos_hoy', 'label' => 'Nuevos hoy', 'value' => $this->counters['nuevos_hoy'], 'color' => '#3b82f6', 'wire' => "\$set('filtroEstado', 'nuevo')", 'active' => $filtroEstado === 'nuevo'],
+            ['key' => 'mis_tickets', 'label' => 'Mis tickets', 'value' => $this->counters['mis_tickets'], 'color' => '#6366f1', 'wire' => "\$set('filtroAgente', 'mis')", 'active' => $filtroAgente === 'mis'],
+            ['key' => 'en_revision', 'label' => 'En revision', 'value' => $this->counters['en_revision'], 'color' => '#f59e0b', 'wire' => "\$set('filtroEstado', 'en_revision')", 'active' => $filtroEstado === 'en_revision'],
+            ['key' => 'esperando', 'label' => 'Esperando usuario', 'value' => $this->counters['esperando'], 'color' => '#6b7280', 'wire' => "\$set('filtroEstado', 'esperando_usuario')", 'active' => $filtroEstado === 'esperando_usuario'],
+            ['key' => 'total_abiertos', 'label' => 'Abiertos', 'value' => $this->counters['total_abiertos'], 'color' => '#8b5cf6', 'wire' => null, 'active' => false],
+        ];
+    @endphp
 
-        <button wire:click="$set('filtroEstado', 'nuevo')"
-                class="fi-wi-stats-overview-stat relative rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left transition hover:ring-primary-500/50 {{ $filtroEstado === 'nuevo' ? 'ring-primary-500 ring-2' : '' }}">
-            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Nuevos hoy</span>
-            <span class="mt-1 block text-2xl font-bold text-info-600 dark:text-info-400">{{ $this->counters['nuevos_hoy'] }}</span>
-        </button>
+    {{-- Main layout: Panel (left) + Counters (right) --}}
+    <div class="grid grid-cols-1 gap-4 lg:grid-cols-12" style="min-height: 80vh;">
 
-        <button wire:click="$set('filtroAgente', 'mis')"
-                class="fi-wi-stats-overview-stat relative rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left transition hover:ring-primary-500/50 {{ $filtroAgente === 'mis' ? 'ring-primary-500 ring-2' : '' }}">
-            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Mis tickets</span>
-            <span class="mt-1 block text-2xl font-bold text-primary-600 dark:text-primary-400">{{ $this->counters['mis_tickets'] }}</span>
-        </button>
-
-        <button wire:click="$set('filtroEstado', 'en_revision')"
-                class="fi-wi-stats-overview-stat relative rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left transition hover:ring-primary-500/50 {{ $filtroEstado === 'en_revision' ? 'ring-primary-500 ring-2' : '' }}">
-            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">En revision</span>
-            <span class="mt-1 block text-2xl font-bold text-warning-600 dark:text-warning-400">{{ $this->counters['en_revision'] }}</span>
-        </button>
-
-        <button wire:click="$set('filtroEstado', 'esperando_usuario')"
-                class="fi-wi-stats-overview-stat relative rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left transition hover:ring-primary-500/50 {{ $filtroEstado === 'esperando_usuario' ? 'ring-primary-500 ring-2' : '' }}">
-            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Esperando usuario</span>
-            <span class="mt-1 block text-2xl font-bold text-gray-600 dark:text-gray-400">{{ $this->counters['esperando'] }}</span>
-        </button>
-
-        <div class="fi-wi-stats-overview-stat relative rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left">
-            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Total abiertos</span>
-            <span class="mt-1 block text-2xl font-bold text-gray-900 dark:text-white">{{ $this->counters['total_abiertos'] }}</span>
-        </div>
-    </div>
-
-    {{-- Split layout --}}
-    <div class="grid grid-cols-1 gap-4 lg:grid-cols-5" style="min-height: 70vh;">
+    {{-- LEFT: Ticket panel (list + detail) --}}
+    <div class="lg:col-span-9 grid grid-cols-1 gap-4 lg:grid-cols-5" style="min-height: 70vh;">
 
         {{-- LEFT: Ticket list --}}
         <div class="lg:col-span-2 flex flex-col rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
@@ -49,7 +27,7 @@
                     <input type="text"
                            wire:model.live.debounce.300ms="busqueda"
                            placeholder="Buscar ticket..."
-                           class="fi-input block w-full rounded-lg border-gray-300 text-sm shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white focus:border-primary-500 focus:ring-primary-500">
+                           class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-500">
                     @if ($filtroEstado || $filtroPrioridad || $filtroAgente || $filtroEmpresa || $busqueda)
                         <button wire:click="limpiarFiltros"
                                 class="shrink-0 rounded-lg bg-gray-100 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-200 dark:bg-white/5 dark:text-gray-400 dark:hover:bg-white/10"
@@ -60,7 +38,7 @@
                 </div>
                 <div class="grid grid-cols-2 gap-2">
                     <select wire:model.live="filtroEstado"
-                            class="fi-input block w-full rounded-lg border-gray-300 text-xs shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white">
+                            class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-900 shadow-sm transition focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
                         <option value="">Estado: Todos</option>
                         <option value="nuevo">Nuevo</option>
                         <option value="en_revision">En revision</option>
@@ -69,7 +47,7 @@
                         <option value="cerrado">Cerrado</option>
                     </select>
                     <select wire:model.live="filtroPrioridad"
-                            class="fi-input block w-full rounded-lg border-gray-300 text-xs shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white">
+                            class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-900 shadow-sm transition focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
                         <option value="">Prioridad: Todas</option>
                         <option value="urgente">Urgente</option>
                         <option value="alta">Alta</option>
@@ -77,14 +55,14 @@
                         <option value="baja">Baja</option>
                     </select>
                     <select wire:model.live="filtroEmpresa"
-                            class="fi-input block w-full rounded-lg border-gray-300 text-xs shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white">
+                            class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-900 shadow-sm transition focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
                         <option value="">Empresa: Todas</option>
                         @foreach ($this->empresas as $id => $nombre)
                             <option value="{{ $id }}">{{ $nombre }}</option>
                         @endforeach
                     </select>
                     <select wire:model.live="filtroAgente"
-                            class="fi-input block w-full rounded-lg border-gray-300 text-xs shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white">
+                            class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-900 shadow-sm transition focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
                         <option value="">Agente: Todos</option>
                         <option value="sin_asignar">Sin asignar</option>
                         <option value="mis">Mis tickets</option>
@@ -226,7 +204,7 @@
                         {{-- Quick actions --}}
                         <div class="flex items-center gap-2 shrink-0">
                             @if (! $ticket->asignado_a || $ticket->asignado_a !== auth()->id())
-                                <x-filament::button size="sm" color="info" wire:click="asignarAMi" icon="heroicon-m-hand-raised">
+                                <x-filament::button size="sm" color="info" wire:click="asignarAMi" wire:loading.attr="disabled" icon="heroicon-m-hand-raised">
                                     Tomar
                                 </x-filament::button>
                             @endif
@@ -262,9 +240,10 @@
                                         Formato sugerido
                                     </x-filament::dropdown.header>
                                     <x-filament::dropdown.list>
-                                        @foreach ($this->formatosSugeridos as $tipoEnum => $label)
+                                        @foreach ($this->formatosSugeridos as $tipoValue => $label)
                                             <x-filament::dropdown.list.item
-                                                wire:click="crearRegistroDesdeTicket('{{ $tipoEnum->value }}')"
+                                                wire:click="crearRegistroDesdeTicket('{{ $tipoValue }}')"
+                                                wire:loading.attr="disabled"
                                                 icon="heroicon-m-document-text">
                                                 {{ $label }}
                                             </x-filament::dropdown.list.item>
@@ -287,21 +266,18 @@
 
                 {{-- Conversation --}}
                 <div class="flex-1 overflow-y-auto p-4" style="max-height: calc(70vh - 220px);">
-                    <div style="max-width: 640px; margin: 0 auto; display: flex; flex-direction: column; gap: 12px;">
+                    <div class="mx-auto flex max-w-[640px] flex-col gap-3">
 
                         {{-- Original description --}}
-                        <div style="display: flex; justify-content: flex-start;">
-                            <div style="max-width: 80%;">
-                                <div style="font-size: 11px; font-weight: 600; color: #818cf8; margin-bottom: 2px; margin-left: 8px;">
+                        <div class="flex justify-start">
+                            <div class="max-w-[80%]">
+                                <div class="mb-0.5 ml-2 text-[11px] font-semibold text-indigo-400">
                                     {{ $ticket->creador?->name ?? 'Usuario' }}
                                 </div>
-                                <div style="background: rgba(255,255,255,0.08); border-radius: 16px 16px 16px 4px; padding: 10px 16px;">
-                                    <div style="font-size: 14px; line-height: 1.5; color: #e5e7eb; overflow: hidden;">
-                                        <style>.chat-desc img { max-width: 160px !important; height: auto !important; border-radius: 8px; display: block; margin: 4px 0; }</style>
-                                        <div class="chat-desc">{!! strip_tags($ticket->descripcion, '<p><br><strong><em><u><a><img><ul><ol><li>') !!}</div>
-                                    </div>
-                                    <div style="text-align: right; margin-top: 4px;">
-                                        <span style="font-size: 10px; color: #6b7280;">{{ $ticket->created_at->format('d/m/Y H:i') }}</span>
+                                <div class="rounded-2xl rounded-bl-sm bg-gray-100 px-4 py-2.5 dark:bg-white/8">
+                                    <div class="m-0 text-sm leading-relaxed text-gray-800 dark:text-gray-200">{!! $this->sanitizeHtml($ticket->descripcion ?? '') !!}</div>
+                                    <div class="mt-1 text-right">
+                                        <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ $ticket->created_at->format('d/m/Y H:i') }}</span>
                                     </div>
                                 </div>
                             </div>
@@ -314,16 +290,16 @@
 
                             @if ($mensaje->isInterno())
                                 {{-- Internal note --}}
-                                <div style="display: flex; justify-content: center;">
-                                    <div style="max-width: 85%; width: 100%;">
-                                        <div style="background: rgba(245,158,11,0.08); border: 1px dashed rgba(245,158,11,0.3); border-radius: 12px; padding: 10px 16px;">
-                                            <div style="display: flex; align-items: center; gap: 6px; margin-bottom: 4px;">
-                                                <span style="font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #f59e0b;">&#128274; Nota interna</span>
-                                                <span style="font-size: 10px; color: rgba(245,158,11,0.6);">&middot; {{ $mensaje->autor?->name ?? 'Agente' }}</span>
+                                <div class="flex justify-center">
+                                    <div class="w-full max-w-[85%]">
+                                        <div class="rounded-xl border border-dashed border-warning-300/30 bg-warning-50/50 px-4 py-2.5 dark:border-warning-500/30 dark:bg-warning-500/[0.08]">
+                                            <div class="mb-1 flex items-center gap-1.5">
+                                                <span class="text-[10px] font-bold uppercase tracking-wide text-warning-500">&#128274; Nota interna</span>
+                                                <span class="text-[10px] text-warning-400/60 dark:text-warning-500/60">&middot; {{ $mensaje->autor?->name ?? 'Agente' }}</span>
                                             </div>
-                                            <p style="font-size: 14px; color: #fde68a; margin: 0;">{{ $mensaje->contenido }}</p>
-                                            <div style="text-align: right; margin-top: 4px;">
-                                                <span style="font-size: 10px; color: rgba(245,158,11,0.4);">{{ $mensaje->created_at->format('d/m/Y H:i') }}</span>
+                                            <p class="m-0 text-sm text-warning-700 dark:text-warning-200">{{ $mensaje->contenido }}</p>
+                                            <div class="mt-1 text-right">
+                                                <span class="text-[10px] text-warning-300 dark:text-warning-500/40">{{ $mensaje->created_at->format('d/m/Y H:i') }}</span>
                                             </div>
                                         </div>
                                     </div>
@@ -331,27 +307,27 @@
 
                             @elseif ($isAgent)
                                 {{-- Agent message --}}
-                                <div style="display: flex; justify-content: flex-end;">
-                                    <div style="max-width: 80%;">
-                                        <div style="font-size: 11px; font-weight: 600; color: #34d399; margin-bottom: 2px; text-align: right; margin-right: 8px;">
+                                <div class="flex justify-end">
+                                    <div class="max-w-[80%]">
+                                        <div class="mb-0.5 mr-2 text-right text-[11px] font-semibold text-success-500 dark:text-success-400">
                                             &#9989; {{ $mensaje->autor?->name ?? 'Agente' }}
                                         </div>
-                                        <div style="background: rgba(16,185,129,0.12); border-radius: 16px 4px 16px 16px; padding: 10px 16px;">
-                                            <p style="font-size: 14px; color: #e5e7eb; margin: 0; line-height: 1.5;">{{ $mensaje->contenido }}</p>
+                                        <div class="rounded-2xl rounded-tr-sm bg-success-50 px-4 py-2.5 dark:bg-success-500/[0.12]">
+                                            <p class="m-0 text-sm leading-relaxed text-gray-800 dark:text-gray-200">{{ $mensaje->contenido }}</p>
                                             @if ($mensaje->adjuntos->isNotEmpty())
-                                                <div style="margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
+                                                <div class="mt-2 flex flex-col gap-1">
                                                     @foreach ($mensaje->adjuntos as $adjunto)
                                                         <a href="{{ route('tickets.adjunto.download', $adjunto) }}"
-                                                           style="display: flex; align-items: center; gap: 8px; background: rgba(16,185,129,0.1); border-radius: 8px; padding: 6px 10px; text-decoration: none;">
-                                                            <span style="font-size: 14px;">&#128206;</span>
-                                                            <span style="font-size: 12px; color: #6ee7b7; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px;">{{ $adjunto->nombre_original }}</span>
-                                                            <span style="font-size: 10px; color: rgba(16,185,129,0.5); margin-left: auto;">{{ number_format($adjunto->tamano / 1024, 0) }}KB</span>
+                                                           class="flex items-center gap-2 rounded-lg bg-success-100/50 px-2.5 py-1.5 no-underline dark:bg-success-500/10">
+                                                            <span class="text-sm">&#128206;</span>
+                                                            <span class="max-w-[180px] truncate text-xs text-success-700 dark:text-success-300">{{ $adjunto->nombre_original }}</span>
+                                                            <span class="ml-auto text-[10px] text-success-400 dark:text-success-500/50">{{ number_format($adjunto->tamano / 1024, 0) }}KB</span>
                                                         </a>
                                                     @endforeach
                                                 </div>
                                             @endif
-                                            <div style="text-align: right; margin-top: 4px;">
-                                                <span style="font-size: 10px; color: rgba(16,185,129,0.4);">{{ $mensaje->created_at->format('d/m/Y H:i') }}</span>
+                                            <div class="mt-1 text-right">
+                                                <span class="text-[10px] text-success-300 dark:text-success-500/40">{{ $mensaje->created_at->format('d/m/Y H:i') }}</span>
                                             </div>
                                         </div>
                                     </div>
@@ -359,27 +335,27 @@
 
                             @else
                                 {{-- User message --}}
-                                <div style="display: flex; justify-content: flex-start;">
-                                    <div style="max-width: 80%;">
-                                        <div style="font-size: 11px; font-weight: 600; color: #818cf8; margin-bottom: 2px; margin-left: 8px;">
+                                <div class="flex justify-start">
+                                    <div class="max-w-[80%]">
+                                        <div class="mb-0.5 ml-2 text-[11px] font-semibold text-indigo-400">
                                             {{ $mensaje->autor?->name ?? 'Usuario' }}
                                         </div>
-                                        <div style="background: rgba(255,255,255,0.08); border-radius: 16px 16px 16px 4px; padding: 10px 16px;">
-                                            <p style="font-size: 14px; color: #e5e7eb; margin: 0; line-height: 1.5;">{{ $mensaje->contenido }}</p>
+                                        <div class="rounded-2xl rounded-bl-sm bg-gray-100 px-4 py-2.5 dark:bg-white/8">
+                                            <p class="m-0 text-sm leading-relaxed text-gray-800 dark:text-gray-200">{{ $mensaje->contenido }}</p>
                                             @if ($mensaje->adjuntos->isNotEmpty())
-                                                <div style="margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
+                                                <div class="mt-2 flex flex-col gap-1">
                                                     @foreach ($mensaje->adjuntos as $adjunto)
                                                         <a href="{{ route('tickets.adjunto.download', $adjunto) }}"
-                                                           style="display: flex; align-items: center; gap: 8px; background: rgba(255,255,255,0.05); border-radius: 8px; padding: 6px 10px; text-decoration: none;">
-                                                            <span style="font-size: 14px;">&#128206;</span>
-                                                            <span style="font-size: 12px; color: #d1d5db; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px;">{{ $adjunto->nombre_original }}</span>
-                                                            <span style="font-size: 10px; color: #6b7280; margin-left: auto;">{{ number_format($adjunto->tamano / 1024, 0) }}KB</span>
+                                                           class="flex items-center gap-2 rounded-lg bg-gray-50 px-2.5 py-1.5 no-underline dark:bg-white/5">
+                                                            <span class="text-sm">&#128206;</span>
+                                                            <span class="max-w-[180px] truncate text-xs text-gray-600 dark:text-gray-300">{{ $adjunto->nombre_original }}</span>
+                                                            <span class="ml-auto text-[10px] text-gray-400 dark:text-gray-500">{{ number_format($adjunto->tamano / 1024, 0) }}KB</span>
                                                         </a>
                                                     @endforeach
                                                 </div>
                                             @endif
-                                            <div style="text-align: right; margin-top: 4px;">
-                                                <span style="font-size: 10px; color: #6b7280;">{{ $mensaje->created_at->format('d/m/Y H:i') }}</span>
+                                            <div class="mt-1 text-right">
+                                                <span class="text-[10px] text-gray-400 dark:text-gray-500">{{ $mensaje->created_at->format('d/m/Y H:i') }}</span>
                                             </div>
                                         </div>
                                     </div>
@@ -388,8 +364,8 @@
                         @endforeach
 
                         @if ($this->mensajes->isEmpty())
-                            <div style="text-align: center; padding: 24px 0;">
-                                <p style="font-size: 14px; color: #6b7280;">No hay mensajes aun.</p>
+                            <div class="py-6 text-center">
+                                <p class="text-sm text-gray-500">No hay mensajes aun.</p>
                             </div>
                         @endif
                     </div>
@@ -402,14 +378,14 @@
                             <textarea wire:model="respuestaContenido"
                                       rows="3"
                                       placeholder="Escribe tu respuesta..."
-                                      class="fi-input block w-full rounded-lg border-gray-300 text-sm shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white focus:border-primary-500 focus:ring-primary-500"></textarea>
+                                      class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-gray-500"></textarea>
                             <div class="mt-2 flex items-center justify-between">
                                 <label class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
                                     <input type="checkbox" wire:model="respuestaInterna"
-                                           class="fi-checkbox-input rounded border-gray-300 text-primary-600 shadow-sm dark:border-white/10 dark:bg-white/5">
+                                           class="rounded border border-gray-300 text-primary-600 shadow-sm focus:ring-primary-500 dark:border-white/10 dark:bg-white/5">
                                     Nota interna
                                 </label>
-                                <x-filament::button type="submit" size="sm" icon="heroicon-m-paper-airplane">
+                                <x-filament::button type="submit" size="sm" icon="heroicon-m-paper-airplane" wire:loading.attr="disabled">
                                     Enviar
                                 </x-filament::button>
                             </div>
@@ -426,5 +402,68 @@
                 </div>
             @endif
         </div>
+    </div>{{-- /LEFT: ticket panel --}}
+
+    {{-- RIGHT: Counter cards with sparklines --}}
+    <div class="lg:col-span-3 flex flex-col gap-2">
+        @foreach ($cards as $i => $card)
+            @php
+                $trendData = $trends[$card['key']];
+                $today = end($trendData);
+                $yesterday = $trendData[count($trendData) - 2] ?? $today;
+                $delta = $today - $yesterday;
+            @endphp
+            <button
+                wire:click="{{ $card['wire'] ?? 'limpiarFiltros' }}"
+                class="relative overflow-hidden rounded-xl bg-white p-3 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 text-left transition hover:ring-primary-500/50 {{ $card['active'] ? 'ring-primary-500 ring-2' : '' }}"
+                x-data="{
+                    init() {
+                        new Chart(this.$refs.spark{{ $i }}, {
+                            type: 'line',
+                            data: {
+                                labels: @js($trendData).map((_, i) => i),
+                                datasets: [{
+                                    data: @js($trendData),
+                                    borderColor: '{{ $card['color'] }}',
+                                    backgroundColor: '{{ $card['color'] }}18',
+                                    fill: true,
+                                    tension: 0.4,
+                                    pointRadius: 0,
+                                    borderWidth: 1.5,
+                                }]
+                            },
+                            options: {
+                                responsive: true,
+                                maintainAspectRatio: false,
+                                plugins: { legend: { display: false }, tooltip: { enabled: false } },
+                                scales: { x: { display: false }, y: { display: false, beginAtZero: true } },
+                                animation: { duration: 500 },
+                            }
+                        });
+                    }
+                }">
+                <div class="flex items-center justify-between">
+                    <div class="min-w-0">
+                        <span class="text-[11px] font-medium text-gray-500 dark:text-gray-400">{{ $card['label'] }}</span>
+                        <div class="flex items-baseline gap-2">
+                            <span class="text-xl font-bold" style="color: {{ $card['color'] }}">{{ $card['value'] }}</span>
+                            @if ($delta > 0)
+                                <span class="text-[10px] font-semibold text-success-500">+{{ $delta }}</span>
+                            @elseif ($delta < 0)
+                                <span class="text-[10px] font-semibold text-danger-500">{{ $delta }}</span>
+                            @else
+                                <span class="text-[10px] text-gray-400">=</span>
+                            @endif
+                        </div>
+                    </div>
+                    <div style="width: 72px; height: 30px;">
+                        <canvas x-ref="spark{{ $i }}"></canvas>
+                    </div>
+                </div>
+            </button>
+        @endforeach
     </div>
+
+    </div>{{-- /Main layout --}}
+    </div>{{-- /wrapper --}}
 </x-filament-panels::page>

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.js', 'resources/css/filament/admin/theme.css'],
             refresh: true,
         }),
         tailwindcss(),


### PR DESCRIPTION
## Summary
- **Security**: Fix XSS in ticket descriptions, add permission checks to all mutation methods, validate ticket state before registro creation
- **Bug fixes**: Fix enum-as-array-key crash, fix missing Filament Action class, fix Tailwind not compiling (custom theme), fix input styles
- **UI**: Full-width layout with metric cards (sparklines + deltas) on the right, chat bubbles with Tailwind dark mode support, safe image rendering
- **Registro creation**: Pre-fill all format fields from ticket data, add observaciones with ticket link, enforce one registro per ticket

## Related issues
- SEN-17: Panel de agente helpdesk
- SEN-65: Crear registro de formato desde ticket resuelto
- SEN-67: QA manual testing

## Test plan
- [ ] Verify panel loads at full width with counter cards + sparklines on the right
- [ ] Click "Tomar" on an unassigned ticket — should assign and update counters
- [ ] Change ticket estado via dropdown — should update badge and counters
- [ ] Click "Crear registro" on a resolved/en_revision ticket — should create registro with all fields pre-filled
- [ ] Try creating a second registro on same ticket — should show "ya existe" warning
- [ ] Verify images render in ticket descriptions (only local /storage/ URLs)
- [ ] Verify inputs/selects/textarea have correct styling in dark mode
- [ ] Test as agente_helpdesk role — verify permission checks work

🤖 Generated with [Claude Code](https://claude.com/claude-code)