### PR TITLE
feat: registro create — catalogo visual de formatos

### DIFF
--- a/app/Filament/Resources/Registros/Pages/CreateRegistro.php
+++ b/app/Filament/Resources/Registros/Pages/CreateRegistro.php
@@ -20,7 +20,10 @@ class CreateRegistro extends CreateRecord
 
         \Filament\Support\Facades\FilamentView::registerRenderHook(
             PanelsRenderHook::HEAD_END,
-            fn () => new HtmlString('<style>.fi-grid.lg\:fi-grid-cols { columns: 1 !important; }</style>'),
+            fn () => new HtmlString('<style>
+                .fi-sc-form .fi-grid.lg\:fi-grid-cols { display: grid !important; columns: unset !important; break-inside: unset !important; }
+                .fi-sc-form .fi-grid.lg\:fi-grid-cols > * { break-inside: unset !important; margin-bottom: 0 !important; }
+            </style>'),
         );
     }
 

--- a/app/Filament/Resources/Registros/Schemas/RegistroForm.php
+++ b/app/Filament/Resources/Registros/Schemas/RegistroForm.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Illuminate\Support\HtmlString;
@@ -19,52 +20,160 @@ class RegistroForm
         return $schema
             ->columns(1)
             ->components([
-                Section::make('Tipo de registro')
+                // Full-width catalog when no format selected (create only)
+                Section::make('Selecciona un formato de seguridad')
                     ->icon('heroicon-o-document-text')
-                    ->description('Selecciona el formato de seguridad que deseas registrar.')
+                    ->description('Elige el tipo de registro que deseas crear. Cada formato corresponde a una politica de seguridad.')
                     ->schema([
-                        Select::make('tipo_formato')
-                            ->label('Formato de seguridad')
-                            ->options(TipoFormato::options())
-                            ->required()
-                            ->live()
-                            ->searchable()
-                            ->disabled(fn (string $operation): bool => $operation === 'edit')
-                            ->columnSpanFull(),
-                        Placeholder::make('formato_info')
+                        Placeholder::make('formato_catalog')
                             ->label('')
-                            ->content(function (Get $get): ?HtmlString {
-                                $tipo = TipoFormato::tryFrom($get('tipo_formato') ?? '');
-                                if (! $tipo) {
-                                    return null;
-                                }
-
-                                return new HtmlString(
-                                    '<div class="rounded-lg border border-primary-200 bg-primary-50 p-3 dark:border-primary-800 dark:bg-primary-950/50">'
-                                    . '<p class="text-sm font-semibold text-primary-700 dark:text-primary-400">' . e($tipo->label()) . '</p>'
-                                    . '<p class="mt-1 text-xs text-primary-600 dark:text-primary-500">' . e($tipo->description()) . '</p>'
-                                    . '<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Politica: ' . e($tipo->psc()) . '</p>'
-                                    . '</div>'
-                                );
-                            })
-                            ->visible(fn (Get $get): bool => filled($get('tipo_formato')))
+                            ->hiddenLabel()
+                            ->content(fn () => new HtmlString(self::buildCatalogHtml()))
                             ->columnSpanFull(),
-                        TextInput::make('numero_registro')
-                            ->label('N° Registro')
-                            ->disabled()
-                            ->dehydrated()
-                            ->helperText('Se genera automaticamente al guardar.')
-                            ->columnSpanFull(),
-                    ])->columns(1),
+                    ])
+                    ->visible(fn (Get $get, string $operation): bool => $operation === 'create' && ! filled($get('tipo_formato')))
+                    ->columnSpanFull(),
 
