### PR TITLE
feat(SEN-76,77,78): politicas CRUD, aceptacion obligatoria, panel cumplimiento

### DIFF
--- a/app/Filament/Pages/AceptarPoliticas.php
+++ b/app/Filament/Pages/AceptarPoliticas.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\AceptacionPolitica;
+use App\Models\Politica;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class AceptarPoliticas extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-shield-check';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected static ?string $title = 'Aceptar politicas';
+
+    protected static ?string $slug = 'aceptar-politicas';
+
+    protected string $view = 'filament.pages.aceptar-politicas';
+
+    public ?Politica $politicaActual = null;
+
+    public bool $acepto = false;
+
+    public function mount(): void
+    {
+        $user = auth()->user();
+
+        if (! $user->empresa_id) {
+            $this->redirect('/admin');
+
+            return;
+        }
+
+        $pendientes = Politica::pendientesPara($user->id, $user->empresa_id);
+
+        if ($pendientes->isEmpty()) {
+            $this->redirect('/admin/' . ($user->empresa?->ruc ?? ''));
+
+            return;
+        }
+
+        $this->politicaActual = $pendientes->first();
+    }
+
+    public function aceptar(): void
+    {
+        if (! $this->acepto) {
+            Notification::make()
+                ->title('Debes marcar la casilla para aceptar')
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        AceptacionPolitica::create([
+            'user_id' => auth()->id(),
+            'politica_id' => $this->politicaActual->id,
+            'version_aceptada' => $this->politicaActual->version,
+            'fecha_aceptacion' => now(),
+            'ip_address' => request()->ip(),
+            'user_agent' => request()->userAgent(),
+        ]);
+
+        $this->acepto = false;
+
+        // Check if more pending
+        $user = auth()->user();
+        $pendientes = Politica::pendientesPara($user->id, $user->empresa_id);
+
+        if ($pendientes->isNotEmpty()) {
+            $this->politicaActual = $pendientes->first();
+
+            Notification::make()
+                ->title('Politica aceptada')
+                ->body('Aun tienes politicas pendientes por aceptar.')
+                ->info()
+                ->send();
+        } else {
+            Notification::make()
+                ->title('Todas las politicas aceptadas')
+                ->success()
+                ->send();
+
+            $this->redirect('/admin/' . ($user->empresa?->ruc ?? ''));
+        }
+    }
+}

--- a/app/Filament/Resources/Politicas/Pages/CreatePolitica.php
+++ b/app/Filament/Resources/Politicas/Pages/CreatePolitica.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Politicas\Pages;
+
+use App\Filament\Resources\Politicas\PoliticaResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePolitica extends CreateRecord
+{
+    protected static string $resource = PoliticaResource::class;
+}

--- a/app/Filament/Resources/Politicas/Pages/EditPolitica.php
+++ b/app/Filament/Resources/Politicas/Pages/EditPolitica.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\Politicas\Pages;
+
+use App\Filament\Resources\Politicas\PoliticaResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPolitica extends EditRecord
+{
+    protected static string $resource = PoliticaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [DeleteAction::make()];
+    }
+}

