### PR TITLE
fix: vista compacta de checklist con selects y checkboxes funcionales

### DIFF
--- a/app/Filament/Pages/EjecutarChecklist.php
+++ b/app/Filament/Pages/EjecutarChecklist.php
@@ -6,18 +6,12 @@ use App\Models\ChecklistEjecucion;
 use App\Models\ChecklistPlantilla;
 use App\Models\Equipo;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
-use Filament\Schemas\Schema;
 use Livewire\Attributes\Url;
 
-class EjecutarChecklist extends Page implements HasForms
+class EjecutarChecklist extends Page
 {
-    use InteractsWithForms;
-
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-check';
 
     protected static bool $shouldRegisterNavigation = false;
@@ -29,9 +23,9 @@ class EjecutarChecklist extends Page implements HasForms
     protected string $view = 'filament.pages.ejecutar-checklist';
 
     #[Url]
-    public ?int $equipo_id = null;
+    public ?string $equipo_id = null;
 
-    public ?int $plantilla_id = null;
+    public ?string $plantilla_id = null;
 
     public ?Equipo $equipo = null;
 
@@ -41,52 +35,11 @@ class EjecutarChecklist extends Page implements HasForms
 
     public string $observaciones_generales = '';
 
-    public array $selectorData = [];
-
     public function mount(): void
     {
         if ($this->equipo_id) {
             $this->equipo = Equipo::find($this->equipo_id);
-            $this->selectorData['equipo_id'] = $this->equipo_id;
         }
-    }
-
-    public function selectorForm(Schema $schema): Schema
-    {
-        $empresaId = Filament::getTenant()?->id;
-
-        return $schema
-            ->statePath('selectorData')
-            ->components([
-                Select::make('equipo_id')
-                    ->label('Equipo')
-                    ->options(
-                        Equipo::where('empresa_id', $empresaId)
-                            ->where('estado', 'activo')
-                            ->get()
-                            ->mapWithKeys(fn ($e) => [$e->id => "{$e->codigo_interno} — {$e->marca} {$e->modelo}"])
-                    )
-                    ->default($this->equipo_id)
-                    ->searchable()
-                    ->live()
-                    ->afterStateUpdated(function ($state) {
-                        $this->equipo_id = $state;
-                        $this->equipo = $state ? Equipo::find($state) : null;
-                    }),
-                Select::make('plantilla_id')
-                    ->label('Plantilla de checklist')
-                    ->options(
-                        ChecklistPlantilla::where('empresa_id', $empresaId)
-                            ->where('activa', true)
-                            ->pluck('nombre', 'id')
-                    )
-                    ->searchable()
-                    ->live()
-                    ->afterStateUpdated(function ($state) {
-                        $this->plantilla_id = $state;
-                        $this->loadItems();
-                    }),
-            ]);
     }
 
     public function getPlantillasProperty(): array
@@ -117,15 +70,14 @@ class EjecutarChecklist extends Page implements HasForms
 
     public function updatedEquipoId(): void
     {
-        if ($this->equipo_id) {
-            $this->equipo = Equipo::find($this->equipo_id);
-        }
+        $this->equipo = $this->equipo_id ? Equipo::find($this->equipo_id) : null;
     }
 
     public function loadItems(): void
     {
         if (! $this->plantilla_id) {
             $this->items = [];
+            $this->plantilla = null;
 
             return;
         }
@@ -164,7 +116,6 @@ class EjecutarChecklist extends Page implements HasForms
             'observacion' => $item['observacion'] ?? '',
         ])->toArray();
 
-        // Calculate estado
         $obligatoriosFallidos = collect($this->items)
             ->where('obligatorio', true)
             ->where('cumple', false)
@@ -187,8 +138,7 @@ class EjecutarChecklist extends Page implements HasForms
 
         Notification::make()
             ->title('Checklist guardado')
-            ->body("{$this->plantilla->nombre}: {$cumple}/{$total} items cumplen. Estado: {$estado}")
-            ->color($estado === 'completo' ? 'success' : 'warning')
+            ->body("{$this->plantilla->nombre}: {$cumple}/{$total} items cumplen.")
             ->success()
             ->send();
 

--- a/resources/views/filament/pages/ejecutar-checklist.blade.php
+++ b/resources/views/filament/pages/ejecutar-checklist.blade.php
@@ -1,96 +1,110 @@
 <x-filament-panels::page>
-    <div class="mx-auto max-w-3xl space-y-6">
+    <div class="mx-auto max-w-4xl space-y-4">
 
