### PR TITLE
refactor: mejorar formulario de registros con descripciones y mejor layout

### DIFF
--- a/app/Enums/TipoFormato.php
+++ b/app/Enums/TipoFormato.php
@@ -75,6 +75,25 @@ enum TipoFormato: string
         };
     }
 
+    public function description(): string
+    {
+        return match ($this) {
+            self::F01 => 'Documenta las auditorias internas y externas realizadas sobre los sistemas de informacion, registrando responsables, resultados y acciones correctivas.',
+            self::F02 => 'Inventario de los bancos de datos personales inscritos ante la Autoridad, incluyendo su categoria, areas con acceso y descripcion.',
+            self::F03 => 'Registro de prestadores de servicios (terceros) que tienen acceso a datos personales, con detalle de contrato y datos facilitados.',
+            self::F04 => 'Inventario de datos sensibles que maneja la organizacion, su ubicacion y las areas autorizadas para acceder a ellos.',
+            self::F05 => 'Control del personal autorizado para acceder a los bancos de datos, con fecha de asignacion y banco correspondiente.',
+            self::F06 => 'Registro de accesos de soporte tecnico no autorizado o sospechoso, documentando quien accedio, cuando y desde donde.',
+            self::F07 => 'Inventario de soportes fisicos y digitales (discos, USB, servidores, expedientes) que contienen datos personales.',
+            self::F08 => 'Control de ingresos y salidas de soportes fisicos/digitales, con trazabilidad de origen, destino y autorizacion.',
+            self::F09 => 'Notificacion y documentacion de incidencias de seguridad (accesos no autorizados, perdida de datos, malware, fallos de sistema).',
+            self::F10 => 'Documentacion de la resolucion de incidencias previamente reportadas (F09), incluyendo medidas adoptadas y acciones preventivas.',
+            self::F11 => 'Registro de procesos de recuperacion de datos tras una incidencia, con autorizacion, responsable y proceso ejecutado.',
+            self::F12 => 'Control de las copias de seguridad (backups) realizadas, su contenido, periodicidad y fecha de ejecucion.',
+            self::F13 => 'Registro de destruccion segura de activos de informacion, documentando metodo, responsable y autorizacion.',
+        };
+    }
+
     public static function options(): array
     {
         return collect(self::cases())

--- a/app/Filament/Resources/Registros/Schemas/RegistroForm.php
+++ b/app/Filament/Resources/Registros/Schemas/RegistroForm.php
@@ -4,38 +4,66 @@ namespace App\Filament\Resources\Registros\Schemas;
 
 use App\Enums\TipoFormato;
 use App\Services\FormatoFieldsService;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Illuminate\Support\HtmlString;
 
 class RegistroForm
 {
     public static function configure(Schema $schema): Schema
     {
         return $schema
+            ->columns(1)
             ->components([
                 Section::make('Tipo de registro')
+                    ->icon('heroicon-o-document-text')
+                    ->description('Selecciona el formato de seguridad que deseas registrar.')
                     ->schema([
                         Select::make('tipo_formato')
                             ->label('Formato de seguridad')
                             ->options(TipoFormato::options())
                             ->required()
                             ->live()
+                            ->searchable()
                             ->disabled(fn (string $operation): bool => $operation === 'edit')
-                            ->helperText(fn (Get $get): ?string => self::getPscText($get('tipo_formato'))),
+                            ->columnSpanFull(),
+                        Placeholder::make('formato_info')
+                            ->label('')
+                            ->content(function (Get $get): ?HtmlString {
+                                $tipo = TipoFormato::tryFrom($get('tipo_formato') ?? '');
+                                if (! $tipo) {
+                                    return null;
+                                }
+
+                                return new HtmlString(
+                                    '<div class="rounded-lg border border-primary-200 bg-primary-50 p-3 dark:border-primary-800 dark:bg-primary-950/50">'
+                                    . '<p class="text-sm font-semibold text-primary-700 dark:text-primary-400">' . e($tipo->label()) . '</p>'
+                                    . '<p class="mt-1 text-xs text-primary-600 dark:text-primary-500">' . e($tipo->description()) . '</p>'
+                                    . '<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Politica: ' . e($tipo->psc()) . '</p>'
+                                    . '</div>'
+                                );
+                            })
+                            ->visible(fn (Get $get): bool => filled($get('tipo_formato')))
+                            ->columnSpanFull(),
                         TextInput::make('numero_registro')
                             ->label('N° Registro')
                             ->disabled()
                             ->dehydrated()
-                            ->helperText('Se genera automáticamente al guardar.'),
-                    ])->columns(2),
+                            ->helperText('Se genera automaticamente al guardar.')
+                            ->columnSpanFull(),
+                    ])->columns(1),
 
-                Section::make('Datos del formato')
+                Section::make(fn (Get $get): string => self::getSectionTitle($get('tipo_formato')))
+                    ->icon('heroicon-o-clipboard-document-list')
+                    ->description(fn (Get $get): ?string => self::getSectionDescription($get('tipo_formato')))
                     ->schema(fn (Get $get): array => self::getDynamicFields($get('tipo_formato')))
                     ->visible(fn (Get $get): bool => filled($get('tipo_formato')))
-                    ->columns(2),
+                    ->columns(2)
+                    ->collapsible(),
             ]);
     }
 