-                Section::make(fn (Get $get): string => self::getSectionTitle($get('tipo_formato')))
-                    ->icon('heroicon-o-clipboard-document-list')
-                    ->description(fn (Get $get): ?string => self::getSectionDescription($get('tipo_formato')))
-                    ->schema(fn (Get $get): array => self::getDynamicFields($get('tipo_formato')))
-                    ->visible(fn (Get $get): bool => filled($get('tipo_formato')))
-                    ->columns(2)
-                    ->collapsible(),
+                // Hidden select to hold the value
+                Select::make('tipo_formato')
+                    ->label('Formato')
+                    ->options(TipoFormato::options())
+                    ->required()
+                    ->live()
+                    ->searchable()
+                    ->disabled(fn (string $operation): bool => $operation === 'edit')
+                    ->hidden(fn (string $operation): bool => $operation === 'create')
+                    ->columnSpanFull(),
+
+                // 2-column layout when format IS selected
+                Grid::make([
+                    'default' => 1,
+                    'lg' => 7,
+                ])
+                ->visible(fn (Get $get): bool => filled($get('tipo_formato')))
+                ->schema([
+                    // Left column — selected format + mini selector
+                    Section::make('Formato seleccionado')
+                        ->icon('heroicon-o-document-text')
+                        ->schema([
+                            Placeholder::make('formato_selected')
+                                ->label('')
+                                ->hiddenLabel()
+                                ->content(function (Get $get): ?HtmlString {
+                                    $tipo = TipoFormato::tryFrom($get('tipo_formato') ?? '');
+                                    if (! $tipo) {
+                                        return null;
+                                    }
+
+                                    $html = '<div class="rounded-lg border border-primary-500 dark:border-primary-500 bg-primary-50/50 dark:bg-primary-500/5 p-4 mb-3">'
+                                        . '<div class="flex items-center gap-2 mb-2">'
+                                        . '<span class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary-100 dark:bg-primary-500/20 text-xs font-bold text-primary-700 dark:text-primary-300">' . e($tipo->value) . '</span>'
+                                        . '<p class="text-sm font-bold text-gray-900 dark:text-white">' . e(str_replace($tipo->value . ' - ', '', $tipo->label())) . '</p>'
+                                        . '</div>'
+                                        . '<p class="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">' . e($tipo->description()) . '</p>'
+                                        . '<p class="mt-2 text-[11px] font-medium text-gray-400 dark:text-gray-500">Politica: ' . e($tipo->psc()) . '</p>'
+                                        . '</div>'
+                                        . '<button type="button" wire:click="$set(\'data.tipo_formato\', null)" '
+                                        . 'class="w-full text-center text-xs text-primary-600 dark:text-primary-400 hover:underline cursor-pointer py-1">'
+                                        . '← Cambiar formato</button>';
+
+                                    return new HtmlString($html);
+                                })
+                                ->visible(fn (string $operation): bool => $operation === 'create')
+                                ->columnSpanFull(),
+                            TextInput::make('numero_registro')
+                                ->label('N° Registro')
+                                ->disabled()
+                                ->dehydrated()
+                                ->helperText('Se genera automaticamente al guardar.')
+                                ->columnSpanFull(),
+                        ])
+                        ->columns(1)
+                        ->columnSpan(['default' => 1, 'lg' => 2]),
+
+                    // Right column — dynamic form
+                    Section::make(fn (Get $get): string => self::getSectionTitle($get('tipo_formato')))
+                        ->icon('heroicon-o-clipboard-document-list')
+                        ->description(fn (Get $get): ?string => self::getSectionDescription($get('tipo_formato')))
+                        ->schema(fn (Get $get): array => self::getDynamicFields($get('tipo_formato')))
+                        ->columns(2)
+                        ->collapsible()
+                        ->columnSpan(['default' => 1, 'lg' => 5]),
+                ]),
             ]);
