### PR TITLE
feat(SEN-9): dashboard empresa con Filament widgets

### DIFF
--- a/app/Filament/Widgets/LatestRegistros.php
+++ b/app/Filament/Widgets/LatestRegistros.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\TipoFormato;
+use App\Models\Registro;
+use Filament\Facades\Filament;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class LatestRegistros extends BaseWidget
+{
+    protected static ?int $sort = 2;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $heading = 'Ultimos registros';
+
+    public function table(Table $table): Table
+    {
+        $empresa = Filament::getTenant();
+
+        return $table
+            ->query(
+                Registro::query()
+                    ->where('empresa_id', $empresa?->id)
+                    ->latest('created_at')
+                    ->limit(5)
+            )
+            ->columns([
+                TextColumn::make('numero_registro')
+                    ->label('N° Registro')
+                    ->searchable(),
+                TextColumn::make('tipo_formato')
+                    ->label('Formato')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => TipoFormato::tryFrom($state)?->label() ?? $state),
+                TextColumn::make('creador.name')
+                    ->label('Creado por'),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'activo' => 'success',
+                        'inactivo' => 'danger',
+                        default => 'gray',
+                    }),
+                TextColumn::make('created_at')
+                    ->label('Fecha')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Filament/Widgets/QuickAccessFormatos.php
+++ b/app/Filament/Widgets/QuickAccessFormatos.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\TipoFormato;
+use App\Models\Registro;
+use Filament\Facades\Filament;
+use Filament\Widgets\Widget;
+
+class QuickAccessFormatos extends Widget
+{
+    protected static ?int $sort = 3;
+
+    protected string $view = 'filament.widgets.quick-access-formatos';
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function getFormatos(): array
+    {
+        $empresa = Filament::getTenant();
+        $empresaId = $empresa?->id;
+
+        if (! $empresaId) {
+            return [];
+        }
+
+        $counts = Registro::where('empresa_id', $empresaId)
+            ->selectRaw('tipo_formato, count(*) as total')
+            ->groupBy('tipo_formato')
+            ->pluck('total', 'tipo_formato')
+            ->toArray();
+
+        $formatos = [];
+        foreach (TipoFormato::cases() as $tipo) {
+            $formatos[] = [
+                'value' => $tipo->value,
+                'label' => $tipo->label(),
+                'prefix' => $tipo->prefix(),
+                'count' => $counts[$tipo->value] ?? 0,
+                'url' => url("admin/{$empresa->ruc}/registros?tableFilters[tipo_formato][value]={$tipo->value}"),
+                'create_url' => url("admin/{$empresa->ruc}/registros/create?tipo_formato={$tipo->value}"),
+            ];
+        }
+
+        // Sort by count descending
+        usort($formatos, fn ($a, $b) => $b['count'] <=> $a['count']);
+
+        return $formatos;
+    }
+}

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Registro;
+use App\Models\Ticket;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class StatsOverview extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    protected function getStats(): array
+    {
+        $empresa = Filament::getTenant();
+        $empresaId = $empresa?->id;
+
+        if (! $empresaId) {
+            return [];
+        }
+
+        $registrosMes = Registro::where('empresa_id', $empresaId)
+            ->whereMonth('created_at', now()->month)
+            ->whereYear('created_at', now()->year)
+            ->count();
+
+        $registrosMesAnterior = Registro::where('empresa_id', $empresaId)
+            ->whereMonth('created_at', now()->subMonth()->month)
+            ->whereYear('created_at', now()->subMonth()->year)
+            ->count();
+
+        $ticketsAbiertos = Ticket::where('empresa_id', $empresaId)
+            ->whereNotIn('estado', ['cerrado', 'resuelto'])
+            ->count();
+
+        $ticketsMes = Ticket::where('empresa_id', $empresaId)
+            ->whereMonth('created_at', now()->month)
+            ->whereYear('created_at', now()->year)
+            ->count();
+
+        $incidenciasMes = Registro::where('empresa_id', $empresaId)
+            ->where('tipo_formato', 'F09')
+            ->whereMonth('created_at', now()->month)
+            ->whereYear('created_at', now()->year)
+            ->count();
+
+        $usuariosActivos = User::where('empresa_id', $empresaId)
+            ->where('estado', 'activo')
+            ->count();
+
+        // Sparkline data: registros per day last 7 days
+        $registrosTrend = collect(range(6, 0))->map(fn ($i) => Registro::where('empresa_id', $empresaId)
+            ->whereDate('created_at', now()->subDays($i))
+            ->count()
+        )->toArray();
+
+        $ticketsTrend = collect(range(6, 0))->map(fn ($i) => Ticket::where('empresa_id', $empresaId)
+            ->whereDate('created_at', now()->subDays($i))
+            ->count()
+        )->toArray();
+
+        return [
+            Stat::make('Registros del mes', $registrosMes)
+                ->description($this->deltaDescription($registrosMes, $registrosMesAnterior))
+                ->descriptionIcon($registrosMes >= $registrosMesAnterior ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
+                ->color($registrosMes >= $registrosMesAnterior ? 'success' : 'warning')
+                ->chart($registrosTrend),
+
+            Stat::make('Tickets abiertos', $ticketsAbiertos)
+                ->description("{$ticketsMes} creados este mes")
+                ->descriptionIcon('heroicon-m-ticket')
+                ->color($ticketsAbiertos > 5 ? 'warning' : 'success')
+                ->chart($ticketsTrend),
+
+            Stat::make('Incidencias (F09)', $incidenciasMes)
+                ->description('Este mes')
+                ->descriptionIcon('heroicon-m-exclamation-triangle')
+                ->color($incidenciasMes > 0 ? 'danger' : 'success'),
+
+            Stat::make('Usuarios activos', $usuariosActivos)
+                ->description('En tu empresa')
+                ->descriptionIcon('heroicon-m-users')
+                ->color('info'),
+        ];
+    }
+
+    private function deltaDescription(int $current, int $previous): string
+    {
+        if ($previous === 0) {
+            return $current > 0 ? "+{$current} vs mes anterior" : 'Sin cambios';
+        }
+
+        $delta = $current - $previous;
+        $sign = $delta >= 0 ? '+' : '';
+
+        return "{$sign}{$delta} vs mes anterior";
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -96,10 +96,7 @@ class AdminPanelProvider extends PanelProvider
                 Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
-            ->widgets([
-                AccountWidget::class,
-                FilamentInfoWidget::class,
-            ])
+            ->widgets([])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/resources/views/filament/widgets/quick-access-formatos.blade.php
+++ b/resources/views/filament/widgets/quick-access-formatos.blade.php
@@ -1,0 +1,18 @@
+<x-filament-widgets::widget>
+    <x-filament::section heading="Formatos de seguridad" icon="heroicon-o-document-text" collapsible>
+        <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+            @foreach ($this->getFormatos() as $formato)
+                <a href="{{ $formato['url'] }}"
+                   class="group flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3 transition hover:border-primary-500 hover:shadow-sm dark:border-white/10 dark:bg-white/5 dark:hover:border-primary-500">
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary-50 text-xs font-bold text-primary-600 dark:bg-primary-500/10 dark:text-primary-400">
+                        {{ $formato['prefix'] }}
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <p class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ $formato['value'] }}</p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">{{ $formato['count'] }} registros</p>
+                    </div>
+                </a>
+            @endforeach
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/resources/views/filament/widgets/quick-access-formatos.blade.php
+++ b/resources/views/filament/widgets/quick-access-formatos.blade.php
@@ -8,7 +8,7 @@
                         {{ $formato['prefix'] }}
                     </div>
                     <div class="min-w-0 flex-1">
-                        <p class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ $formato['value'] }}</p>
+                        <p class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ $formato['label'] }}</p>
                         <p class="text-xs text-gray-500 dark:text-gray-400">{{ $formato['count'] }} registros</p>
                     </div>
                 </a>


### PR DESCRIPTION
## Summary
- **StatsOverview**: 4 metric cards with sparklines — registros del mes (+ delta vs anterior), tickets abiertos, incidencias F09, usuarios activos
- **LatestRegistros**: Table widget with last 5 registros (numero, formato badge, creador, estado, fecha)
- **QuickAccessFormatos**: Collapsible grid of 13 security formats with prefix badge, count, sorted by usage
- All widgets tenant-scoped via empresa_id
- Removed default AccountWidget and FilamentInfoWidget

## Test plan
- [ ] Dashboard loads with 3 widgets for empresa tenant
- [ ] Stats show correct counts scoped to current empresa
- [ ] Sparklines show 7-day trend for registros and tickets
- [ ] Delta shows "+N vs mes anterior" correctly
- [ ] Latest registros table shows last 5 records with correct data
- [ ] Formatos grid shows all 13 formats sorted by usage count
- [ ] Clicking a formato card navigates to filtered registros list
- [ ] Switch empresa tenant — verify data changes accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)