### PR TITLE
feat(SEN-70, SEN-71): asignacion, transferencia y devolucion de equipos

### DIFF
--- a/app/Filament/Resources/Equipos/Pages/EditEquipo.php
+++ b/app/Filament/Resources/Equipos/Pages/EditEquipo.php
@@ -3,10 +3,18 @@
 namespace App\Filament\Resources\Equipos\Pages;
 
 use App\Filament\Resources\Equipos\EquipoResource;
+use App\Models\EquipoAsignacion;
+use App\Models\User;
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\RestoreAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\DB;
 
 class EditEquipo extends EditRecord
 {
@@ -15,8 +23,145 @@ class EditEquipo extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            DeleteAction::make()
-                ->label('Desactivar'),
+            Action::make('asignar')
+                ->label('Asignar')
+                ->icon('heroicon-o-user-plus')
+                ->color('success')
+                ->form([
+                    Select::make('user_id')
+                        ->label('Asignar a')
+                        ->options(fn () => User::where('empresa_id', Filament::getTenant()?->id)
+                            ->where('estado', 'activo')
+                            ->pluck('name', 'id'))
+                        ->searchable()
+                        ->required(),
+                    Select::make('condicion_entrega')
+                        ->label('Condicion del equipo al entregar')
+                        ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])
+                        ->required(),
+                    Textarea::make('notas')
+                        ->label('Notas')
+                        ->rows(2)
+                        ->placeholder('Accesorios entregados, observaciones...'),
+                ])
+                ->action(function (array $data) {
+                    EquipoAsignacion::create([
+                        'equipo_id' => $this->record->id,
+                        'user_id' => $data['user_id'],
+                        'tipo' => 'asignacion',
+                        'fecha_inicio' => now(),
+                        'condicion_entrega' => $data['condicion_entrega'],
+                        'notas' => $data['notas'] ?? null,
+                        'asignado_por' => auth()->id(),
+                    ]);
+
+                    Notification::make()
+                        ->title('Equipo asignado')
+                        ->body('El equipo fue asignado a ' . User::find($data['user_id'])?->name)
+                        ->success()
+                        ->send();
+                })
+                ->visible(fn () => ! $this->record->estaAsignado() && $this->record->estado === 'activo'),
+
+            Action::make('transferir')
+                ->label('Transferir')
+                ->icon('heroicon-o-arrow-path')
+                ->color('warning')
+                ->form([
+                    Select::make('nuevo_user_id')
+                        ->label('Transferir a')
+                        ->options(fn () => User::where('empresa_id', Filament::getTenant()?->id)
+                            ->where('estado', 'activo')
+                            ->where('id', '!=', $this->record->asignacionVigente?->user_id)
+                            ->pluck('name', 'id'))
+                        ->searchable()
+                        ->required(),
+                    Select::make('condicion_devolucion')
+                        ->label('Condicion al recoger del usuario anterior')
+                        ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])
+                        ->required(),
+                    Select::make('condicion_entrega')
+                        ->label('Condicion al entregar al nuevo usuario')
+                        ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])
+                        ->required(),
+                    Textarea::make('notas')
+                        ->label('Notas')
+                        ->rows(2),
+                ])
+                ->action(function (array $data) {
+                    DB::transaction(function () use ($data) {
+                        $vigente = $this->record->asignacionVigente;
+                        if ($vigente) {
+                            $vigente->update([
+                                'fecha_fin' => now(),
+                                'condicion_devolucion' => $data['condicion_devolucion'],
+                            ]);
+                        }
+
+                        EquipoAsignacion::create([
+                            'equipo_id' => $this->record->id,
+                            'user_id' => $data['nuevo_user_id'],
+                            'tipo' => 'transferencia',
+                            'fecha_inicio' => now(),
+                            'condicion_entrega' => $data['condicion_entrega'],
+                            'notas' => $data['notas'] ?? null,
+                            'asignado_por' => auth()->id(),
+                        ]);
+                    });
+
+                    Notification::make()
+                        ->title('Equipo transferido')
+                        ->body('Transferido a ' . User::find($data['nuevo_user_id'])?->name)
+                        ->success()
+                        ->send();
+                })
+                ->visible(fn () => $this->record->estaAsignado()),
+
+            Action::make('devolver')
+                ->label('Devolver')
+                ->icon('heroicon-o-arrow-uturn-left')
+                ->color('gray')
+                ->requiresConfirmation()
+                ->modalHeading('Devolver equipo')
+                ->modalDescription('El equipo quedara libre y sin usuario asignado.')
+                ->form([
+                    Select::make('condicion_devolucion')
+                        ->label('Condicion del equipo al devolver')
+                        ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])
+                        ->required(),
+                    Textarea::make('notas')
+                        ->label('Notas')
+                        ->rows(2),
+                ])
+                ->action(function (array $data) {
+                    $vigente = $this->record->asignacionVigente;
+                    if ($vigente) {
+                        $vigente->update([
+                            'fecha_fin' => now(),
+                            'condicion_devolucion' => $data['condicion_devolucion'],
+                        ]);
+                    }
+
+                    EquipoAsignacion::create([
+                        'equipo_id' => $this->record->id,
+                        'user_id' => $vigente?->user_id ?? auth()->id(),
+                        'tipo' => 'devolucion',
+                        'fecha_inicio' => now(),
+                        'fecha_fin' => now(),
+                        'condicion_entrega' => $data['condicion_devolucion'],
+                        'notas' => $data['notas'] ?? null,
+                        'asignado_por' => auth()->id(),
+                    ]);
+
+                    Notification::make()
+                        ->title('Equipo devuelto')
+                        ->body('El equipo esta disponible para asignar.')
+                        ->success()
+                        ->send();
+                })
+                ->visible(fn () => $this->record->estaAsignado()),
+
+            DeleteAction::make()->label('Desactivar'),
             RestoreAction::make(),
             ForceDeleteAction::make(),
         ];