+    }
+
+    private static function buildCatalogHtml(): string
+    {
+        $groups = [
+            'Datos y acceso' => [TipoFormato::F02, TipoFormato::F04, TipoFormato::F05, TipoFormato::F03],
+            'Soportes y activos' => [TipoFormato::F07, TipoFormato::F08, TipoFormato::F12, TipoFormato::F13],
+            'Incidencias' => [TipoFormato::F09, TipoFormato::F10, TipoFormato::F11],
+            'Auditoria y control' => [TipoFormato::F01, TipoFormato::F06],
+        ];
+
+        $icons = [
+            'Datos y acceso' => '&#x1F4BE;',
+            'Soportes y activos' => '&#x1F4E6;',
+            'Incidencias' => '&#x26A0;',
+            'Auditoria y control' => '&#x1F50D;',
+        ];
+
+        $html = '<style>'
+            . '.fmt-card{cursor:pointer;border-radius:12px;border:1px solid rgba(255,255,255,0.08);padding:20px;transition:all 0.15s ease;position:relative;overflow:hidden;}'
+            . '.fmt-card:hover{border-color:#8b5cf6;background:rgba(139,92,246,0.04);}'
+            . '.fmt-card:active{opacity:0.85;}'
+            . '.fmt-card:hover .fmt-badge{background:rgba(139,92,246,0.2);color:#c4b5fd;}'
+            . '.fmt-card:hover .fmt-title{color:#c4b5fd;}'
+            . '</style>'
+            . '<div x-data="{ search: \'\' }" style="display:flex;flex-direction:column;gap:40px;padding:8px 0;">'
+            . '<div style="position:sticky;top:0;z-index:10;padding-bottom:8px;">'
+            . '<label class="text-sm font-medium text-gray-700 dark:text-gray-300" style="display:block;margin-bottom:6px;">Buscar formato</label>'
+            . '<div style="position:relative;">'
+            . '<svg style="position:absolute;left:12px;top:50%;transform:translateY(-50%);width:16px;height:16px;" class="text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" /></svg>'
+            . '<input type="text" x-model="search" placeholder="Escribe el codigo, nombre o palabra clave..." '
+            . 'class="w-full rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 py-2.5 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 outline-none transition" style="padding-left:36px;padding-right:16px;" />'
+            . '</div>'
+            . '</div>';
+
+        foreach ($groups as $groupName => $formatos) {
+            $icon = $icons[$groupName] ?? '';
+            $searchTerms = collect($formatos)->map(fn ($t) => strtolower($t->value . ' ' . $t->label() . ' ' . $t->description() . ' ' . $t->psc()));
+            $html .= '<div x-show="!' . "search || " . collect($formatos)->map(fn ($t) => "'" . strtolower($t->value . ' ' . str_replace("'", "", $t->label()) . ' ' . str_replace("'", "", $t->description())) . "'.includes(search.toLowerCase())")->implode(' || ') . '" x-cloak>'
+                . '<div style="display:flex;align-items:center;gap:10px;margin-bottom:16px;padding-bottom:8px;border-bottom:1px solid rgba(255,255,255,0.05);">'
+                . '<span style="font-size:16px;">' . $icon . '</span>'
+                . '<h3 class="text-sm font-bold text-gray-800 dark:text-gray-200 uppercase tracking-wide">' . e($groupName) . '</h3>'
+                . '<span class="text-[10px] text-gray-400 dark:text-gray-500 font-medium">' . count($formatos) . ' formatos</span>'
+                . '</div>'
+                . '<div style="display:grid;grid-template-columns:repeat(2,1fr);gap:16px;">';
+
+            foreach ($formatos as $tipo) {
+                $searchStr = strtolower($tipo->value . ' ' . str_replace("'", "", $tipo->label()) . ' ' . str_replace("'", "", $tipo->description()));
+                $html .= '<div wire:click="$set(\'data.tipo_formato\', \'' . $tipo->value . '\')" '
+                    . 'x-show="!search || \'' . $searchStr . '\'.includes(search.toLowerCase())" x-cloak '
+                    . 'class="fmt-card">'
+                    // Badge code top-right
+                    . '<div style="position:absolute;top:16px;right:16px;">'
+                    . '<span class="fmt-badge" style="display:inline-flex;align-items:center;border-radius:6px;background:rgba(255,255,255,0.05);padding:2px 8px;font-size:10px;font-weight:700;color:rgba(255,255,255,0.4);transition:all 0.15s;">' . e($tipo->value) . '</span>'
+                    . '</div>'
+                    // Title
+                    . '<p class="fmt-title" style="font-size:14px;font-weight:700;color:#fff;line-height:1.3;padding-right:50px;transition:color 0.15s;">' . e(str_replace($tipo->value . ' - ', '', $tipo->label())) . '</p>'
+                    // Description
+                    . '<p style="font-size:12px;color:rgba(255,255,255,0.45);line-height:1.6;margin-top:10px;">' . e($tipo->description()) . '</p>'
+                    // Policy footer
+                    . '<div style="display:flex;align-items:center;gap:6px;margin-top:14px;">'
+                    . '<svg style="width:12px;height:12px;color:rgba(255,255,255,0.3);" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" /></svg>'
+                    . '<span style="font-size:10px;font-weight:500;color:rgba(255,255,255,0.3);">' . e($tipo->psc()) . '</span>'
+                    . '</div>'
+                    . '</div>';
+            }
+
+            $html .= '</div></div>';
+        }
+
+        $html .= '</div>';
+
+        return $html;
     }
 
     private static function getDynamicFields(?string $tipo): array

