### PR TITLE
fix: dropdowns de checklist con componentes Filament nativos

### DIFF
--- a/app/Filament/Pages/EjecutarChecklist.php
+++ b/app/Filament/Pages/EjecutarChecklist.php
@@ -6,12 +6,18 @@ use App\Models\ChecklistEjecucion;
 use App\Models\ChecklistPlantilla;
 use App\Models\Equipo;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Livewire\Attributes\Url;
 
-class EjecutarChecklist extends Page
+class EjecutarChecklist extends Page implements HasForms
 {
+    use InteractsWithForms;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-check';
 
     protected static bool $shouldRegisterNavigation = false;
@@ -35,11 +41,52 @@ class EjecutarChecklist extends Page
 
     public string $observaciones_generales = '';
 
+    public array $selectorData = [];
+
     public function mount(): void
     {
         if ($this->equipo_id) {
             $this->equipo = Equipo::find($this->equipo_id);
+            $this->selectorData['equipo_id'] = $this->equipo_id;
         }
+    }
+
+    public function selectorForm(Schema $schema): Schema
+    {
+        $empresaId = Filament::getTenant()?->id;
+
+        return $schema
+            ->statePath('selectorData')
+            ->components([
+                Select::make('equipo_id')
+                    ->label('Equipo')
+                    ->options(
+                        Equipo::where('empresa_id', $empresaId)
+                            ->where('estado', 'activo')
+                            ->get()
+                            ->mapWithKeys(fn ($e) => [$e->id => "{$e->codigo_interno} — {$e->marca} {$e->modelo}"])
+                    )
+                    ->default($this->equipo_id)
+                    ->searchable()
+                    ->live()
+                    ->afterStateUpdated(function ($state) {
+                        $this->equipo_id = $state;
+                        $this->equipo = $state ? Equipo::find($state) : null;
+                    }),
+                Select::make('plantilla_id')
+                    ->label('Plantilla de checklist')
+                    ->options(
+                        ChecklistPlantilla::where('empresa_id', $empresaId)
+                            ->where('activa', true)
+                            ->pluck('nombre', 'id')
+                    )
+                    ->searchable()
+                    ->live()
+                    ->afterStateUpdated(function ($state) {
+                        $this->plantilla_id = $state;
+                        $this->loadItems();
+                    }),
+            ]);
     }
 
     public function getPlantillasProperty(): array

--- a/resources/views/filament/pages/ejecutar-checklist.blade.php
+++ b/resources/views/filament/pages/ejecutar-checklist.blade.php
@@ -1,30 +1,11 @@
 <x-filament-panels::page>
     <div class="mx-auto max-w-3xl space-y-6">
 
-        {{-- Selectors --}}
+        {{-- Selectors (Filament form) --}}
         <div class="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
             <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Seleccionar equipo y checklist</h3>
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <div>
-                    <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Equipo</label>
-                    <select wire:model.live="equipo_id"
-                            class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white">
-                        <option value="">Seleccionar equipo...</option>
-                        @foreach ($this->equipos as $id => $nombre)
-                            <option value="{{ $id }}">{{ $nombre }}</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div>
-                    <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Plantilla de checklist</label>
-                    <select wire:model.live="plantilla_id"
-                            class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white">
-                        <option value="">Seleccionar checklist...</option>
-                        @foreach ($this->plantillas as $id => $nombre)
-                            <option value="{{ $id }}">{{ $nombre }}</option>
-                        @endforeach
-                    </select>
-                </div>
+                {{ $this->selectorForm }}
             </div>
 
             @if ($equipo)


### PR DESCRIPTION
## Summary
- Replace native HTML `<select>` with Filament Select components
- Searchable, dark-mode compatible, pre-populated from URL param

🤖 Generated with [Claude Code](https://claude.com/claude-code)