--- a/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
+++ b/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
@@ -2,13 +2,16 @@
 
 namespace App\Filament\Resources\Equipos\Schemas;
 
+use App\Models\Equipo;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Illuminate\Support\HtmlString;
 
 class EquipoForm
 {
@@ -118,6 +121,78 @@ class EquipoForm
                     ])
                     ->collapsible()
                     ->collapsed(),
+
+                Section::make('Historial de asignaciones')
+                    ->icon('heroicon-o-clock')
+                    ->description('Registro de todas las asignaciones, transferencias y devoluciones.')
+                    ->schema([
+                        Placeholder::make('asignacion_actual')
+                            ->label('')
+                            ->content(function ($record): HtmlString {
+                                if (! $record instanceof Equipo) {
+                                    return new HtmlString('<p class="text-sm text-gray-500">Guarda el equipo primero para ver el historial.</p>');
+                                }
+
+                                $vigente = $record->asignacionVigente;
+                                $currentHtml = $vigente
+                                    ? '<div class="rounded-lg border border-success-200 bg-success-50 p-3 dark:border-success-800 dark:bg-success-950/50 mb-4">'
+                                      . '<p class="text-sm font-semibold text-success-700 dark:text-success-400">Asignado a: ' . e($vigente->user?->name ?? '—') . '</p>'
+                                      . '<p class="text-xs text-success-600 dark:text-success-500">Desde: ' . $vigente->fecha_inicio->format('d/m/Y H:i') . ' | Condicion: ' . e($vigente->condicion_entrega ?? '—') . '</p>'
+                                      . '</div>'
+                                    : '<div class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800 mb-4">'
+                                      . '<p class="text-sm text-gray-500 dark:text-gray-400">Sin asignar</p></div>';
+
+                                $asignaciones = $record->asignaciones()
+                                    ->with(['user', 'asignador'])
+                                    ->orderBy('created_at', 'desc')
+                                    ->get();
+
+                                if ($asignaciones->isEmpty()) {
+                                    return new HtmlString($currentHtml . '<p class="text-sm text-gray-500">Sin historial.</p>');
+                                }
+
+                                $rows = '';
+                                foreach ($asignaciones as $a) {
+                                    $tipoColor = match ($a->tipo) {
+                                        'asignacion' => 'success',
+                                        'transferencia' => 'warning',
+                                        'devolucion' => 'gray',
+                                        'baja' => 'danger',
+                                        default => 'gray',
+                                    };
+                                    $tipoLabel = match ($a->tipo) {
+                                        'asignacion' => 'Asignacion',
+                                        'transferencia' => 'Transferencia',
+                                        'devolucion' => 'Devolucion',
+                                        'baja' => 'Baja',
+                                        default => $a->tipo,
+                                    };
+                                    $rows .= '<tr class="border-b border-gray-100 dark:border-gray-800">'
+                                        . '<td class="py-2 px-2 text-xs"><span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-' . $tipoColor . '-100 text-' . $tipoColor . '-700 dark:bg-' . $tipoColor . '-500/20 dark:text-' . $tipoColor . '-400">' . $tipoLabel . '</span></td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-700 dark:text-gray-300">' . e($a->user?->name ?? '—') . '</td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . $a->fecha_inicio->format('d/m/Y H:i') . '</td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . ($a->fecha_fin?->format('d/m/Y H:i') ?? '—') . '</td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . e($a->condicion_entrega ?? '') . '</td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . e($a->asignador?->name ?? '—') . '</td>'
+                                        . '</tr>';
+                                }
+
+                                $table = '<table class="w-full text-left">'
+                                    . '<thead><tr class="border-b border-gray-200 dark:border-gray-700">'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Tipo</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Usuario</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Inicio</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Fin</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Condicion</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Realizado por</th>'
+                                    . '</tr></thead><tbody>' . $rows . '</tbody></table>';
+
+                                return new HtmlString($currentHtml . $table);
+                            })
+                            ->columnSpanFull(),
+                    ])
+                    ->visible(fn (string $operation): bool => $operation === 'edit')
+                    ->collapsible(),
             ]);
     }
 }


### PR DESCRIPTION
## Summary
- **Asignar**: assign equipo to user (visible when unassigned + active)
- **Transferir**: transfer to different user (DB transaction, closes old + creates new)
- **Devolver**: return equipo, closes assignment, equipo becomes available
- Assignment history in edit form: current badge + full timeline table
- All actions with Filament modal forms (user select, condition, notes)

## Test plan
- [ ] Open equipo without user → "Asignar" button visible
- [ ] Assign to user → history shows, "Asignar" hidden, "Transferir"/"Devolver" appear
- [ ] Transfer to new user → old assignment closed, new one created
- [ ] Return equipo → assignment closed, equipo free
- [ ] History table shows all movements with badges and dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)