-        {{-- Selectors (Filament form) --}}
-        <div class="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
-            <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Seleccionar equipo y checklist</h3>
-            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                {{ $this->selectorForm }}
-            </div>
-
-            @if ($equipo)
-                <div class="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
-                        <strong>{{ $equipo->codigo_interno }}</strong> — {{ $equipo->marca }} {{ $equipo->modelo }}
-                        @if ($equipo->numero_serie) (S/N: {{ $equipo->numero_serie }}) @endif
-                        | {{ ucfirst($equipo->tipo) }} | {{ $equipo->ubicacion ?? 'Sin ubicacion' }}
-                    </p>
+        {{-- Header: equipo + plantilla selectors --}}
+        <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                    <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">Equipo</label>
+                    <x-filament::input.wrapper>
+                        <x-filament::input.select wire:model.live="equipo_id">
+                            <option value="">Seleccionar equipo...</option>
+                            @foreach ($this->equipos as $id => $nombre)
+                                <option value="{{ $id }}">{{ $nombre }}</option>
+                            @endforeach
+                        </x-filament::input.select>
+                    </x-filament::input.wrapper>
                 </div>
+                <div>
+                    <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">Checklist</label>
+                    <x-filament::input.wrapper>
+                        <x-filament::input.select wire:model.live="plantilla_id">
+                            <option value="">Seleccionar checklist...</option>
+                            @foreach ($this->plantillas as $id => $nombre)
+                                <option value="{{ $id }}">{{ $nombre }}</option>
+                            @endforeach
+                        </x-filament::input.select>
+                    </x-filament::input.wrapper>
+                </div>
+            </div>
+            @if ($equipo)
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                    <strong>{{ $equipo->codigo_interno }}</strong> — {{ $equipo->marca }} {{ $equipo->modelo }}
+                    @if ($equipo->numero_serie) (S/N: {{ $equipo->numero_serie }}) @endif
+                    | {{ ucfirst($equipo->tipo) }} | {{ $equipo->ubicacion ?? '—' }}
+                </p>
             @endif
         </div>
 
         {{-- Checklist items --}}
         @if (!empty($items))
-            <div class="rounded-xl bg-white p-5 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
-                <div class="mb-4">
-                    <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">{{ $plantilla?->nombre }}</h3>
+            <div class="rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="border-b border-gray-200 px-4 py-3 dark:border-white/10">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-white">{{ $plantilla?->nombre }}</h3>
                     @if ($plantilla?->descripcion)
-                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ $plantilla->descripcion }}</p>
+                        <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{{ $plantilla->descripcion }}</p>
                     @endif
                 </div>
 
-                <div class="space-y-3">
+                <div class="divide-y divide-gray-100 dark:divide-white/5">
                     @foreach ($items as $index => $item)
-                        <div class="rounded-lg border p-4 transition {{ $item['cumple'] ? 'border-success-200 bg-success-50/50 dark:border-success-800 dark:bg-success-950/30' : 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800' }}">
-                            <div class="flex items-start justify-between gap-4">
-                                <div class="flex-1">
-                                    <div class="flex items-center gap-2">
-                                        <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $item['nombre'] }}</span>
-                                        @if ($item['obligatorio'])
-                                            <span class="inline-flex items-center rounded-full bg-danger-100 px-1.5 py-0.5 text-[10px] font-semibold text-danger-700 dark:bg-danger-500/20 dark:text-danger-400">Obligatorio</span>
-                                        @endif
-                                    </div>
-                                    @if ($item['descripcion'])
-                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ $item['descripcion'] }}</p>
+                        <div class="flex items-center gap-3 px-4 py-2.5 {{ $item['cumple'] ? 'bg-success-50/50 dark:bg-success-950/20' : '' }}">
+                            {{-- Checkbox --}}
+                            <input type="checkbox" wire:model.live="items.{{ $index }}.cumple"
+                                   class="h-5 w-5 shrink-0 rounded border-gray-300 text-success-600 focus:ring-success-500 dark:border-white/10 dark:bg-white/5">
+
+                            {{-- Item info --}}
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-1.5">
+                                    <span class="text-sm {{ $item['cumple'] ? 'text-success-700 dark:text-success-400 line-through' : 'text-gray-900 dark:text-white' }}">{{ $item['nombre'] }}</span>
+                                    @if ($item['obligatorio'])
+                                        <span class="text-[9px] font-bold uppercase text-danger-500">*</span>
                                     @endif
                                 </div>
