### PR TITLE
feat(SEN-11): preferencias de notificacion por usuario

### DIFF
--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Pages\Auth;
+
+use Filament\Auth\Pages\EditProfile as BaseEditProfile;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class EditProfile extends BaseEditProfile
+{
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Datos personales')
+                    ->icon('heroicon-o-user')
+                    ->schema([
+                        $this->getNameFormComponent(),
+                        $this->getEmailFormComponent(),
+                    ]),
+                Section::make('Cambiar contrasena')
+                    ->icon('heroicon-o-lock-closed')
+                    ->schema([
+                        $this->getPasswordFormComponent(),
+                        $this->getPasswordConfirmationFormComponent(),
+                        $this->getCurrentPasswordFormComponent(),
+                    ])
+                    ->collapsible()
+                    ->collapsed(),
+                Section::make('Preferencias de notificacion')
+                    ->icon('heroicon-o-bell')
+                    ->description('Elige que notificaciones quieres recibir por email. Las notificaciones de cuenta (bienvenida, contrasena) no se pueden desactivar.')
+                    ->schema([
+                        Toggle::make('notif_tickets')
+                            ->label('Notificaciones de tickets')
+                            ->helperText('Recibir emails cuando te asignan un ticket, responden o reabren.'),
+                        Toggle::make('notif_incidencias')
+                            ->label('Notificaciones de incidencias')
+                            ->helperText('Recibir emails cuando se registra una nueva incidencia de seguridad (F09).'),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Pages/PanelAgente.php
+++ b/app/Filament/Pages/PanelAgente.php
@@ -300,7 +300,7 @@ class PanelAgente extends Page implements HasForms
             'created_at' => now(),
         ]);
 
-        if ($ticket->asignado_a && $ticket->agente) {
+        if ($ticket->asignado_a && $ticket->agente && $ticket->agente->notif_tickets) {
             $ticketUrl = url("admin/{$ticket->empresa?->ruc}/tickets/{$ticket->id}");
 
             dispatch(SendEmailJob::fromTemplate(

--- a/app/Filament/Resources/Tickets/Pages/ViewTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/ViewTicket.php
@@ -263,7 +263,7 @@ class ViewTicket extends ViewRecord
 
                     if ($this->record->asignado_a) {
                         $agente = $this->record->agente;
-                        if ($agente) {
+                        if ($agente && $agente->notif_tickets) {
                             $ticketUrl = url("admin/{$this->record->empresa?->ruc}/tickets/{$this->record->id}");
 
                             dispatch(SendEmailJob::fromTemplate(

--- a/app/Observers/RegistroObserver.php
+++ b/app/Observers/RegistroObserver.php
@@ -26,6 +26,7 @@ class RegistroObserver
         $admins = User::where('empresa_id', $registro->empresa_id)
             ->role('admin_empresa')
             ->where('estado', 'activo')
+            ->where('notif_incidencias', true)
             ->get();
 
         if ($admins->isEmpty()) {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -44,7 +44,7 @@ class AdminPanelProvider extends PanelProvider
 
                 return null;
             })
-            ->profile()
+            ->profile(\App\Filament\Pages\Auth\EditProfile::class)
             ->tenant(Empresa::class, slugAttribute: 'ruc')
             ->tenantRegistration(false)
             ->colors([


### PR DESCRIPTION
## Summary
- Custom profile page with notification preference toggles (notif_tickets, notif_incidencias)
- Profile organized in 3 sections: datos personales, contrasena (collapsible), preferencias
- Email dispatch now respects preferences: RegistroObserver filters by notif_incidencias, ticket reopen checks notif_tickets
- Account emails (welcome, password reset) remain always active

## Test plan
- [ ] Go to profile page — verify 3 sections with toggles visible
- [ ] Disable notif_incidencias, create F09 — verify NO email sent
- [ ] Enable notif_incidencias, create F09 — verify email sent
- [ ] Disable notif_tickets, reopen ticket — verify NO email to agent
- [ ] Enable notif_tickets, reopen ticket — verify email sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)