@@ -54,14 +82,17 @@ class RegistroForm
         return FormatoFieldsService::getFields($tipoEnum);
     }
 
-    private static function getPscText(?string $tipo): ?string
+    private static function getSectionTitle(?string $tipo): string
     {
-        if (! $tipo) {
-            return null;
-        }
+        $tipoEnum = TipoFormato::tryFrom($tipo ?? '');
 
-        $tipoEnum = TipoFormato::tryFrom($tipo);
+        return $tipoEnum ? 'Datos — ' . $tipoEnum->label() : 'Datos del formato';
+    }
 
-        return $tipoEnum ? 'Política: ' . $tipoEnum->psc() : null;
+    private static function getSectionDescription(?string $tipo): ?string
+    {
+        $tipoEnum = TipoFormato::tryFrom($tipo ?? '');
+
+        return $tipoEnum ? 'Completa los campos requeridos para el formato ' . $tipoEnum->value . '.' : null;
     }
 }

--- a/app/Services/FormatoFieldsService.php
+++ b/app/Services/FormatoFieldsService.php
@@ -37,53 +37,53 @@ class FormatoFieldsService
     private static function f01(): array
     {
         return [
-            Select::make('datos.tipo')->label('Tipo de auditoría')
+            Select::make('datos.tipo')->label('Tipo de auditoria')
                 ->options(['interna' => 'Interna', 'externa' => 'Externa'])->required(),
             DatePicker::make('datos.fecha')->label('Fecha')->required(),
             TextInput::make('datos.responsable')->label('Responsable / Proveedor')->required(),
             Select::make('datos.resultado')->label('Resultado')
                 ->options(['conforme' => 'Conforme', 'no_conforme' => 'No conforme', 'con_observaciones' => 'Con observaciones'])->required(),
             Select::make('datos.acciones_correctivas')->label('Acciones correctivas')
-                ->options(['si' => 'Sí', 'no' => 'No'])->required(),
-            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3),
+                ->options(['si' => 'Si', 'no' => 'No'])->required(),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3)->columnSpanFull(),
         ];
     }
 
     private static function f02(): array
     {
         return [
-            TextInput::make('datos.nombre_bd')->label('Nombre del banco de datos')->required(),
-            TextInput::make('datos.codigo_registro')->label('Código / Registro'),
-            Textarea::make('datos.descripcion')->label('Descripción')->rows(3)->required(),
-            TagsInput::make('datos.areas_acceso')->label('Unidades / Áreas con acceso'),
-            Select::make('datos.categoria')->label('Categoría / Nivel')
-                ->options(['publica' => 'Pública', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+            TextInput::make('datos.nombre_bd')->label('Nombre del banco de datos')->required()->columnSpanFull(),
+            TextInput::make('datos.codigo_registro')->label('Codigo / Registro'),
+            Select::make('datos.categoria')->label('Categoria / Nivel')
+                ->options(['publica' => 'Publica', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+            Textarea::make('datos.descripcion')->label('Descripcion')->rows(3)->required()->columnSpanFull(),
+            TagsInput::make('datos.areas_acceso')->label('Unidades / Areas con acceso')->columnSpanFull(),
         ];
     }
 
     private static function f03(): array
     {
         return [
-            TextInput::make('datos.prestador')->label('Prestador del servicio')->required(),
-            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2)->required(),
-            TagsInput::make('datos.datos_facilitados')->label('Datos facilitados (tipo)'),
+            TextInput::make('datos.prestador')->label('Prestador del servicio')->required()->columnSpanFull(),
+            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2)->required()->columnSpanFull(),
+            TagsInput::make('datos.datos_facilitados')->label('Datos facilitados (tipo)')->columnSpanFull(),
             DatePicker::make('datos.fecha_contrato')->label('Fecha de contrato'),
             DatePicker::make('datos.vigencia')->label('Vigencia'),
-            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3)->columnSpanFull(),
         ];
     }
 
     private static function f04(): array
     {
         return [
-            TextInput::make('datos.nombre')->label('Nombre')->required(),
-            Textarea::make('datos.descripcion')->label('Descripción')->rows(3)->required(),
-            Select::make('datos.ubicacion_tipo')->label('Ubicación tipo')
-                ->options(['fisica' => 'Física', 'digital' => 'Digital', 'mixta' => 'Mixta'])->required(),
-            TextInput::make('datos.ubicacion_detalle')->label('Ubicación detalle'),
-            TagsInput::make('datos.areas_acceso')->label('Usuarios / Áreas con acceso'),
-            Select::make('datos.categoria')->label('Categoría / Nivel')
-                ->options(['publica' => 'Pública', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+            TextInput::make('datos.nombre')->label('Nombre')->required()->columnSpanFull(),
+            Textarea::make('datos.descripcion')->label('Descripcion')->rows(3)->required()->columnSpanFull(),
+            Select::make('datos.ubicacion_tipo')->label('Ubicacion tipo')
+                ->options(['fisica' => 'Fisica', 'digital' => 'Digital', 'mixta' => 'Mixta'])->required(),
+            TextInput::make('datos.ubicacion_detalle')->label('Ubicacion detalle'),
+            Select::make('datos.categoria')->label('Categoria / Nivel')
+                ->options(['publica' => 'Publica', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+            TagsInput::make('datos.areas_acceso')->label('Usuarios / Areas con acceso')->columnSpanFull(),
         ];
     }
 
@@ -91,16 +91,16 @@ class FormatoFieldsService
     {
         return [
             TextInput::make('datos.usuario')->label('Usuario')->required(),
-            DateTimePicker::make('datos.fecha_asignacion')->label('Fecha y hora de asignación')->required(),
             TextInput::make('datos.banco_datos')->label('Banco de datos')->required(),
+            DateTimePicker::make('datos.fecha_asignacion')->label('Fecha y hora de asignacion')->required()->columnSpanFull(),
         ];
     }
 
     private static function f06(): array
     {
         return [
-            Textarea::make('datos.descripcion_soporte')->label('Descripción del soporte')->rows(3)->required(),
-            TextInput::make('datos.persona_accede')->label('Persona que accede')->required(),
+            TextInput::make('datos.persona_accede')->label('Persona que accede')->required()->columnSpanFull(),
+            Textarea::make('datos.descripcion_soporte')->label('Descripcion del soporte')->rows(3)->required()->columnSpanFull(),
             DatePicker::make('datos.fecha_acceso')->label('Fecha de acceso')->required(),
             TimePicker::make('datos.hora_acceso')->label('Hora de acceso')->required(),
         ];
@@ -113,10 +113,10 @@ class FormatoFieldsService
                 ->options([
                     'hdd_interno' => 'HDD interno', 'hdd_externo' => 'HDD externo',
                     'usb' => 'USB', 'servidor' => 'Servidor', 'nube' => 'Nube',
-                    'dvd' => 'DVD', 'expediente_fisico' => 'Expediente físico', 'otro' => 'Otro',
+                    'dvd' => 'DVD', 'expediente_fisico' => 'Expediente fisico', 'otro' => 'Otro',
                 ])->required(),
-            TextInput::make('datos.ubicacion')->label('Ubicación')->required(),
-            Textarea::make('datos.contenido')->label('Contenido')->rows(3)->required(),
+            TextInput::make('datos.ubicacion')->label('Ubicacion')->required(),
+            Textarea::make('datos.contenido')->label('Contenido')->rows(3)->required()->columnSpanFull(),
             DatePicker::make('datos.fecha_inventariado')->label('Fecha de inventariado')->required(),
         ];
     }
@@ -124,22 +124,22 @@ class FormatoFieldsService
     private static function f08(): array
     {
         return [
-            TextInput::make('datos.codigo_soporte')->label('Código soporte')->required(),
+            TextInput::make('datos.codigo_soporte')->label('Codigo soporte')->required(),
             Select::make('datos.tipo_movimiento')->label('Tipo de movimiento')
-                ->options(['ingreso' => 'Ingreso', 'salida' => 'Salida', 'devolucion' => 'Devolución'])->required(),
+                ->options(['ingreso' => 'Ingreso', 'salida' => 'Salida', 'devolucion' => 'Devolucion'])->required(),
             DateTimePicker::make('datos.fecha_hora')->label('Fecha / Hora')->required(),
             TextInput::make('datos.id_serie')->label('ID / Serie'),
-            Select::make('datos.estado_soporte')->label('Estado')
+            Select::make('datos.estado_soporte')->label('Estado del soporte')
                 ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])->required(),
             TextInput::make('datos.banco_datos')->label('Banco de datos'),
-            Textarea::make('datos.contenido')->label('Contenido')->rows(2),
+            Textarea::make('datos.contenido')->label('Contenido')->rows(2)->columnSpanFull(),
             TextInput::make('datos.origen_remitente')->label('Origen / Remitente'),
             TextInput::make('datos.destinatario')->label('Destinatario'),
-            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2),
+            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2)->columnSpanFull(),
             TextInput::make('datos.medio_transporte')->label('Medio de transporte'),
-            Textarea::make('datos.precauciones')->label('Precauciones')->rows(2),
             TextInput::make('datos.autoriza')->label('Autoriza'),
             TextInput::make('datos.recibe')->label('Recibe'),
+            Textarea::make('datos.precauciones')->label('Precauciones')->rows(2)->columnSpanFull(),
         ];
     }
 
