### PR TITLE
feat(SEN-8): graficos de registros y tendencia de tickets

### DIFF
--- a/app/Filament/Widgets/LatestRegistros.php
+++ b/app/Filament/Widgets/LatestRegistros.php
@@ -11,7 +11,7 @@ use Filament\Widgets\TableWidget as BaseWidget;
 
 class LatestRegistros extends BaseWidget
 {
-    protected static ?int $sort = 2;
+    protected static ?int $sort = 4;
 
     protected int|string|array $columnSpan = 'full';
 

--- a/app/Filament/Widgets/QuickAccessFormatos.php
+++ b/app/Filament/Widgets/QuickAccessFormatos.php
@@ -9,7 +9,7 @@ use Filament\Widgets\Widget;
 
 class QuickAccessFormatos extends Widget
 {
-    protected static ?int $sort = 3;
+    protected static ?int $sort = 5;
 
     protected string $view = 'filament.widgets.quick-access-formatos';
 

--- a/app/Filament/Widgets/RegistrosPorTipoChart.php
+++ b/app/Filament/Widgets/RegistrosPorTipoChart.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\TipoFormato;
+use App\Models\Registro;
+use Filament\Facades\Filament;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Carbon;
+
+class RegistrosPorTipoChart extends ChartWidget
+{
+    protected static ?int $sort = 2;
+
+    protected ?string $heading = 'Registros por formato';
+
+    protected ?string $description = 'Ultimos 6 meses';
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $maxHeight = '300px';
+
+    public ?string $filter = '6';
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    protected function getFilters(): ?array
+    {
+        return [
+            '3' => 'Ultimos 3 meses',
+            '6' => 'Ultimos 6 meses',
+            '12' => 'Ultimo ano',
+        ];
+    }
+
+    protected function getData(): array
+    {
+        $empresa = Filament::getTenant();
+        $months = (int) ($this->filter ?? 6);
+
+        $labels = [];
+        $datasets = [];
+
+        // Build month labels
+        for ($i = $months - 1; $i >= 0; $i--) {
+            $date = now()->subMonths($i);
+            $labels[] = $date->translatedFormat('M Y');
+        }
+
+        // Colors per format type
+        $colors = [
+            'F01' => '#6366f1', 'F02' => '#8b5cf6', 'F03' => '#a78bfa',
+            'F04' => '#c084fc', 'F05' => '#3b82f6', 'F06' => '#60a5fa',
+            'F07' => '#22d3ee', 'F08' => '#2dd4bf', 'F09' => '#ef4444',
+            'F10' => '#f59e0b', 'F11' => '#10b981', 'F12' => '#6b7280',
+            'F13' => '#f43f5e',
+        ];
+
+        // Query counts per format per month
+        $query = Registro::query()
+            ->where('empresa_id', $empresa?->id)
+            ->where('created_at', '>=', now()->subMonths($months)->startOfMonth())
+            ->selectRaw('tipo_formato, YEAR(created_at) as yr, MONTH(created_at) as mo, count(*) as total')
+            ->groupBy('tipo_formato', 'yr', 'mo')
+            ->get();
+
+        // Build lookup: [formato][yr-mo] = count
+        $lookup = [];
+        foreach ($query as $row) {
+            $key = sprintf('%d-%02d', $row->yr, $row->mo);
+            $lookup[$row->tipo_formato][$key] = $row->total;
+        }
+
+        // Only include formats that have data
+        foreach (TipoFormato::cases() as $tipo) {
+            if (! isset($lookup[$tipo->value])) {
+                continue;
+            }
+
+            $data = [];
+            for ($i = $months - 1; $i >= 0; $i--) {
+                $date = now()->subMonths($i);
+                $key = $date->format('Y-m');
+                $data[] = $lookup[$tipo->value][$key] ?? 0;
+            }
+
+            $datasets[] = [
+                'label' => $tipo->value . ' - ' . $tipo->prefix(),
+                'data' => $data,
+                'backgroundColor' => $colors[$tipo->value] ?? '#6b7280',
+                'borderRadius' => 4,
+            ];
+        }
+
+        // If no data at all, show empty chart
+        if (empty($datasets)) {
+            $datasets[] = [
+                'label' => 'Sin registros',
+                'data' => array_fill(0, $months, 0),
+                'backgroundColor' => '#374151',
+            ];
+        }
+
+        return [
+            'labels' => $labels,
+            'datasets' => $datasets,
+        ];
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            'scales' => [
+                'x' => ['stacked' => true],
+                'y' => ['stacked' => true, 'beginAtZero' => true],
+            ],
+            'plugins' => [
+                'legend' => ['position' => 'bottom'],
+            ],
+        ];
+    }
+}

--- a/app/Filament/Widgets/TicketsTendenciaChart.php
+++ b/app/Filament/Widgets/TicketsTendenciaChart.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Ticket;
+use Filament\Facades\Filament;
+use Filament\Widgets\ChartWidget;
+
+class TicketsTendenciaChart extends ChartWidget
+{
+    protected static ?int $sort = 3;
+
+    protected ?string $heading = 'Tendencia de tickets';
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $maxHeight = '250px';
+
+    public ?string $filter = '30';
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+
+    protected function getFilters(): ?array
+    {
+        return [
+            '7' => 'Ultima semana',
+            '30' => 'Ultimo mes',
+            '90' => 'Ultimos 3 meses',
+        ];
+    }
+
+    protected function getData(): array
+    {
+        $empresa = Filament::getTenant();
+        $days = (int) ($this->filter ?? 30);
+
+        $labels = [];
+        $creados = [];
+        $resueltos = [];
+
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $date = now()->subDays($i);
+            $labels[] = $days <= 7 ? $date->translatedFormat('D d') : $date->format('d/m');
+
+            $creados[] = Ticket::where('empresa_id', $empresa?->id)
+                ->whereDate('created_at', $date)
+                ->count();
+
+            $resueltos[] = Ticket::where('empresa_id', $empresa?->id)
+                ->whereIn('estado', ['resuelto', 'cerrado'])
+                ->whereDate('fecha_cierre', $date)
+                ->count();
+        }
+
+        return [
+            'labels' => $labels,
+            'datasets' => [
+                [
+                    'label' => 'Creados',
+                    'data' => $creados,
+                    'borderColor' => '#6366f1',
+                    'backgroundColor' => 'rgba(99, 102, 241, 0.1)',
+                    'fill' => true,
+                    'tension' => 0.3,
+                    'pointRadius' => $days <= 7 ? 4 : 2,
+                ],
+                [
+                    'label' => 'Resueltos',
+                    'data' => $resueltos,
+                    'borderColor' => '#10b981',
+                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                    'fill' => true,
+                    'tension' => 0.3,
+                    'pointRadius' => $days <= 7 ? 4 : 2,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- **RegistrosPorTipoChart**: Stacked bar chart showing registros by format type (F01-F13) over configurable time range (3/6/12 months). Only formats with data are shown. Color-coded per format.
- **TicketsTendenciaChart**: Line chart showing tickets created vs resolved over configurable range (7/30/90 days) with area fill.
- Both charts are tenant-scoped and filterable via dropdown selector.

## Test plan
- [ ] Bar chart shows registros grouped by month with correct format colors
- [ ] Filter dropdown changes time range (3/6/12 months)
- [ ] Line chart shows created vs resolved tickets trend
- [ ] Filter dropdown changes range (7/30/90 days)
- [ ] Switch tenant — data changes accordingly
- [ ] Empty empresa shows "Sin registros" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)