### PR TITLE
feat(SEN-14): reapertura de ticket resuelto con ventana de 7 dias

### DIFF
--- a/app/Filament/Pages/PanelAgente.php
+++ b/app/Filament/Pages/PanelAgente.php
@@ -283,7 +283,7 @@ class PanelAgente extends Page implements HasForms
     {
         $ticket = $this->selectedTicket;
 
-        if (! $ticket || ! $ticket->puedeReabrirse()) {
+        if (! $ticket || ! $ticket->puedeReabrirse() || ! auth()->user()->can('editar_tickets')) {
             return;
         }
 

--- a/app/Filament/Pages/PanelAgente.php
+++ b/app/Filament/Pages/PanelAgente.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Enums\TipoFormato;
+use App\Jobs\SendEmailJob;
 use App\Models\Registro;
 use App\Models\Ticket;
 use App\Models\User;
@@ -274,6 +275,55 @@ class PanelAgente extends Page implements HasForms
 
         Notification::make()
             ->title('Estado actualizado a: ' . $estado)
+            ->success()
+            ->send();
+    }
+
+    public function reabrirTicket(): void
+    {
+        $ticket = $this->selectedTicket;
+
+        if (! $ticket || ! $ticket->puedeReabrirse()) {
+            return;
+        }
+
+        $ticket->update([
+            'estado' => 'en_revision',
+            'fecha_ultima_actividad' => now(),
+            'fecha_cierre' => null,
+        ]);
+
+        $ticket->mensajes()->create([
+            'autor_id' => auth()->id(),
+            'tipo' => 'interno',
+            'contenido' => 'TICKET REABIERTO por ' . auth()->user()->name . '.',
+            'created_at' => now(),
+        ]);
+
+        if ($ticket->asignado_a && $ticket->agente) {
+            $ticketUrl = url("admin/{$ticket->empresa?->ruc}/tickets/{$ticket->id}");
+
+            dispatch(SendEmailJob::fromTemplate(
+                destinatario: $ticket->agente->email,
+                nombreDestino: $ticket->agente->name,
+                templateSlug: 'ticket_reabierto',
+                templateVariables: [
+                    'nombre' => $ticket->agente->name,
+                    'numero_ticket' => $ticket->numero_ticket,
+                    'asunto' => $ticket->asunto,
+                    'quien_reabrio' => auth()->user()->name,
+                    'motivo' => 'Reabierto desde panel de agente',
+                    'enlace_ticket' => $ticketUrl,
+                ],
+                actionUrl: $ticketUrl,
+                actionLabel: 'Ver ticket',
+            ));
+        }
+
+        unset($this->selectedTicket, $this->tickets, $this->counters, $this->mensajes);
+
+        Notification::make()
+            ->title('Ticket reabierto')
             ->success()
             ->send();
     }

--- a/app/Filament/Resources/Tickets/Pages/ViewTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/ViewTicket.php
@@ -7,6 +7,7 @@ use App\Models\Ticket;
 use App\Models\TicketAdjunto;
 use App\Models\TicketMensaje;
 use App\Models\User;
+use App\Jobs\SendEmailJob;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\FileUpload;
@@ -231,6 +232,65 @@ class ViewTicket extends ViewRecord
                         ->send();
                 })
                 ->visible(fn () => auth()->user()->can('editar_tickets')),
+
+            Action::make('reabrir')
+                ->label('Reabrir ticket')
+                ->icon('heroicon-o-arrow-uturn-left')
+                ->color('warning')
+                ->requiresConfirmation()
+                ->modalHeading('Reabrir ticket')
+                ->modalDescription('El ticket sera reabierto y el agente asignado sera notificado por email.')
+                ->form([
+                    Textarea::make('motivo')
+                        ->label('Motivo de reapertura')
+                        ->required()
+                        ->rows(3)
+                        ->placeholder('Explica por que necesitas reabrir este ticket...'),
+                ])
+                ->action(function (array $data) {
+                    $this->record->update([
+                        'estado' => 'en_revision',
+                        'fecha_ultima_actividad' => now(),
+                        'fecha_cierre' => null,
+                    ]);
+
+                    $this->record->mensajes()->create([
+                        'autor_id' => auth()->id(),
+                        'tipo' => 'interno',
+                        'contenido' => "TICKET REABIERTO por " . auth()->user()->name . ".\nMotivo: {$data['motivo']}",
+                        'created_at' => now(),
+                    ]);
+
+                    if ($this->record->asignado_a) {
+                        $agente = $this->record->agente;
+                        if ($agente) {
+                            $ticketUrl = url("admin/{$this->record->empresa?->ruc}/tickets/{$this->record->id}");
+
+                            dispatch(SendEmailJob::fromTemplate(
+                                destinatario: $agente->email,
+                                nombreDestino: $agente->name,
+                                templateSlug: 'ticket_reabierto',
+                                templateVariables: [
+                                    'nombre' => $agente->name,
+                                    'numero_ticket' => $this->record->numero_ticket,
+                                    'asunto' => $this->record->asunto,
+                                    'quien_reabrio' => auth()->user()->name,
+                                    'motivo' => $data['motivo'],
+                                    'enlace_ticket' => $ticketUrl,
+                                ],
+                                actionUrl: $ticketUrl,
+                                actionLabel: 'Ver ticket',
+                            ));
+                        }
+                    }
+
+                    Notification::make()
+                        ->title('Ticket reabierto')
+                        ->body('El agente ha sido notificado por email.')
+                        ->success()
+                        ->send();
+                })
+                ->visible(fn () => $this->record->puedeReabrirse()),
         ];
     }
 }

