### PR TITLE
feat(SEN-10): email de incidencia al Admin Empresa

### DIFF
--- a/app/Observers/RegistroObserver.php
+++ b/app/Observers/RegistroObserver.php
@@ -19,6 +19,10 @@ class RegistroObserver
 
     private function notifyAdminEmpresa(Registro $registro): void
     {
+        if (! $registro->empresa_id) {
+            return;
+        }
+
         $admins = User::where('empresa_id', $registro->empresa_id)
             ->role('admin_empresa')
             ->where('estado', 'activo')

--- a/app/Observers/RegistroObserver.php
+++ b/app/Observers/RegistroObserver.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\SendEmailJob;
+use App\Models\Registro;
+use App\Models\User;
+
+class RegistroObserver
+{
+    public function created(Registro $registro): void
+    {
+        if ($registro->tipo_formato !== 'F09') {
+            return;
+        }
+
+        $this->notifyAdminEmpresa($registro);
+    }
+
+    private function notifyAdminEmpresa(Registro $registro): void
+    {
+        $admins = User::where('empresa_id', $registro->empresa_id)
+            ->role('admin_empresa')
+            ->where('estado', 'activo')
+            ->get();
+
+        if ($admins->isEmpty()) {
+            return;
+        }
+
+        $datos = $registro->datos ?? [];
+        $tipo = $this->labelTipoIncidencia($datos['tipo_incidencia'] ?? 'otro');
+        $severidad = ucfirst($datos['severidad'] ?? 'media');
+        $registroUrl = url("admin/{$registro->empresa?->ruc}/registros/{$registro->id}/edit");
+
+        foreach ($admins as $admin) {
+            $job = SendEmailJob::fromTemplate(
+                destinatario: $admin->email,
+                nombreDestino: $admin->name,
+                templateSlug: 'nueva_incidencia',
+                templateVariables: [
+                    'nombre' => $admin->name,
+                    'numero_incidencia' => $registro->numero_registro,
+                    'tipo' => $tipo,
+                    'severidad' => $severidad,
+                    'enlace_registro' => $registroUrl,
+                ],
+                actionUrl: $registroUrl,
+                actionLabel: 'Ver incidencia',
+            );
+
+            dispatch($job);
+        }
+    }
+
+    private function labelTipoIncidencia(string $tipo): string
+    {
+        return match ($tipo) {
+            'acceso_no_autorizado' => 'Acceso no autorizado',
+            'perdida_datos' => 'Perdida de datos',
+            'fuga_informacion' => 'Fuga de informacion',
+            'malware' => 'Malware',
+            'fallo_sistema' => 'Fallo de sistema',
+            default => 'Otro',
+        };
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,8 +29,8 @@ class AppServiceProvider extends ServiceProvider
             URL::forceScheme('https');
         }
 
-        Registro::observe(\App\Observers\RegistroObserver::class);
         Registro::observe(AuditableObserver::class);
+        Registro::observe(\App\Observers\RegistroObserver::class);
         Ticket::observe(AuditableObserver::class);
         Empresa::observe(AuditableObserver::class);
         User::observe(AuditableObserver::class);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,6 +29,7 @@ class AppServiceProvider extends ServiceProvider
             URL::forceScheme('https');
         }
 
+        Registro::observe(\App\Observers\RegistroObserver::class);
         Registro::observe(AuditableObserver::class);
         Ticket::observe(AuditableObserver::class);
         Empresa::observe(AuditableObserver::class);


### PR DESCRIPTION
## Summary
- RegistroObserver detects F09 creation and dispatches email to all active admin_empresa users
- Uses existing `nueva_incidencia` email template with variables: nombre, numero_incidencia, tipo, severidad, enlace_registro
- Subject auto-prefixed with severity level (e.g. `[Alta] Nueva incidencia INC-2026-004: Fallo de sistema`)
- Emails queued via Redis (SendEmailJob) with 3 retries and logged to notificaciones_email

## Test plan
- [x] Create F09 registro via tinker -> email sent to carlos@palacios.pe
- [x] Email visible in MailHog with correct subject and content
- [x] NotificacionEmail record created with estado=enviado
- [ ] Create F09 from Panel de Agente -> verify email triggers
- [ ] Create non-F09 registro -> verify NO email sent
- [ ] Test with empresa without admin_empresa users -> no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)