### PR TITLE
feat(SEN-7): dashboard agente helpdesk con widgets condicionales

### DIFF
--- a/app/Filament/Widgets/AgentStatsOverview.php
+++ b/app/Filament/Widgets/AgentStatsOverview.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Ticket;
+use App\Models\TicketMensaje;
+use App\Models\User;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class AgentStatsOverview extends BaseWidget
+{
+    protected static ?int $sort = 0;
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'agente_helpdesk']) ?? false;
+    }
+
+    protected function getStats(): array
+    {
+        $userId = auth()->id();
+
+        $base = Ticket::withoutGlobalScopes();
+
+        $misTickets = (clone $base)->where('asignado_a', $userId)
+            ->whereNotIn('estado', ['cerrado', 'resuelto'])->count();
+
+        $sinAsignar = (clone $base)->whereNull('asignado_a')
+            ->whereNotIn('estado', ['cerrado', 'resuelto'])->count();
+
+        $resueltosHoy = (clone $base)->where('asignado_a', $userId)
+            ->where('estado', 'resuelto')
+            ->whereDate('fecha_cierre', today())->count();
+
+        // Tickets by estado for sparkline
+        $estadoCounts = [
+            'nuevo' => (clone $base)->where('estado', 'nuevo')->count(),
+            'en_revision' => (clone $base)->where('estado', 'en_revision')->count(),
+            'esperando' => (clone $base)->where('estado', 'esperando_usuario')->count(),
+            'resuelto' => (clone $base)->where('estado', 'resuelto')
+                ->whereMonth('fecha_cierre', now()->month)->count(),
+        ];
+
+        // Avg response time (hours) for tickets assigned to me this month
+        $avgResponseHours = $this->calcAvgResponseTime($userId);
+
+        return [
+            Stat::make('Mis tickets activos', $misTickets)
+                ->description($resueltosHoy > 0 ? "{$resueltosHoy} resueltos hoy" : 'Asignados a ti')
+                ->descriptionIcon($resueltosHoy > 0 ? 'heroicon-m-check-circle' : 'heroicon-m-user')
+                ->color($misTickets > 5 ? 'warning' : 'primary')
+                ->chart(array_values($estadoCounts)),
+
+            Stat::make('Sin asignar', $sinAsignar)
+                ->description('Tickets sin agente')
+                ->descriptionIcon('heroicon-m-exclamation-circle')
+                ->color($sinAsignar > 0 ? 'danger' : 'success'),
+
+            Stat::make('Tiempo resp. promedio', $avgResponseHours)
+                ->description('Horas (este mes)')
+                ->descriptionIcon('heroicon-m-clock')
+                ->color($this->responseTimeColor($avgResponseHours)),
+
+            Stat::make('Total global abiertos', (clone $base)->whereNotIn('estado', ['cerrado', 'resuelto'])->count())
+                ->description('Todas las empresas')
+                ->descriptionIcon('heroicon-m-globe-alt')
+                ->color('info'),
+        ];
+    }
+
+    private function calcAvgResponseTime(int $userId): string
+    {
+        $tickets = Ticket::withoutGlobalScopes()
+            ->where('asignado_a', $userId)
+            ->whereMonth('created_at', now()->month)
+            ->whereYear('created_at', now()->year)
+            ->with(['mensajes' => fn ($q) => $q->where('autor_id', $userId)->orderBy('created_at')->limit(1)])
+            ->get();
+
+        $totalHours = 0;
+        $count = 0;
+
+        foreach ($tickets as $ticket) {
+            $firstResponse = $ticket->mensajes->first();
+            if ($firstResponse) {
+                $totalHours += $ticket->created_at->diffInMinutes($firstResponse->created_at) / 60;
+                $count++;
+            }
+        }
+
+        if ($count === 0) {
+            return '—';
+        }
+
+        $avg = round($totalHours / $count, 1);
+
+        return $avg < 1 ? round($avg * 60) . 'min' : $avg . 'h';
+    }
+
+    private function responseTimeColor(string $avgResponseHours): string
+    {
+        if ($avgResponseHours === '—') {
+            return 'gray';
+        }
+
+        $hours = (float) $avgResponseHours;
+
+        return match (true) {
+            $hours <= 2 => 'success',
+            $hours <= 8 => 'warning',
+            default => 'danger',
+        };
+    }
+}

--- a/app/Filament/Widgets/LatestTicketUpdates.php
+++ b/app/Filament/Widgets/LatestTicketUpdates.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Ticket;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class LatestTicketUpdates extends BaseWidget
+{
+    protected static ?int $sort = 4;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $heading = 'Ultimas actualizaciones de tickets';
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'agente_helpdesk']) ?? false;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Ticket::withoutGlobalScopes()
+                    ->with(['empresa', 'creador', 'agente'])
+                    ->latest('fecha_ultima_actividad')
+                    ->limit(5)
+            )
+            ->columns([
+                TextColumn::make('numero_ticket')
+                    ->label('Ticket')
+                    ->searchable(),
+                TextColumn::make('asunto')
+                    ->label('Asunto')
+                    ->limit(40),
+                TextColumn::make('empresa.razon_social')
+                    ->label('Empresa')
+                    ->limit(25),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'nuevo' => 'info',
+                        'en_revision' => 'warning',
+                        'esperando_usuario' => 'gray',
+                        'resuelto' => 'success',
+                        'cerrado' => 'gray',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'nuevo' => 'Nuevo',
+                        'en_revision' => 'En revision',
+                        'esperando_usuario' => 'Esperando',
+                        'resuelto' => 'Resuelto',
+                        'cerrado' => 'Cerrado',
+                        default => $state,
+                    }),
+                TextColumn::make('agente.name')
+                    ->label('Agente')
+                    ->placeholder('Sin asignar'),
+                TextColumn::make('fecha_ultima_actividad')
+                    ->label('Ultima actividad')
+                    ->since(),
+            ])
+            ->paginated(false);
+    }
+}


### PR DESCRIPTION
## Summary
- **AgentStatsOverview**: 4 cards (mis tickets activos, sin asignar, tiempo resp. promedio, total global abiertos) — solo visible para super_admin y agente_helpdesk
- **LatestTicketUpdates**: tabla con ultimas 5 actualizaciones de tickets de todas las empresas — solo para agentes
- Widgets usan `canView()` para visibilidad condicional por rol
- Sorted antes de los widgets de empresa (sort=0)

## Test plan
- [ ] Login como super_admin — ver 2 filas de stats (agente + empresa)
- [ ] Login como admin_empresa — ver solo stats de empresa (no agent widgets)
- [ ] Tiempo resp. promedio muestra minutos o horas segun valor
- [ ] Tabla muestra tickets de todas las empresas con estado badge
- [ ] "Sin asignar" refleja tickets sin agente globalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)