--- a/app/Filament/Resources/Tickets/Pages/ViewTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/ViewTicket.php
@@ -284,13 +284,17 @@ class ViewTicket extends ViewRecord
                         }
                     }
 
+                    $notifBody = $this->record->asignado_a
+                        ? 'El agente ha sido notificado por email.'
+                        : 'No hay agente asignado, no se envio notificacion.';
+
                     Notification::make()
                         ->title('Ticket reabierto')
-                        ->body('El agente ha sido notificado por email.')
+                        ->body($notifBody)
                         ->success()
                         ->send();
                 })
-                ->visible(fn () => $this->record->puedeReabrirse()),
+                ->visible(fn () => $this->record->puedeReabrirse() && auth()->user()->can('editar_tickets')),
         ];
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -62,6 +62,6 @@ class Ticket extends Model
             return false;
         }
 
-        return $this->fecha_cierre->diffInDays(now()) <= 7;
+        return $this->fecha_cierre->greaterThan(now()->subDays(7));
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -51,4 +51,17 @@ class Ticket extends Model
     {
         return $this->hasMany(TicketMensaje::class, 'ticket_id');
     }
+
+    public function puedeReabrirse(): bool
+    {
+        if ($this->estado !== 'resuelto') {
+            return false;
+        }
+
+        if (! $this->fecha_cierre) {
+            return false;
+        }
+
+        return $this->fecha_cierre->diffInDays(now()) <= 7;
+    }
 }

--- a/database/seeders/EmailTemplateSeeder.php
+++ b/database/seeders/EmailTemplateSeeder.php
@@ -122,6 +122,20 @@ HTML,
 <p>Recuerda que las incidencias de severidad Alta requieren atencion inmediata segun la politica PSC000-25.</p>
 HTML,
             ],
+            [
+                'slug' => 'ticket_reabierto',
+                'nombre' => 'Ticket reabierto',
+                'asunto' => 'Ticket {{numero_ticket}} reabierto: {{asunto}}',
+                'variables_disponibles' => ['nombre', 'numero_ticket', 'asunto', 'quien_reabrio', 'motivo', 'enlace_ticket'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>El ticket <strong>{{numero_ticket}}</strong> ha sido <strong>reabierto</strong> por <strong>{{quien_reabrio}}</strong>.</p>
+<p><strong>Asunto:</strong> {{asunto}}<br>
+<strong>Motivo de reapertura:</strong> {{motivo}}</p>
+<p>Por favor revisa el ticket y toma las acciones necesarias:</p>
+<p><a href="{{enlace_ticket}}">Ver ticket</a></p>
+HTML,
+            ],
         ];
     }
 }

--- a/resources/views/filament/pages/panel-agente.blade.php
+++ b/resources/views/filament/pages/panel-agente.blade.php
@@ -252,6 +252,12 @@
                                 </x-filament::dropdown>
                             @endif
 
+                            @if ($ticket->puedeReabrirse())
+                                <x-filament::button size="sm" color="warning" wire:click="reabrirTicket" wire:loading.attr="disabled" icon="heroicon-m-arrow-uturn-left">
+                                    Reabrir
+                                </x-filament::button>
+                            @endif
+
                             <x-filament::link
                                 :href="url('admin/' . ($ticket->empresa?->ruc ?? '') . '/tickets/' . $ticket->id)"
                                 size="sm"


### PR DESCRIPTION
## Summary
- Users can reopen resolved tickets within 7 days of resolution
- "Reabrir" button visible in both ViewTicket page (with motivo form) and PanelAgente
- Reopening: sets estado=en_revision, clears fecha_cierre, logs internal message to thread
- Dispatches email notification to assigned agent via `ticket_reabierto` template
- After 7 days, the reopen button disappears automatically

## Test plan
- [ ] Resolve a ticket, verify "Reabrir" button appears
- [ ] Click "Reabrir" on ViewTicket page — fill motivo, confirm
- [ ] Verify ticket estado changes to en_revision, fecha_cierre is null
- [ ] Verify internal message "TICKET REABIERTO" appears in thread
- [ ] Verify email sent to agent in MailHog
- [ ] Click "Reabrir" on PanelAgente — verify same behavior
- [ ] Wait 7+ days (or modify fecha_cierre) — verify button disappears
- [ ] Verify button NOT visible for cerrado or non-resuelto tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)