--- a/app/Services/FormatoFieldsService.php
+++ b/app/Services/FormatoFieldsService.php
@@ -45,18 +45,18 @@ class FormatoFieldsService
                 ->options(['conforme' => 'Conforme', 'no_conforme' => 'No conforme', 'con_observaciones' => 'Con observaciones'])->required(),
             Select::make('datos.acciones_correctivas')->label('Acciones correctivas')
                 ->options(['si' => 'Si', 'no' => 'No'])->required(),
-            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3)->columnSpanFull(),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(4)->columnSpanFull(),
         ];
     }
 
     private static function f02(): array
     {
         return [
-            TextInput::make('datos.nombre_bd')->label('Nombre del banco de datos')->required()->columnSpanFull(),
+            TextInput::make('datos.nombre_bd')->label('Nombre del banco de datos')->required(),
             TextInput::make('datos.codigo_registro')->label('Codigo / Registro'),
             Select::make('datos.categoria')->label('Categoria / Nivel')
                 ->options(['publica' => 'Publica', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
-            Textarea::make('datos.descripcion')->label('Descripcion')->rows(3)->required()->columnSpanFull(),
+            Textarea::make('datos.descripcion')->label('Descripcion')->rows(4)->required()->columnSpanFull(),
             TagsInput::make('datos.areas_acceso')->label('Unidades / Areas con acceso')->columnSpanFull(),
         ];
     }
@@ -64,25 +64,25 @@ class FormatoFieldsService
     private static function f03(): array
     {
         return [
-            TextInput::make('datos.prestador')->label('Prestador del servicio')->required()->columnSpanFull(),
-            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2)->required()->columnSpanFull(),
-            TagsInput::make('datos.datos_facilitados')->label('Datos facilitados (tipo)')->columnSpanFull(),
+            TextInput::make('datos.prestador')->label('Prestador del servicio')->required(),
             DatePicker::make('datos.fecha_contrato')->label('Fecha de contrato'),
             DatePicker::make('datos.vigencia')->label('Vigencia'),
-            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3)->columnSpanFull(),
+            Textarea::make('datos.finalidad')->label('Finalidad')->rows(4)->required()->columnSpanFull(),
+            TagsInput::make('datos.datos_facilitados')->label('Datos facilitados (tipo)')->columnSpanFull(),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(4)->columnSpanFull(),
         ];
     }
 
     private static function f04(): array
     {
         return [
-            TextInput::make('datos.nombre')->label('Nombre')->required()->columnSpanFull(),
-            Textarea::make('datos.descripcion')->label('Descripcion')->rows(3)->required()->columnSpanFull(),
+            TextInput::make('datos.nombre')->label('Nombre')->required(),
             Select::make('datos.ubicacion_tipo')->label('Ubicacion tipo')
                 ->options(['fisica' => 'Fisica', 'digital' => 'Digital', 'mixta' => 'Mixta'])->required(),
-            TextInput::make('datos.ubicacion_detalle')->label('Ubicacion detalle'),
             Select::make('datos.categoria')->label('Categoria / Nivel')
                 ->options(['publica' => 'Publica', 'interna' => 'Interna', 'confidencial' => 'Confidencial', 'sensible' => 'Sensible'])->required(),
+            TextInput::make('datos.ubicacion_detalle')->label('Ubicacion detalle')->columnSpanFull(),
+            Textarea::make('datos.descripcion')->label('Descripcion')->rows(4)->required()->columnSpanFull(),
             TagsInput::make('datos.areas_acceso')->label('Usuarios / Areas con acceso')->columnSpanFull(),
         ];
     }