@@ -149,19 +149,19 @@ class FormatoFieldsService
             DateTimePicker::make('datos.fecha_evento')->label('Fecha / Hora del evento')->required(),
             Select::make('datos.tipo_incidencia')->label('Tipo de incidencia')
                 ->options([
-                    'acceso_no_autorizado' => 'Acceso no autorizado', 'perdida_datos' => 'Pérdida de datos',
-                    'fuga_informacion' => 'Fuga de información', 'malware' => 'Malware/Virus',
+                    'acceso_no_autorizado' => 'Acceso no autorizado', 'perdida_datos' => 'Perdida de datos',
+                    'fuga_informacion' => 'Fuga de informacion', 'malware' => 'Malware/Virus',
                     'fallo_sistema' => 'Fallo de sistema', 'otro' => 'Otro',
                 ])->required(),
             TextInput::make('datos.sistema_equipo')->label('Sistema / Equipo / Lugar'),
             TextInput::make('datos.banco_datos')->label('Banco de datos'),
-            RichEditor::make('datos.descripcion')->label('Descripción')->required(),
-            Textarea::make('datos.medidas_inmediatas')->label('Medidas inmediatas')->rows(3),
+            RichEditor::make('datos.descripcion')->label('Descripcion')->required()->columnSpanFull(),
+            Textarea::make('datos.medidas_inmediatas')->label('Medidas inmediatas')->rows(3)->columnSpanFull(),
             TagsInput::make('datos.personas_notificadas')->label('Personas notificadas'),
