### PR TITLE
feat(SEN-75): migraciones y modelos para politicas y aceptaciones

### DIFF
--- a/app/Models/AceptacionPolitica.php
+++ b/app/Models/AceptacionPolitica.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AceptacionPolitica extends Model
+{
+    protected $table = 'aceptaciones_politica';
+
+    protected $fillable = [
+        'user_id',
+        'politica_id',
+        'version_aceptada',
+        'fecha_aceptacion',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'fecha_aceptacion' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id')->withoutGlobalScopes();
+    }
+
+    public function politica(): BelongsTo
+    {
+        return $this->belongsTo(Politica::class, 'politica_id');
+    }
+}

--- a/app/Models/Politica.php
+++ b/app/Models/Politica.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\BelongsToEmpresa;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+class Politica extends Model
+{
+    use BelongsToEmpresa, SoftDeletes;
+
+    protected $fillable = [
+        'empresa_id',
+        'titulo',
+        'slug',
+        'contenido',
+        'version',
+        'obligatoria',
+        'activa',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'obligatoria' => 'boolean',
+            'activa' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (Politica $politica) {
+            if (empty($politica->slug)) {
+                $politica->slug = Str::slug($politica->titulo);
+            }
+        });
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+
+    public function aceptaciones(): HasMany
+    {
+        return $this->hasMany(AceptacionPolitica::class, 'politica_id');
+    }
+
+    /**
+     * Get obligatory active policies that a user hasn't accepted (or accepted an older version).
+     */
+    public static function pendientesPara(int $userId, int $empresaId): \Illuminate\Database\Eloquent\Collection
+    {
+        return static::where('empresa_id', $empresaId)
+            ->where('obligatoria', true)
+            ->where('activa', true)
+            ->whereDoesntHave('aceptaciones', function ($q) use ($userId) {
+                $q->where('user_id', $userId)
+                  ->whereColumn('aceptaciones_politica.version_aceptada', 'politicas.version');
+            })
+            ->get();
+    }
+
+    public function aceptadaPor(int $userId): bool
+    {
+        return $this->aceptaciones()
+            ->where('user_id', $userId)
+            ->where('version_aceptada', $this->version)
+            ->exists();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -98,6 +98,20 @@ class User extends Authenticatable implements FilamentUser, HasTenants
             ->whereIn('tipo', ['asignacion', 'transferencia']);
     }
 
+    public function aceptacionesPolitica(): HasMany
+    {
+        return $this->hasMany(AceptacionPolitica::class, 'user_id');
+    }
+
+    public function tienePoliticasPendientes(): bool
+    {
+        if (! $this->empresa_id) {
+            return false;
+        }
+
+        return Politica::pendientesPara($this->id, $this->empresa_id)->isNotEmpty();
+    }
+
     public function isActivo(): bool
     {
         return $this->estado === 'activo';

--- a/database/migrations/2026_04_02_000004_create_politicas_table.php
+++ b/database/migrations/2026_04_02_000004_create_politicas_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('politicas', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('empresa_id');
+            $table->foreign('empresa_id')->references('id')->on('empresas')->cascadeOnDelete();
+            $table->string('titulo');
+            $table->string('slug');
+            $table->longText('contenido');
+            $table->string('version')->default('1.0');
+            $table->boolean('obligatoria')->default(true);
+            $table->boolean('activa')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['empresa_id', 'slug']);
+        });
+
+        Schema::create('aceptaciones_politica', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('politica_id')->constrained('politicas')->cascadeOnDelete();
+            $table->string('version_aceptada');
+            $table->datetime('fecha_aceptacion');
+            $table->string('ip_address')->nullable();
+            $table->string('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'politica_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('aceptaciones_politica');
+        Schema::dropIfExists('politicas');
+    }
+};


### PR DESCRIPTION
## Summary
- politicas table + aceptaciones_politica table
- Politica model with pendientesPara() scope and aceptadaPor() check
- User model with tienePoliticasPendientes() helper

## Test plan
- [x] Migrations run without errors
- [x] Create politica → slug auto-generated
- [x] pendientesPara() returns unaccepted policies
- [x] After acceptance → pendientesPara() returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)