### PR TITLE
feat(SEN-73, SEN-74): vincular tickets con equipos + dashboard activos

### DIFF
--- a/app/Filament/Resources/Tickets/Pages/CreateTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/CreateTicket.php
@@ -23,4 +23,13 @@ class CreateTicket extends CreateRecord
 
         return $data;
     }
+
+    protected function afterCreate(): void
+    {
+        $equipos = $this->data['equipos'] ?? [];
+
+        if (! empty($equipos)) {
+            $this->record->equipos()->sync($equipos);
+        }
+    }
 }

--- a/app/Filament/Resources/Tickets/Schemas/TicketForm.php
+++ b/app/Filament/Resources/Tickets/Schemas/TicketForm.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Resources\Tickets\Schemas;
 
+use App\Models\Equipo;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -48,6 +50,21 @@ class TicketForm
                             ])
                             ->default('media')
                             ->required(),
+                        Select::make('equipos')
+                            ->label('Equipo afectado')
+                            ->multiple()
+                            ->options(function () {
+                                $empresa = Filament::getTenant();
+
+                                return Equipo::where('empresa_id', $empresa?->id)
+                                    ->where('estado', 'activo')
+                                    ->get()
+                                    ->mapWithKeys(fn ($e) => [$e->id => "{$e->codigo_interno} — {$e->marca} {$e->modelo}"])
+                                    ->toArray();
+                            })
+                            ->searchable()
+                            ->helperText('Opcional: selecciona los equipos relacionados con el problema')
+                            ->columnSpanFull(),
                         RichEditor::make('descripcion')
                             ->label('Descripción')
                             ->required()

--- a/app/Filament/Widgets/EquiposStatsOverview.php
+++ b/app/Filament/Widgets/EquiposStatsOverview.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Equipo;
+use Filament\Facades\Filament;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class EquiposStatsOverview extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    protected function getStats(): array
+    {
+        $empresa = Filament::getTenant();
+        $empresaId = $empresa?->id;
+
+        if (! $empresaId) {
+            return [];
+        }
+
+        $total = Equipo::where('empresa_id', $empresaId)->count();
+        $asignados = Equipo::where('empresa_id', $empresaId)
+            ->where('estado', 'activo')
+            ->whereHas('asignacionVigente')
+            ->count();
+        $sinAsignar = Equipo::where('empresa_id', $empresaId)
+            ->where('estado', 'activo')
+            ->whereDoesntHave('asignacionVigente')
+            ->count();
+        $mantenimiento = Equipo::where('empresa_id', $empresaId)
+            ->where('estado', 'mantenimiento')
+            ->count();
+
+        return [
+            Stat::make('Total equipos', $total)
+                ->description('Inventario completo')
+                ->descriptionIcon('heroicon-m-computer-desktop')
+                ->color('primary'),
+            Stat::make('Asignados', $asignados)
+                ->description('Con usuario asignado')
+                ->descriptionIcon('heroicon-m-user-circle')
+                ->color('success'),
+            Stat::make('Sin asignar', $sinAsignar)
+                ->description('Disponibles')
+                ->descriptionIcon('heroicon-m-inbox')
+                ->color($sinAsignar > 0 ? 'warning' : 'gray'),
+            Stat::make('En mantenimiento', $mantenimiento)
+                ->description('Requieren atencion')
+                ->descriptionIcon('heroicon-m-wrench')
+                ->color($mantenimiento > 0 ? 'danger' : 'gray'),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- **SEN-73**: Multi-select "Equipo afectado" in ticket creation form, synced via pivot table
- **SEN-74**: EquiposStatsOverview dashboard widget (total, asignados, sin asignar, mantenimiento)

## Test plan
- [ ] Create ticket → equipo select shows empresa equipos
- [ ] Select equipos → after save, pivot records exist
- [ ] Dashboard shows equipos stats for admin_empresa
- [ ] Stats not visible for regular users

🤖 Generated with [Claude Code](https://claude.com/claude-code)