### PR TITLE
feat(SEN-79): notificacion email al publicar nueva politica

### DIFF
--- a/app/Observers/PoliticaObserver.php
+++ b/app/Observers/PoliticaObserver.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\SendEmailJob;
+use App\Models\Politica;
+use App\Models\User;
+
+class PoliticaObserver
+{
+    public function created(Politica $politica): void
+    {
+        if ($politica->activa && $politica->obligatoria) {
+            $this->notifyUsers($politica);
+        }
+    }
+
+    public function updated(Politica $politica): void
+    {
+        if ($politica->wasChanged('version') && $politica->activa && $politica->obligatoria) {
+            $this->notifyUsers($politica);
+        }
+    }
+
+    private function notifyUsers(Politica $politica): void
+    {
+        if (! $politica->empresa_id) {
+            return;
+        }
+
+        $users = User::where('empresa_id', $politica->empresa_id)
+            ->where('estado', 'activo')
+            ->get();
+
+        $loginUrl = url('admin/' . ($politica->empresa?->ruc ?? '') . '/aceptar-politicas');
+
+        foreach ($users as $user) {
+            dispatch(SendEmailJob::fromTemplate(
+                destinatario: $user->email,
+                nombreDestino: $user->name,
+                templateSlug: 'nueva_politica',
+                templateVariables: [
+                    'nombre' => $user->name,
+                    'titulo_politica' => $politica->titulo,
+                    'version' => $politica->version,
+                    'enlace_plataforma' => $loginUrl,
+                ],
+                actionUrl: $loginUrl,
+                actionLabel: 'Aceptar politica',
+            ));
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,5 +34,6 @@ class AppServiceProvider extends ServiceProvider
         Ticket::observe(AuditableObserver::class);
         Empresa::observe(AuditableObserver::class);
         User::observe(AuditableObserver::class);
+        \App\Models\Politica::observe(\App\Observers\PoliticaObserver::class);
     }
 }

--- a/database/seeders/EmailTemplateSeeder.php
+++ b/database/seeders/EmailTemplateSeeder.php
@@ -136,6 +136,19 @@ HTML,
 <p><a href="{{enlace_ticket}}">Ver ticket</a></p>
 HTML,
             ],
+            [
+                'slug' => 'nueva_politica',
+                'nombre' => 'Nueva politica publicada',
+                'asunto' => 'Nueva politica: {{titulo_politica}} (v{{version}})',
+                'variables_disponibles' => ['nombre', 'titulo_politica', 'version', 'enlace_plataforma'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>Se ha publicado una nueva politica de seguridad que requiere tu aceptacion:</p>
+<p><strong>{{titulo_politica}}</strong> (version {{version}})</p>
+<p>Es necesario que leas y aceptes esta politica para poder seguir usando la plataforma.</p>
+<p><a href="{{enlace_plataforma}}">Ir a aceptar</a></p>
+HTML,
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- PoliticaObserver sends email to all active users when policy is created or version updated
- nueva_politica email template with link to acceptance page
- Registered in AppServiceProvider

🤖 Generated with [Claude Code](https://claude.com/claude-code)