@@ -92,17 +92,17 @@ class FormatoFieldsService
         return [
             TextInput::make('datos.usuario')->label('Usuario')->required(),
             TextInput::make('datos.banco_datos')->label('Banco de datos')->required(),
-            DateTimePicker::make('datos.fecha_asignacion')->label('Fecha y hora de asignacion')->required()->columnSpanFull(),
+            DateTimePicker::make('datos.fecha_asignacion')->label('Fecha y hora de asignacion')->required(),
         ];
     }
 
     private static function f06(): array
     {
         return [
-            TextInput::make('datos.persona_accede')->label('Persona que accede')->required()->columnSpanFull(),
-            Textarea::make('datos.descripcion_soporte')->label('Descripcion del soporte')->rows(3)->required()->columnSpanFull(),
+            TextInput::make('datos.persona_accede')->label('Persona que accede')->required(),
             DatePicker::make('datos.fecha_acceso')->label('Fecha de acceso')->required(),
             TimePicker::make('datos.hora_acceso')->label('Hora de acceso')->required(),
+            Textarea::make('datos.descripcion_soporte')->label('Descripcion del soporte')->rows(4)->required()->columnSpanFull(),
         ];
     }
 
@@ -116,8 +116,8 @@ class FormatoFieldsService
                     'dvd' => 'DVD', 'expediente_fisico' => 'Expediente fisico', 'otro' => 'Otro',
                 ])->required(),
             TextInput::make('datos.ubicacion')->label('Ubicacion')->required(),
-            Textarea::make('datos.contenido')->label('Contenido')->rows(3)->required()->columnSpanFull(),
             DatePicker::make('datos.fecha_inventariado')->label('Fecha de inventariado')->required(),
+            Textarea::make('datos.contenido')->label('Contenido')->rows(4)->required()->columnSpanFull(),
         ];
     }
 
@@ -132,14 +132,14 @@ class FormatoFieldsService
             Select::make('datos.estado_soporte')->label('Estado del soporte')
                 ->options(['bueno' => 'Bueno', 'regular' => 'Regular', 'malo' => 'Malo'])->required(),
             TextInput::make('datos.banco_datos')->label('Banco de datos'),
-            Textarea::make('datos.contenido')->label('Contenido')->rows(2)->columnSpanFull(),
             TextInput::make('datos.origen_remitente')->label('Origen / Remitente'),
             TextInput::make('datos.destinatario')->label('Destinatario'),
-            Textarea::make('datos.finalidad')->label('Finalidad')->rows(2)->columnSpanFull(),
             TextInput::make('datos.medio_transporte')->label('Medio de transporte'),
+            Textarea::make('datos.contenido')->label('Contenido')->rows(4)->columnSpanFull(),
+            Textarea::make('datos.finalidad')->label('Finalidad')->rows(4)->columnSpanFull(),
             TextInput::make('datos.autoriza')->label('Autoriza'),
             TextInput::make('datos.recibe')->label('Recibe'),