-                                <label class="relative inline-flex cursor-pointer items-center">
-                                    <input type="checkbox" wire:model.live="items.{{ $index }}.cumple" class="peer sr-only">
-                                    <div class="h-6 w-11 rounded-full bg-gray-300 transition after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-all peer-checked:bg-success-500 peer-checked:after:translate-x-full dark:bg-gray-600 dark:peer-checked:bg-success-500"></div>
-                                </label>
+                                @if ($item['descripcion'] && !$item['cumple'])
+                                    <p class="text-[11px] text-gray-400">{{ $item['descripcion'] }}</p>
+                                @endif
                             </div>
+
+                            {{-- Observation (inline, only when not compliant) --}}
                             @if (!$item['cumple'])
-                                <div class="mt-3">
-                                    <textarea wire:model.blur="items.{{ $index }}.observacion"
-                                              rows="2"
-                                              placeholder="Observacion (por que no cumple)..."
-                                              class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs text-gray-900 shadow-sm placeholder:text-gray-400 dark:border-white/10 dark:bg-white/5 dark:text-white"></textarea>
-                                </div>
+                                <input type="text" wire:model.blur="items.{{ $index }}.observacion"
+                                       placeholder="Observacion..."
+                                       class="w-48 shrink-0 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 dark:border-white/10 dark:bg-white/5 dark:text-gray-300">
+                            @else
+                                <span class="w-48 shrink-0"></span>
                             @endif
                         </div>
                     @endforeach
                 </div>
 
-                {{-- Observaciones generales --}}
-                <div class="mt-4">
-                    <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Observaciones generales</label>
-                    <textarea wire:model="observaciones_generales"
-                              rows="2"
-                              placeholder="Notas adicionales sobre esta verificacion..."
-                              class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white"></textarea>
-                </div>
+                {{-- Footer: observaciones + summary + save --}}
+                <div class="border-t border-gray-200 px-4 py-3 dark:border-white/10">
+                    <div class="flex items-center gap-4">
+                        <input type="text" wire:model="observaciones_generales"
+                               placeholder="Observaciones generales..."
+                               class="flex-1 rounded border border-gray-300 bg-white px-3 py-1.5 text-xs text-gray-700 dark:border-white/10 dark:bg-white/5 dark:text-gray-300">
 
-                {{-- Summary + save --}}
-                <div class="mt-4 flex items-center justify-between border-t border-gray-200 pt-4 dark:border-gray-700">
-                    <div class="text-sm text-gray-500 dark:text-gray-400">
                         @php
                             $cumple = collect($items)->where('cumple', true)->count();
                             $total = count($items);
                             $obligatoriosFallidos = collect($items)->where('obligatorio', true)->where('cumple', false)->count();
                         @endphp
-                        <span class="font-semibold {{ $cumple === $total ? 'text-success-600' : 'text-warning-600' }}">{{ $cumple }}/{{ $total }}</span> items cumplen
-                        @if ($obligatoriosFallidos > 0)
-                            <span class="text-danger-500 font-medium">— {{ $obligatoriosFallidos }} obligatorio(s) sin cumplir</span>
-                        @endif
+
+                        <span class="shrink-0 text-xs {{ $cumple === $total ? 'text-success-600' : 'text-gray-500' }}">
+                            <strong>{{ $cumple }}/{{ $total }}</strong>
+                            @if ($obligatoriosFallidos > 0)
+                                <span class="text-danger-500">({{ $obligatoriosFallidos }} oblig.)</span>
+                            @endif
+                        </span>
+
+                        <x-filament::button wire:click="guardar" wire:loading.attr="disabled" size="sm"
+                                            icon="heroicon-m-check"
+                                            color="{{ $obligatoriosFallidos > 0 ? 'warning' : 'success' }}">
+                            Guardar
+                        </x-filament::button>
                     </div>
-                    <x-filament::button wire:click="guardar" wire:loading.attr="disabled" icon="heroicon-m-check" color="{{ $obligatoriosFallidos > 0 ? 'warning' : 'success' }}">
-                        Guardar checklist
-                    </x-filament::button>
                 </div>
-            </div>
-        @elseif ($plantilla_id)
-            <div class="text-center py-8 text-gray-500">
-                <p>Cargando items...</p>
             </div>
         @endif
     </div>


### PR DESCRIPTION
## Summary
- Fix: selects now use Filament input components (dark mode compatible)
- Fix: items load correctly when selecting plantilla (pure Livewire)
- Compact layout: checkbox + name + observation inline per row
- All items visible without excessive scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)