--- a/app/Filament/Resources/Politicas/Pages/ListPoliticas.php
+++ b/app/Filament/Resources/Politicas/Pages/ListPoliticas.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\Politicas\Pages;
+
+use App\Filament\Resources\Politicas\PoliticaResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPoliticas extends ListRecords
+{
+    protected static string $resource = PoliticaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/Politicas/PoliticaResource.php
+++ b/app/Filament/Resources/Politicas/PoliticaResource.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Filament\Resources\Politicas;
+
+use App\Filament\Resources\Politicas\Pages\CreatePolitica;
+use App\Filament\Resources\Politicas\Pages\EditPolitica;
+use App\Filament\Resources\Politicas\Pages\ListPoliticas;
+use App\Models\Politica;
+use BackedEnum;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class PoliticaResource extends Resource
+{
+    protected static ?string $model = Politica::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedShieldCheck;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Seguridad';
+
+    protected static ?string $modelLabel = 'Politica';
+
+    protected static ?string $pluralModelLabel = 'Politicas';
+
+    protected static ?int $navigationSort = 2;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(1)
+            ->components([
+                Section::make('Informacion de la politica')
+                    ->icon('heroicon-o-document-text')
+                    ->description('Define el titulo y contenido de la politica o NDA.')
+                    ->schema([
+                        TextInput::make('titulo')
+                            ->label('Titulo')
+                            ->required()
+                            ->maxLength(255)
+                            ->columnSpanFull(),
+                        TextInput::make('version')
+                            ->label('Version')
+                            ->default('1.0')
+                            ->required()
+                            ->helperText('Incrementa la version al hacer cambios importantes para que los usuarios deban re-aceptar.'),
+                        RichEditor::make('contenido')
+                            ->label('Contenido completo')
+                            ->required()
+                            ->columnSpanFull(),
+                    ])->columns(2),
+
+                Section::make('Configuracion')
+                    ->schema([
+                        Toggle::make('obligatoria')
+                            ->label('Obligatoria')
+                            ->helperText('Si esta activa, los usuarios no podran usar el sistema sin aceptar esta politica.')
+                            ->default(true),
+                        Toggle::make('activa')
+                            ->label('Activa')
+                            ->helperText('Las politicas inactivas no se muestran a los usuarios.')
+                            ->default(true),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('titulo')
+                    ->label('Titulo')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('version')
+                    ->label('Version')
+                    ->badge()
+                    ->color('info'),
+                IconColumn::make('obligatoria')
+                    ->label('Obligatoria')
+                    ->boolean(),
+                IconColumn::make('activa')
+                    ->label('Activa')
+                    ->boolean(),
+                TextColumn::make('aceptaciones_count')
+                    ->label('Aceptaciones')
+                    ->counts('aceptaciones')
+                    ->badge()
+                    ->color('success'),
+                TextColumn::make('created_at')
+                    ->label('Creada')
+                    ->dateTime('d/m/Y')
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                SelectFilter::make('activa')
+                    ->options(['1' => 'Activas', '0' => 'Inactivas']),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPoliticas::route('/'),
+            'create' => CreatePolitica::route('/create'),
+            'edit' => EditPolitica::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Widgets/PoliticasCumplimiento.php
+++ b/app/Filament/Widgets/PoliticasCumplimiento.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Politica;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Widgets\Widget;
+
+class PoliticasCumplimiento extends Widget
+{
+    protected static ?int $sort = 6;
+
+    protected string $view = 'filament.widgets.politicas-cumplimiento';
+
+    protected int|string|array $columnSpan = 'full';
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public function getData(): array
+    {
+        $empresa = Filament::getTenant();
+        $empresaId = $empresa?->id;
+
+        if (! $empresaId) {
+            return ['politicas' => [], 'totalUsuarios' => 0];
+        }
+
+        $totalUsuarios = User::where('empresa_id', $empresaId)->where('estado', 'activo')->count();
+
+        $politicas = Politica::where('empresa_id', $empresaId)
+            ->where('activa', true)
+            ->where('obligatoria', true)
+            ->withCount(['aceptaciones as aceptaciones_vigentes_count' => function ($q) {
+                $q->whereColumn('aceptaciones_politica.version_aceptada', 'politicas.version');
+            }])
+            ->get()
+            ->map(fn ($p) => [
+                'titulo' => $p->titulo,
+                'version' => $p->version,
+                'aceptadas' => $p->aceptaciones_vigentes_count,
+                'total' => $totalUsuarios,
+                'porcentaje' => $totalUsuarios > 0 ? round(($p->aceptaciones_vigentes_count / $totalUsuarios) * 100) : 0,
+            ]);
+
+        return [
+            'politicas' => $politicas,
+            'totalUsuarios' => $totalUsuarios,
+        ];
+    }
+}

--- a/app/Http/Middleware/EnsurePoliciesAccepted.php
+++ b/app/Http/Middleware/EnsurePoliciesAccepted.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Politica;
+use Closure;
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePoliciesAccepted
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = auth()->user();
+
+        if (! $user || ! $user->empresa_id) {
+            return $next($request);
+        }
+
+        // Skip for super_admin — they manage policies, not accept them
+        if ($user->hasRole('super_admin')) {
+            return $next($request);
+        }
+
+        // Skip if already on acceptance page or auth routes
+        $path = $request->path();
+        if (str_contains($path, 'aceptar-politicas') || str_contains($path, 'logout')) {
+            return $next($request);
+        }
+
+        $pendientes = Politica::pendientesPara($user->id, $user->empresa_id);
+
+        if ($pendientes->isNotEmpty()) {
+            $tenant = Filament::getTenant();
+            $ruc = $tenant?->ruc ?? $user->empresa?->ruc ?? '';
+
+            return redirect("/admin/{$ruc}/aceptar-politicas");
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -53,6 +53,7 @@ class AdminPanelProvider extends PanelProvider
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->tenantMiddleware([
                 ApplyTenantBranding::class,
+                \App\Http\Middleware\EnsurePoliciesAccepted::class,
             ], isPersistent: true)
             ->renderHook('panels::head.end', function () {
                 $tenant = Filament::getTenant();

--- a/resources/views/filament/pages/aceptar-politicas.blade.php
+++ b/resources/views/filament/pages/aceptar-politicas.blade.php
@@ -1,0 +1,42 @@
+<x-filament-panels::page>
+    <div class="mx-auto max-w-3xl">
+        @if ($politicaActual)
+            <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="mb-4 flex items-center gap-3">
+                    <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-primary-50 dark:bg-primary-500/10">
+                        <x-heroicon-o-shield-check class="h-6 w-6 text-primary-600 dark:text-primary-400" />
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ $politicaActual->titulo }}</h2>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">Version {{ $politicaActual->version }}</p>
+                    </div>
+                </div>
+
+                <div class="prose prose-sm dark:prose-invert max-h-[50vh] overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
+                    {!! $politicaActual->contenido !!}
+                </div>
+
+                <div class="mt-6 border-t border-gray-200 pt-4 dark:border-gray-700">
+                    <label class="flex items-start gap-3 cursor-pointer">
+                        <input type="checkbox" wire:model="acepto"
+                               class="mt-0.5 rounded border border-gray-300 text-primary-600 shadow-sm focus:ring-primary-500 dark:border-white/10 dark:bg-white/5">
+                        <span class="text-sm text-gray-700 dark:text-gray-300">
+                            He leido y acepto esta politica en su totalidad. Entiendo que su incumplimiento puede tener consecuencias legales y laborales.
+                        </span>
+                    </label>
+
+                    <div class="mt-4 flex justify-end">
+                        <x-filament::button wire:click="aceptar" wire:loading.attr="disabled" icon="heroicon-m-check" size="lg">
+                            Aceptar y continuar
+                        </x-filament::button>
+                    </div>
+                </div>
+            </div>
+        @else
+            <div class="text-center py-12 text-gray-500">
+                <x-heroicon-o-check-circle class="mx-auto h-12 w-12 text-success-500 mb-3" />
+                <p class="text-lg font-medium">No tienes politicas pendientes</p>
+            </div>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/widgets/politicas-cumplimiento.blade.php
+++ b/resources/views/filament/widgets/politicas-cumplimiento.blade.php
@@ -1,0 +1,30 @@
+<x-filament-widgets::widget>
+    <x-filament::section heading="Cumplimiento de politicas" icon="heroicon-o-shield-check" collapsible>
+        @php $data = $this->getData(); @endphp
+
+        @if ($data['politicas']->isEmpty())
+            <p class="text-sm text-gray-500">No hay politicas obligatorias activas.</p>
+        @else
+            <div class="space-y-3">
+                @foreach ($data['politicas'] as $p)
+                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+                        <div class="flex items-center justify-between mb-2">
+                            <div>
+                                <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $p['titulo'] }}</span>
+                                <span class="ml-2 text-xs text-gray-500">v{{ $p['version'] }}</span>
+                            </div>
+                            <span class="text-sm font-bold {{ $p['porcentaje'] === 100 ? 'text-success-600' : ($p['porcentaje'] >= 50 ? 'text-warning-600' : 'text-danger-600') }}">
+                                {{ $p['porcentaje'] }}%
+                            </span>
+                        </div>
+                        <div class="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+                            <div class="h-2 rounded-full {{ $p['porcentaje'] === 100 ? 'bg-success-500' : ($p['porcentaje'] >= 50 ? 'bg-warning-500' : 'bg-danger-500') }}"
+                                 style="width: {{ $p['porcentaje'] }}%"></div>
+                        </div>
+                        <p class="mt-1 text-xs text-gray-500">{{ $p['aceptadas'] }} de {{ $p['total'] }} usuarios</p>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>


### PR DESCRIPTION
## Summary
- **SEN-76**: PoliticaResource CRUD (titulo, version, contenido rich text, obligatoria/activa)
- **SEN-77**: EnsurePoliciesAccepted middleware + acceptance page with checkbox, IP/user-agent logging
- **SEN-78**: PoliticasCumplimiento dashboard widget with progress bars per policy

## Test plan
- [ ] Create politica from admin panel
- [ ] Login as regular user → redirected to acceptance page
- [ ] Accept policy → checkbox + button → recorded with IP
- [ ] After acceptance → can navigate normally
- [ ] Change policy version → user must re-accept
- [ ] Dashboard shows compliance % per policy
- [ ] super_admin skips acceptance (manages policies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)