-            Textarea::make('datos.precauciones')->label('Precauciones')->rows(2)->columnSpanFull(),
+            Textarea::make('datos.precauciones')->label('Precauciones')->rows(4)->columnSpanFull(),
         ];
     }
 
@@ -153,14 +153,14 @@ class FormatoFieldsService
                     'fuga_informacion' => 'Fuga de informacion', 'malware' => 'Malware/Virus',
                     'fallo_sistema' => 'Fallo de sistema', 'otro' => 'Otro',
                 ])->required(),
-            TextInput::make('datos.sistema_equipo')->label('Sistema / Equipo / Lugar'),
-            TextInput::make('datos.banco_datos')->label('Banco de datos'),
-            RichEditor::make('datos.descripcion')->label('Descripcion')->required()->columnSpanFull(),
-            Textarea::make('datos.medidas_inmediatas')->label('Medidas inmediatas')->rows(3)->columnSpanFull(),
-            TagsInput::make('datos.personas_notificadas')->label('Personas notificadas'),
             Select::make('datos.severidad')->label('Severidad')
                 ->options(['alta' => 'Alta', 'media' => 'Media', 'baja' => 'Baja'])->required(),
-            Textarea::make('datos.impacto_potencial')->label('Impacto potencial')->rows(2)->columnSpanFull(),
+            TextInput::make('datos.sistema_equipo')->label('Sistema / Equipo / Lugar'),
+            TextInput::make('datos.banco_datos')->label('Banco de datos'),
+            TagsInput::make('datos.personas_notificadas')->label('Personas notificadas'),
+            RichEditor::make('datos.descripcion')->label('Descripcion')->required()->columnSpanFull(),
+            Textarea::make('datos.medidas_inmediatas')->label('Medidas inmediatas')->rows(4)->columnSpanFull(),
+            Textarea::make('datos.impacto_potencial')->label('Impacto potencial')->rows(4)->columnSpanFull(),
             TextInput::make('datos.comunica_nombre')->label('Comunica (nombre y cargo)')->columnSpanFull(),
         ];
     }
@@ -172,12 +172,12 @@ class FormatoFieldsService
             DateTimePicker::make('datos.fecha_cierre')->label('Fecha / Hora de cierre')->required(),
             Select::make('datos.clasificacion')->label('Clasificacion')
                 ->options(['baja' => 'Baja', 'media' => 'Media', 'alta' => 'Alta'])->required(),
-            Toggle::make('datos.requirio_recuperacion')->label('Requirio recuperacion'),
-            Textarea::make('datos.medidas_adoptadas')->label('Medidas adoptadas')->rows(3)->required()->columnSpanFull(),
-            Textarea::make('datos.resultado_verificacion')->label('Resultado / Verificacion')->rows(3)->columnSpanFull(),
             TextInput::make('datos.ejecuto')->label('Ejecuto (nombre y cargo)'),
             TextInput::make('datos.firma_responsable')->label('Firma responsable de seguridad'),
-            Textarea::make('datos.acciones_preventivas')->label('Acciones preventivas')->rows(3)->columnSpanFull(),
+            Toggle::make('datos.requirio_recuperacion')->label('Requirio recuperacion'),
+            Textarea::make('datos.medidas_adoptadas')->label('Medidas adoptadas')->rows(4)->required()->columnSpanFull(),
+            Textarea::make('datos.resultado_verificacion')->label('Resultado / Verificacion')->rows(4)->columnSpanFull(),
+            Textarea::make('datos.acciones_preventivas')->label('Acciones preventivas')->rows(4)->columnSpanFull(),
         ];
     }
 
