### PR TITLE
refactor: tema Shadcn completo con colores adaptativos

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -15,7 +15,7 @@ use Filament\Navigation\NavigationItem;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
-use Filament\Support\Colors\Color;
+use Openplain\FilamentShadcnTheme\Color as ShadcnColor;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -49,34 +49,22 @@ class AdminPanelProvider extends PanelProvider
             ->tenant(Empresa::class, slugAttribute: 'ruc')
             ->tenantRegistration(false)
             ->colors([
-                'primary' => Color::Indigo,
-                'danger' => Color::Rose,
-                'info' => Color::Sky,
-                'success' => Color::Emerald,
-                'warning' => Color::Amber,
+                'primary' => ShadcnColor::Violet,
+                'danger' => ShadcnColor::Red,
+                'info' => ShadcnColor::Blue,
+                'success' => ShadcnColor::Green,
+                'warning' => ShadcnColor::Orange,
             ])
             ->font('Inter')
             ->sidebarCollapsibleOnDesktop()
             ->sidebarWidth('16rem')
             ->collapsedSidebarWidth('4.5rem')
             ->navigationGroups([
-                NavigationGroup::make('Soporte')
-                    ->icon('heroicon-o-lifebuoy')
-                    ->collapsible(),
-                NavigationGroup::make('Reportes')
-                    ->icon('heroicon-o-chart-bar')
-                    ->collapsible()
-                    ->collapsed(),
-                NavigationGroup::make('Activos')
-                    ->icon('heroicon-o-computer-desktop')
-                    ->collapsible(),
-                NavigationGroup::make('Seguridad')
-                    ->icon('heroicon-o-shield-check')
-                    ->collapsible(),
-                NavigationGroup::make('Administración')
-                    ->icon('heroicon-o-cog-6-tooth')
-                    ->collapsible()
-                    ->collapsed(),
+                NavigationGroup::make('Soporte')->collapsible(),
+                NavigationGroup::make('Reportes')->collapsible()->collapsed(),
+                NavigationGroup::make('Activos')->collapsible(),
+                NavigationGroup::make('Seguridad')->collapsible(),
+                NavigationGroup::make('Administración')->collapsible()->collapsed(),
             ])
             ->globalSearch(true)
             ->globalSearchKeyBindings(['command+k', 'ctrl+k'])

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -3,51 +3,11 @@
 @source '../../../../app/Filament/**/*.php';
 @source '../../../../resources/views/filament/**/*.blade.php';
 
-/* Sidebar refinements */
-.fi-sidebar {
-    border-right: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.fi-sidebar-nav {
-    padding: 0.5rem;
-}
-
-.fi-sidebar-item a {
-    border-radius: 0.5rem;
-    transition: all 0.15s ease;
-}
+/* Minimal overrides — Shadcn theme handles the rest */
 
 .fi-sidebar-group-label {
     font-size: 0.65rem;
     letter-spacing: 0.05em;
     text-transform: uppercase;
     font-weight: 600;
-    padding: 0.5rem 0.75rem 0.25rem;
-}
-
-/* Topbar refinements */
-.fi-topbar {
-    backdrop-filter: blur(12px);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-/* Card refinements */
-.fi-section {
-    border-radius: 0.75rem;
-}
-
-/* Table row hover */
-.fi-ta-row:hover {
-    transition: background-color 0.15s ease;
-}
-
-/* Badge refinements */
-.fi-badge {
-    font-weight: 600;
-    letter-spacing: 0.01em;
-}
-
-/* Smooth page transitions */
-.fi-main {
-    transition: padding 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- Shadcn adaptive colors: Violet, Red, Blue, Green, Orange (change between light/dark)
- Removed custom CSS overrides that conflicted with Shadcn
- Removed navigation group icons (Filament 5 conflict)
- Consistent theme across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)