-            Textarea::make('datos.impacto_potencial')->label('Impacto potencial')->rows(2),
-            TextInput::make('datos.comunica_nombre')->label('Comunica (nombre y cargo)'),
             Select::make('datos.severidad')->label('Severidad')
                 ->options(['alta' => 'Alta', 'media' => 'Media', 'baja' => 'Baja'])->required(),
+            Textarea::make('datos.impacto_potencial')->label('Impacto potencial')->rows(2)->columnSpanFull(),
+            TextInput::make('datos.comunica_nombre')->label('Comunica (nombre y cargo)')->columnSpanFull(),
         ];
     }
 
@@ -170,14 +170,14 @@ class FormatoFieldsService
         return [
             TextInput::make('datos.incidencia_ref')->label('N° Incidencia (referencia F09)')->required(),
             DateTimePicker::make('datos.fecha_cierre')->label('Fecha / Hora de cierre')->required(),
-            Select::make('datos.clasificacion')->label('Clasificación')
+            Select::make('datos.clasificacion')->label('Clasificacion')
                 ->options(['baja' => 'Baja', 'media' => 'Media', 'alta' => 'Alta'])->required(),
-            Toggle::make('datos.requirio_recuperacion')->label('Requirió recuperación'),
-            Textarea::make('datos.medidas_adoptadas')->label('Medidas adoptadas')->rows(3)->required(),
-            Textarea::make('datos.resultado_verificacion')->label('Resultado / Verificación')->rows(3),
-            TextInput::make('datos.ejecuto')->label('Ejecutó (nombre y cargo)'),
+            Toggle::make('datos.requirio_recuperacion')->label('Requirio recuperacion'),
+            Textarea::make('datos.medidas_adoptadas')->label('Medidas adoptadas')->rows(3)->required()->columnSpanFull(),
+            Textarea::make('datos.resultado_verificacion')->label('Resultado / Verificacion')->rows(3)->columnSpanFull(),
+            TextInput::make('datos.ejecuto')->label('Ejecuto (nombre y cargo)'),
             TextInput::make('datos.firma_responsable')->label('Firma responsable de seguridad'),
-            Textarea::make('datos.acciones_preventivas')->label('Acciones preventivas')->rows(3),
+            Textarea::make('datos.acciones_preventivas')->label('Acciones preventivas')->rows(3)->columnSpanFull(),
         ];
     }
 