@@ -186,32 +186,31 @@ class FormatoFieldsService
         return [
             TextInput::make('datos.incidencia_relacionada')->label('Incidencia relacionada'),
             DateTimePicker::make('datos.fecha_realizacion')->label('Fecha / Hora de realizacion')->required(),
-            Toggle::make('datos.autorizacion_escrita')->label('Autorizacion por escrito'),
             TextInput::make('datos.responsable_bd')->label('Responsable BD que autoriza'),
-            Textarea::make('datos.proceso_realizado')->label('Proceso realizado')->rows(3)->required()->columnSpanFull(),
-            TextInput::make('datos.persona_ejecutora')->label('Persona ejecutora')->columnSpanFull(),
-            Textarea::make('datos.observaciones')->label('Observaciones')->rows(3)->columnSpanFull(),
+            TextInput::make('datos.persona_ejecutora')->label('Persona ejecutora'),
+            Toggle::make('datos.autorizacion_escrita')->label('Autorizacion por escrito'),
+            Textarea::make('datos.proceso_realizado')->label('Proceso realizado')->rows(4)->required()->columnSpanFull(),
+            Textarea::make('datos.observaciones')->label('Observaciones')->rows(4)->columnSpanFull(),
         ];
     }
 
     private static function f12(): array
     {
         return [
-            TextInput::make('datos.nombre_backup')->label('Nombre del backup')->required()->columnSpanFull(),
-            Textarea::make('datos.descripcion_contenido')->label('Descripcion del contenido')->rows(3)->required()->columnSpanFull(),
+            TextInput::make('datos.nombre_backup')->label('Nombre del backup')->required(),
             DatePicker::make('datos.fecha_copia')->label('Fecha de copia')->required(),
             Select::make('datos.periodicidad')->label('Periodicidad')
                 ->options([
                     'diaria' => 'Diaria', 'semanal' => 'Semanal', 'quincenal' => 'Quincenal',
                     'mensual' => 'Mensual', 'trimestral' => 'Trimestral', 'puntual' => 'Puntual',
                 ])->required(),
+            Textarea::make('datos.descripcion_contenido')->label('Descripcion del contenido')->rows(4)->required()->columnSpanFull(),
         ];
     }
 
     private static function f13(): array
     {
         return [
-            Textarea::make('datos.descripcion_activo')->label('Descripcion del activo')->rows(3)->required()->columnSpanFull(),
             DatePicker::make('datos.fecha_destruccion')->label('Fecha de destruccion')->required(),
             Select::make('datos.metodo')->label('Metodo de destruccion')
                 ->options([
@@ -219,9 +218,10 @@ class FormatoFieldsService
                     'desmagnetizacion' => 'Desmagnetizacion', 'incineracion' => 'Incineracion',
                     'trituracion' => 'Trituracion', 'proveedor_certificado' => 'Proveedor certificado',
                 ])->required(),
+            DatePicker::make('datos.proxima_revision')->label('Proxima revision'),
             TextInput::make('datos.responsable')->label('Responsable')->required(),
             TextInput::make('datos.autoriza')->label('Autoriza')->required(),
-            DatePicker::make('datos.proxima_revision')->label('Proxima revision'),
+            Textarea::make('datos.descripcion_activo')->label('Descripcion del activo')->rows(4)->required()->columnSpanFull(),
         ];
     }
 }


### PR DESCRIPTION
## Summary
- **Catalogo de formatos**: vista full-width con 13 formatos organizados en 4 categorias, cards clickeables con titulo, descripcion y politica PSC
- **Buscador**: filtrado en tiempo real por codigo, nombre o palabra clave (Alpine.js, sin request)
- **Layout 2 columnas**: al seleccionar formato, sidebar con info (2/7) + formulario dinamico (5/7)
- **Campos mejorados**: inputs cortos en 2 columnas, textareas con mas height, orden logico por formato

## Test plan
- [ ] Verificar catalogo muestra los 13 formatos agrupados correctamente
- [ ] Verificar buscador filtra cards en tiempo real
- [ ] Verificar click en card abre formulario con layout 2 columnas
- [ ] Verificar "Cambiar formato" vuelve al catalogo
- [ ] Verificar formularios de todos los formatos (F01-F13) renderizan correctamente
- [ ] Verificar dark/light mode compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)