### PR TITLE
feat(SEN-69): EquipoResource CRUD con ficha tecnica

### DIFF
--- a/app/Filament/Resources/Equipos/EquipoResource.php
+++ b/app/Filament/Resources/Equipos/EquipoResource.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Filament\Resources\Equipos;
+
+use App\Filament\Resources\Equipos\Pages\CreateEquipo;
+use App\Filament\Resources\Equipos\Pages\EditEquipo;
+use App\Filament\Resources\Equipos\Pages\ListEquipos;
+use App\Filament\Resources\Equipos\Schemas\EquipoForm;
+use App\Filament\Resources\Equipos\Tables\EquiposTable;
+use App\Models\Equipo;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class EquipoResource extends Resource
+{
+    protected static ?string $model = Equipo::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedComputerDesktop;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Activos';
+
+    protected static ?string $modelLabel = 'Equipo';
+
+    protected static ?string $pluralModelLabel = 'Equipos';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return EquipoForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return EquiposTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListEquipos::route('/'),
+            'create' => CreateEquipo::route('/create'),
+            'edit' => EditEquipo::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getRecordRouteBindingEloquentQuery(): Builder
+    {
+        return parent::getRecordRouteBindingEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/Equipos/Pages/CreateEquipo.php
+++ b/app/Filament/Resources/Equipos/Pages/CreateEquipo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Equipos\Pages;
+
+use App\Filament\Resources\Equipos\EquipoResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateEquipo extends CreateRecord
+{
+    protected static string $resource = EquipoResource::class;
+}

--- a/app/Filament/Resources/Equipos/Pages/EditEquipo.php
+++ b/app/Filament/Resources/Equipos/Pages/EditEquipo.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\Equipos\Pages;
+
+use App\Filament\Resources\Equipos\EquipoResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditEquipo extends EditRecord
+{
+    protected static string $resource = EquipoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make()
+                ->label('Desactivar'),
+            RestoreAction::make(),
+            ForceDeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Equipos/Pages/ListEquipos.php
+++ b/app/Filament/Resources/Equipos/Pages/ListEquipos.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Equipos\Pages;
+
+use App\Filament\Resources\Equipos\EquipoResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListEquipos extends ListRecords
+{
+    protected static string $resource = EquipoResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
+++ b/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Filament\Resources\Equipos\Schemas;
+
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+class EquipoForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(1)
+            ->components([
+                Section::make('Identificacion del equipo')
+                    ->icon('heroicon-o-computer-desktop')
+                    ->description('Datos basicos del activo. El codigo interno es el identificador de tu empresa.')
+                    ->columns(2)
+                    ->schema([
+                        Select::make('tipo')
+                            ->label('Tipo de equipo')
+                            ->options([
+                                'pc_escritorio' => 'PC de escritorio',
+                                'laptop' => 'Laptop',
+                                'impresora' => 'Impresora',
+                                'servidor' => 'Servidor',
+                                'usb' => 'Dispositivo USB',
+                                'otro' => 'Otro',
+                            ])
+                            ->required()
+                            ->live()
+                            ->columnSpanFull(),
+                        TextInput::make('codigo_interno')
+                            ->label('Codigo interno')
+                            ->placeholder('EQ-001')
+                            ->helperText('Codigo de inventario de tu empresa'),
+                        TextInput::make('numero_serie')
+                            ->label('Numero de serie')
+                            ->unique(ignoreRecord: true),
+                        TextInput::make('marca')
+                            ->label('Marca')
+                            ->placeholder('Lenovo, HP, Dell...'),
+                        TextInput::make('modelo')
+                            ->label('Modelo')
+                            ->placeholder('ThinkPad T14, ProBook 450...'),
+                    ]),
+
+                Section::make('Especificaciones tecnicas')
+                    ->icon('heroicon-o-cpu-chip')
+                    ->description('Detalles del hardware. Solo aplica para PCs, laptops y servidores.')
+                    ->columns(2)
+                    ->visible(fn (Get $get): bool => in_array($get('tipo'), ['pc_escritorio', 'laptop', 'servidor']))
+                    ->schema([
+                        TextInput::make('sistema_operativo')
+                            ->label('Sistema operativo')
+                            ->placeholder('Windows 11 Pro, Ubuntu 22.04...'),
+                        TextInput::make('procesador')
+                            ->label('Procesador')
+                            ->placeholder('Intel i7-1365U, AMD Ryzen 5...'),
+                        TextInput::make('ram_gb')
+                            ->label('RAM (GB)')
+                            ->numeric()
+                            ->suffix('GB'),
+                        TextInput::make('disco_gb')
+                            ->label('Disco (GB)')
+                            ->numeric()
+                            ->suffix('GB'),
+                    ]),
+
+                Section::make('Ubicacion y clasificacion')
+                    ->icon('heroicon-o-map-pin')
+                    ->description('Donde esta el equipo y que tan sensible es la informacion que maneja.')
+                    ->columns(3)
+                    ->schema([
+                        TextInput::make('ubicacion')
+                            ->label('Ubicacion')
+                            ->placeholder('Oficina principal - Piso 2')
+                            ->columnSpanFull(),
+                        Select::make('estado')
+                            ->label('Estado')
+                            ->options([
+                                'activo' => 'Activo',
+                                'mantenimiento' => 'En mantenimiento',
+                                'obsoleto' => 'Obsoleto',
+                                'dado_de_baja' => 'Dado de baja',
+                            ])
+                            ->default('activo')
+                            ->required(),
+                        Select::make('nivel_sensibilidad')
+                            ->label('Nivel de sensibilidad')
+                            ->options([
+                                'publico' => 'Publico',
+                                'interno' => 'Interno',
+                                'confidencial' => 'Confidencial',
+                                'sensible' => 'Sensible',
+                            ])
+                            ->default('interno')
+                            ->required()
+                            ->helperText('Segun la clasificacion de datos que maneja'),
+                        DatePicker::make('fecha_adquisicion')
+                            ->label('Fecha de adquisicion'),
+                        DatePicker::make('fecha_garantia')
+                            ->label('Vencimiento de garantia'),
+                    ]),
+
+                Section::make('Observaciones')
+                    ->schema([
+                        Textarea::make('observaciones')
+                            ->label('Notas adicionales')
+                            ->rows(3)
+                            ->placeholder('Software instalado, accesorios incluidos, etc.')
+                            ->columnSpanFull(),
+                    ])
+                    ->collapsible()
+                    ->collapsed(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Equipos/Tables/EquiposTable.php
+++ b/app/Filament/Resources/Equipos/Tables/EquiposTable.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Filament\Resources\Equipos\Tables;
+
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\RestoreBulkAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TrashedFilter;
+use Filament\Tables\Table;
+
+class EquiposTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('codigo_interno')
+                    ->label('Codigo')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('tipo')
+                    ->label('Tipo')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'pc_escritorio' => 'info',
+                        'laptop' => 'primary',
+                        'impresora' => 'gray',
+                        'servidor' => 'warning',
+                        'usb' => 'danger',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'pc_escritorio' => 'PC Escritorio',
+                        'laptop' => 'Laptop',
+                        'impresora' => 'Impresora',
+                        'servidor' => 'Servidor',
+                        'usb' => 'USB',
+                        'otro' => 'Otro',
+                        default => $state,
+                    }),
+                TextColumn::make('marca')
+                    ->label('Marca / Modelo')
+                    ->formatStateUsing(fn ($record): string => trim(($record->marca ?? '') . ' ' . ($record->modelo ?? '')) ?: '—')
+                    ->searchable(['marca', 'modelo']),
+                TextColumn::make('numero_serie')
+                    ->label('N° Serie')
+                    ->searchable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('asignacionVigente.user.name')
+                    ->label('Asignado a')
+                    ->placeholder('Sin asignar')
+                    ->badge()
+                    ->color(fn ($state): string => $state ? 'success' : 'gray'),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'activo' => 'success',
+                        'mantenimiento' => 'warning',
+                        'obsoleto' => 'gray',
+                        'dado_de_baja' => 'danger',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'activo' => 'Activo',
+                        'mantenimiento' => 'Mantenimiento',
+                        'obsoleto' => 'Obsoleto',
+                        'dado_de_baja' => 'Dado de baja',
+                        default => $state,
+                    }),
+                TextColumn::make('ubicacion')
+                    ->label('Ubicacion')
+                    ->limit(30)
+                    ->toggleable(),
+                TextColumn::make('nivel_sensibilidad')
+                    ->label('Sensibilidad')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'publico' => 'gray',
+                        'interno' => 'info',
+                        'confidencial' => 'warning',
+                        'sensible' => 'danger',
+                        default => 'gray',
+                    })
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->label('Registrado')
+                    ->dateTime('d/m/Y')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                SelectFilter::make('tipo')
+                    ->label('Tipo')
+                    ->options([
+                        'pc_escritorio' => 'PC Escritorio',
+                        'laptop' => 'Laptop',
+                        'impresora' => 'Impresora',
+                        'servidor' => 'Servidor',
+                        'usb' => 'USB',
+                        'otro' => 'Otro',
+                    ]),
+                SelectFilter::make('estado')
+                    ->label('Estado')
+                    ->options([
+                        'activo' => 'Activo',
+                        'mantenimiento' => 'Mantenimiento',
+                        'obsoleto' => 'Obsoleto',
+                        'dado_de_baja' => 'Dado de baja',
+                    ]),
+                SelectFilter::make('nivel_sensibilidad')
+                    ->label('Sensibilidad')
+                    ->options([
+                        'publico' => 'Publico',
+                        'interno' => 'Interno',
+                        'confidencial' => 'Confidencial',
+                        'sensible' => 'Sensible',
+                    ]),
+                TrashedFilter::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- EquipoResource with full CRUD (List, Create, Edit) under "Activos" navigation group
- Form: 4 sections (identificacion, specs condicionales, ubicacion/clasificacion, observaciones)
- Table: badges por tipo/estado/sensibilidad, usuario asignado, filtros, search
- Soft delete support

## Test plan
- [ ] Navigate to /admin/{tenant}/equipos - list loads
- [ ] Create new equipo - form shows conditional specs for PC/laptop
- [ ] Edit equipo - data loads correctly
- [ ] Filters work (tipo, estado, sensibilidad)
- [ ] Search by codigo, serie, marca works
- [ ] "Asignado a" column shows user name or "Sin asignar"

🤖 Generated with [Claude Code](https://claude.com/claude-code)