@@ -185,20 +185,20 @@ class FormatoFieldsService
     {
         return [
             TextInput::make('datos.incidencia_relacionada')->label('Incidencia relacionada'),
-            DateTimePicker::make('datos.fecha_realizacion')->label('Fecha / Hora de realización')->required(),
-            Toggle::make('datos.autorizacion_escrita')->label('Autorización por escrito'),
+            DateTimePicker::make('datos.fecha_realizacion')->label('Fecha / Hora de realizacion')->required(),
+            Toggle::make('datos.autorizacion_escrita')->label('Autorizacion por escrito'),
             TextInput::make('datos.responsable_bd')->label('Responsable BD que autoriza'),
-            Textarea::make('datos.proceso_realizado')->label('Proceso realizado')->rows(3)->required(),
-            TextInput::make('datos.persona_ejecutora')->label('Persona ejecutora'),
-            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3),
+            Textarea::make('datos.proceso_realizado')->label('Proceso realizado')->rows(3)->required()->columnSpanFull(),
+            TextInput::make('datos.persona_ejecutora')->label('Persona ejecutora')->columnSpanFull(),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3)->columnSpanFull(),
         ];
     }
 
     private static function f12(): array
     {
         return [
-            TextInput::make('datos.nombre_backup')->label('Nombre del backup')->required(),
-            Textarea::make('datos.descripcion_contenido')->label('Descripción del contenido')->rows(3)->required(),
+            TextInput::make('datos.nombre_backup')->label('Nombre del backup')->required()->columnSpanFull(),
+            Textarea::make('datos.descripcion_contenido')->label('Descripcion del contenido')->rows(3)->required()->columnSpanFull(),
             DatePicker::make('datos.fecha_copia')->label('Fecha de copia')->required(),
             Select::make('datos.periodicidad')->label('Periodicidad')
                 ->options([
@@ -211,17 +211,17 @@ class FormatoFieldsService
     private static function f13(): array
     {
         return [
-            DatePicker::make('datos.fecha_destruccion')->label('Fecha de destrucción')->required(),
-            Textarea::make('datos.descripcion_activo')->label('Descripción del activo')->rows(3)->required(),
-            Select::make('datos.metodo')->label('Método de destrucción')
+            Textarea::make('datos.descripcion_activo')->label('Descripcion del activo')->rows(3)->required()->columnSpanFull(),
+            DatePicker::make('datos.fecha_destruccion')->label('Fecha de destruccion')->required(),
+            Select::make('datos.metodo')->label('Metodo de destruccion')
                 ->options([
-                    'borrado_seguro' => 'Borrado seguro', 'destruccion_fisica' => 'Destrucción física',
-                    'desmagnetizacion' => 'Desmagnetización', 'incineracion' => 'Incineración',
-                    'trituracion' => 'Trituración', 'proveedor_certificado' => 'Proveedor certificado',
+                    'borrado_seguro' => 'Borrado seguro', 'destruccion_fisica' => 'Destruccion fisica',
+                    'desmagnetizacion' => 'Desmagnetizacion', 'incineracion' => 'Incineracion',
+                    'trituracion' => 'Trituracion', 'proveedor_certificado' => 'Proveedor certificado',
                 ])->required(),
             TextInput::make('datos.responsable')->label('Responsable')->required(),
             TextInput::make('datos.autoriza')->label('Autoriza')->required(),
-            DatePicker::make('datos.proxima_revision')->label('Próxima revisión'),
+            DatePicker::make('datos.proxima_revision')->label('Proxima revision'),
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Add `TipoFormato::description()` with explanatory text for each of the 13 security formats
- Redesign form layout: single-column with sections, icons, info box with format description + PSC policy
- Better field distribution: long fields (textareas, rich editors) use full width, short fields in 2 columns
- Collapsible data section with format name in title
- Searchable format selector

## Test plan
- [ ] Create new registro — select each format, verify description appears
- [ ] Edit existing registro — verify layout is clean and readable
- [ ] Verify all 13 formats render correctly with proper field distribution
- [ ] Check mobile responsiveness (single column on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)