### PR TITLE
[EP-16] feat: Sistema NDA — vigencia, firma y PDF por firmante

### DIFF
--- a/app/Filament/Pages/AceptarPoliticas.php
+++ b/app/Filament/Pages/AceptarPoliticas.php
@@ -6,6 +6,7 @@ use App\Models\AceptacionPolitica;
 use App\Models\Politica;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Illuminate\Support\Str;
 use Livewire\WithFileUploads;
 
 class AceptarPoliticas extends Page
@@ -95,7 +96,7 @@ class AceptarPoliticas extends Page
             return;
         }
 
-        AceptacionPolitica::create([
+        $data = [
             'user_id' => auth()->id(),
             'politica_id' => $this->politicaActual->id,
             'version_aceptada' => $this->politicaActual->version,
@@ -105,7 +106,14 @@ class AceptarPoliticas extends Page
             'firma_imagen' => $firmaImagen,
             'firma_nombre' => $this->firmaNombre,
             'firma_cargo' => $this->firmaCargo,
-        ]);
+        ];
+
+        // Calculate expiration for NDAs with vigencia
+        if ($this->politicaActual->es_nda && $this->politicaActual->vigencia_meses) {
+            $data['fecha_expiracion'] = now()->addMonths($this->politicaActual->vigencia_meses);
+        }
+
+        AceptacionPolitica::create($data);
 
         // Save signature for reuse
         $user = auth()->user();
@@ -133,5 +141,39 @@ class AceptarPoliticas extends Page
     public function limpiarFirma(): void
     {
         $this->firmaDataUrl = '';
+    }
+
+    /**
+     * Get rendered content for the current policy.
+     * For NDAs: parse markdown and replace placeholders with user data.
+     * For regular policies: return HTML content as-is.
+     */
+    public function getContenidoRenderizado(): string
+    {
+        if (! $this->politicaActual) {
+            return '';
+        }
+
+        $contenido = $this->politicaActual->contenido;
+
+        if ($this->politicaActual->es_nda) {
+            $user = auth()->user();
+
+            $contenido = str_replace(
+                ['{nombre_completo}', '{dni}', '{direccion}', '{telefono}', '{puesto}'],
+                [
+                    e($user->name),
+                    e($user->dni ?? '___________'),
+                    e($user->direccion ?? '___________'),
+                    e($user->telefono ?? '___________'),
+                    e($user->puesto ?? '___________'),
+                ],
+                $contenido
+            );
+
+            return Str::markdown($contenido);
+        }
+
+        return $contenido;
     }
 }

--- a/app/Filament/Pages/CompletarDatosNda.php
+++ b/app/Filament/Pages/CompletarDatosNda.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\Politica;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class CompletarDatosNda extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-identification';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected static ?string $title = 'Completar datos personales';
+
+    protected static ?string $slug = 'completar-datos-nda';
+
+    protected string $view = 'filament.pages.completar-datos-nda';
+
+    public string $dni = '';
+
+    public string $direccion = '';
+
+    public string $telefono = '';
+
+    public string $puesto = '';
+
+    public function mount(): void
+    {
+        $user = auth()->user();
+
+        if (! $user->empresa_id) {
+            $this->redirect('/admin');
+
+            return;
+        }
+
+        // Pre-fill with existing data
+        $this->dni = $user->dni ?? '';
+        $this->direccion = $user->direccion ?? '';
+        $this->telefono = $user->telefono ?? '';
+        $this->puesto = $user->puesto ?? '';
+
+        // If user already has all data, skip to acceptance
+        if ($this->datosCompletos()) {
+            $ruc = $user->empresa?->ruc ?? '';
+            $this->redirect("/admin/{$ruc}/aceptar-politicas");
+
+            return;
+        }
+    }
+
+    public function guardar(): void
+    {
+        $this->validate([
+            'dni' => 'required|string|max:20',
+            'direccion' => 'required|string|max:500',
+            'telefono' => 'required|string|max:30',
+            'puesto' => 'required|string|max:255',
+        ], [
+            'dni.required' => 'El DNI es obligatorio.',
+            'direccion.required' => 'La direccion es obligatoria.',
+            'telefono.required' => 'El telefono es obligatorio.',
+            'puesto.required' => 'El puesto es obligatorio.',
+        ]);
+
+        $user = auth()->user();
+        $user->update([
+            'dni' => $this->dni,
+            'direccion' => $this->direccion,
+            'telefono' => $this->telefono,
+            'puesto' => $this->puesto,
+        ]);
+
+        Notification::make()
+            ->title('Datos guardados correctamente')
+            ->success()
+            ->send();
+
+        $ruc = $user->empresa?->ruc ?? '';
+        $this->redirect("/admin/{$ruc}/aceptar-politicas");
+    }
+
+    private function datosCompletos(): bool
+    {
+        $user = auth()->user();
+
+        return filled($user->dni)
+            && filled($user->direccion)
+            && filled($user->telefono)
+            && filled($user->puesto);
+    }
+
+    public function getNdaPendiente(): ?Politica
+    {
+        $user = auth()->user();
+
+        return Politica::where('empresa_id', $user->empresa_id)
+            ->where('es_nda', true)
+            ->where('obligatoria', true)
+            ->where('activa', true)
+            ->whereDoesntHave('aceptaciones', function ($q) use ($user) {
+                $q->where('user_id', $user->id)
+                    ->whereColumn('aceptaciones_politica.version_aceptada', 'politicas.version')
+                    ->where(function ($v) {
+                        $v->whereNull('fecha_expiracion')
+                            ->orWhere('fecha_expiracion', '>', now());
+                    });
+            })
+            ->first();
+    }
+}

--- a/app/Filament/Resources/Politicas/Pages/ViewNdaFirmantes.php
+++ b/app/Filament/Resources/Politicas/Pages/ViewNdaFirmantes.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\Resources\Politicas\Pages;
+
+use App\Filament\Resources\Politicas\PoliticaResource;
+use App\Models\AceptacionPolitica;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\Page;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+
+class ViewNdaFirmantes extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string $resource = PoliticaResource::class;
+
+    protected static ?string $title = 'Firmantes NDA';
+
+    protected string $view = 'filament.resources.politicas.pages.view-nda-firmantes';
+
+    public $record;
+
+    public function mount(int|string $record): void
+    {
+        $this->record = \App\Models\Politica::findOrFail($record);
+    }
+
+    public function getTitle(): string
+    {
+        return 'Firmantes — ' . $this->record->titulo;
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return 'Firmantes';
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                AceptacionPolitica::query()
+                    ->where('politica_id', $this->record->id)
+                    ->with('user')
+            )
+            ->columns([
+                TextColumn::make('user.name')
+                    ->label('Nombre')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('user.dni')
+                    ->label('DNI'),
+                TextColumn::make('user.puesto')
+                    ->label('Puesto'),
+                TextColumn::make('version_aceptada')
+                    ->label('Version')
+                    ->badge()
+                    ->color('info'),
+                TextColumn::make('fecha_aceptacion')
+                    ->label('Fecha firma')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+                TextColumn::make('fecha_expiracion')
+                    ->label('Expira')
+                    ->dateTime('d/m/Y')
+                    ->sortable()
+                    ->placeholder('Sin vigencia'),
+                IconColumn::make('vigente')
+                    ->label('Vigente')
+                    ->state(fn (AceptacionPolitica $record) => $record->estaVigente())
+                    ->boolean(),
+            ])
+            ->defaultSort('fecha_aceptacion', 'desc')
+            ->recordActions([
+                \Filament\Actions\Action::make('descargar_pdf')
+                    ->label('PDF')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('info')
+                    ->url(fn (AceptacionPolitica $record) => route('politicas.nda-firmante-pdf', [
+                        'politica' => $this->record,
+                        'aceptacion' => $record,
+                    ]))
+                    ->openUrlInNewTab(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Politicas/PoliticaResource.php
+++ b/app/Filament/Resources/Politicas/PoliticaResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Politicas;
 use App\Filament\Resources\Politicas\Pages\CreatePolitica;
 use App\Filament\Resources\Politicas\Pages\EditPolitica;
 use App\Filament\Resources\Politicas\Pages\ListPoliticas;
+use App\Filament\Resources\Politicas\Pages\ViewNdaFirmantes;
 use App\Filament\Resources\Politicas\RelationManagers\VersionesRelationManager;
 use App\Models\Politica;
 use BackedEnum;
@@ -165,6 +166,13 @@ class PoliticaResource extends Resource
                 IconColumn::make('activa')
                     ->label('Activa')
                     ->boolean(),
+                IconColumn::make('es_nda')
+                    ->label('NDA')
+                    ->boolean()
+                    ->trueIcon('heroicon-o-lock-closed')
+                    ->falseIcon('heroicon-o-minus')
+                    ->trueColor('warning')
+                    ->falseColor('gray'),
                 IconColumn::make('archivo_path')
                     ->label('Doc')
                     ->icon(fn ($state) => $state ? 'heroicon-o-document-text' : null)
@@ -201,6 +209,12 @@ class PoliticaResource extends Resource
                     ->color('gray')
                     ->url(fn ($record) => route('politicas.pdf', $record))
                     ->openUrlInNewTab(),
+                Action::make('ver_firmantes')
+                    ->label('Firmantes')
+                    ->icon('heroicon-o-users')
+                    ->color('warning')
+                    ->visible(fn ($record) => $record->es_nda)
+                    ->url(fn ($record) => static::getUrl('firmantes', ['record' => $record])),
                 EditAction::make(),
             ]);
     }
@@ -218,6 +232,7 @@ class PoliticaResource extends Resource
             'index' => ListPoliticas::route('/'),
             'create' => CreatePolitica::route('/create'),
             'edit' => EditPolitica::route('/{record}/edit'),
+            'firmantes' => ViewNdaFirmantes::route('/{record}/firmantes'),
         ];
     }
 }

--- a/app/Filament/Resources/Politicas/PoliticaResource.php
+++ b/app/Filament/Resources/Politicas/PoliticaResource.php
@@ -11,6 +11,7 @@ use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -68,11 +69,33 @@ class PoliticaResource extends Resource
                             ->label('Obligatoria')
                             ->helperText('Los usuarios no podran usar el sistema sin aceptar.')
                             ->default(true)
-                            ->inline(false),
+                            ->inline(false)
+                            ->disabled(fn (Get $get) => $get('es_nda'))
+                            ->dehydrated(true),
                         Toggle::make('activa')
                             ->label('Activa')
                             ->default(true)
                             ->inline(false),
+                        Toggle::make('es_nda')
+                            ->label('Es NDA')
+                            ->helperText('Activar para convertir en Acuerdo de Confidencialidad.')
+                            ->default(false)
+                            ->inline(false)
+                            ->live()
+                            ->afterStateUpdated(function ($state, Set $set) {
+                                if ($state) {
+                                    $set('obligatoria', true);
+                                }
+                            }),
+                        TextInput::make('vigencia_meses')
+                            ->label('Vigencia')
+                            ->numeric()
+                            ->suffix('meses')
+                            ->minValue(1)
+                            ->maxValue(120)
+                            ->visible(fn (Get $get) => $get('es_nda'))
+                            ->required(fn (Get $get) => $get('es_nda'))
+                            ->helperText('Meses de vigencia desde la firma.'),
                     ])->columns(4),
 
                 Section::make('Contenido de la politica')
@@ -81,8 +104,15 @@ class PoliticaResource extends Resource
                     ->columnSpanFull()
                     ->schema([
                         RichEditor::make('contenido')
-                            ->label('')
+                            ->label('Contenido')
                             ->required()
+                            ->visible(fn (Get $get) => ! $get('es_nda'))
+                            ->columnSpanFull(),
+                        MarkdownEditor::make('contenido')
+                            ->label('Contenido NDA (Markdown)')
+                            ->required()
+                            ->visible(fn (Get $get) => (bool) $get('es_nda'))
+                            ->helperText('Variables disponibles: {nombre_completo}, {dni}, {direccion}, {telefono}, {puesto}. Ejemplo: "Yo, {nombre_completo}, identificado con DNI {dni}..."')
                             ->columnSpanFull(),
                     ]),
 

--- a/app/Http/Controllers/PoliticaPdfController.php
+++ b/app/Http/Controllers/PoliticaPdfController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\AceptacionPolitica;
 use App\Models\Politica;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Mpdf\Mpdf;
 
 class PoliticaPdfController extends Controller
@@ -65,11 +66,14 @@ class PoliticaPdfController extends Controller
                 <tr><td class="label">Version:</td><td class="value">' . e($politica->version) . '</td></tr>
                 <tr><td class="label">Estado:</td><td class="value">' . ($politica->activa ? 'Activa' : 'Inactiva') . '</td></tr>
                 <tr><td class="label">Obligatoria:</td><td class="value">' . ($politica->obligatoria ? 'Si' : 'No') . '</td></tr>
-                <tr><td class="label">Fecha:</td><td class="value">' . $politica->created_at->format('d/m/Y') . '</td></tr>
+                <tr><td class="label">Fecha:</td><td class="value">' . $politica->created_at->format('d/m/Y') . '</td></tr>'
+                . ($politica->es_nda ? '<tr><td class="label">Tipo:</td><td class="value">Acuerdo de Confidencialidad (NDA)</td></tr>' : '')
+                . ($politica->es_nda && $politica->vigencia_meses ? '<tr><td class="label">Vigencia:</td><td class="value">' . $politica->vigencia_meses . ' meses</td></tr>' : '')
+                . ($aceptacion?->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">' . $aceptacion->fecha_expiracion->format('d/m/Y') . '</td></tr>' : '') . '
             </table>
         </div>
 
-        <div class="content">' . $politica->contenido . '</div>
+        <div class="content">' . $this->renderContenido($politica, $user) . '</div>
 
         <div class="signatures">
             <table width="100%"><tr>';
@@ -133,5 +137,151 @@ class PoliticaPdfController extends Controller
         $mpdf->Output($path, \Mpdf\Output\Destination::FILE);
 
         return response()->download($path, $filename)->deleteFileAfterSend();
+    }
+
+    /**
+     * Download a specific user's signed NDA PDF (admin action).
+     */
+    public function downloadNdaFirmante(Request $request, Politica $politica, AceptacionPolitica $aceptacion)
+    {
+        $empresa = $politica->empresa;
+        $firmante = $aceptacion->user;
+
+        $admin = \App\Models\User::where('empresa_id', $politica->empresa_id)
+            ->role('admin_empresa')
+            ->whereNotNull('firma_guardada')
+            ->first();
+
+        $html = '
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 12px; color: #1a1a1a; line-height: 1.6; }
+            .header { text-align: center; border-bottom: 2px solid #4f46e5; padding-bottom: 15px; margin-bottom: 20px; }
+            .header h1 { font-size: 18px; margin: 0; color: #1e1b4b; }
+            .header p { font-size: 11px; color: #6b7280; margin: 4px 0 0; }
+            .meta { background: #f3f4f6; padding: 10px 15px; border-radius: 6px; margin-bottom: 20px; font-size: 11px; }
+            .meta table { width: 100%; }
+            .meta td { padding: 3px 0; }
+            .meta .label { color: #6b7280; width: 140px; }
+            .meta .value { font-weight: bold; }
+            .content { margin-top: 20px; }
+            .content h2 { font-size: 16px; color: #1e1b4b; }
+            .content h3 { font-size: 14px; color: #374151; }
+            .content ul { padding-left: 20px; }
+            .content li { margin-bottom: 4px; }
+            .signatures { margin-top: 40px; }
+            .sig-box { border: 1px solid #d1d5db; border-radius: 8px; padding: 15px; margin-bottom: 10px; }
+            .sig-box h4 { font-size: 11px; color: #6b7280; text-transform: uppercase; margin: 0 0 10px; }
+            .sig-img { height: 50px; margin-bottom: 8px; }
+            .sig-name { font-weight: bold; font-size: 12px; border-top: 1px solid #1a1a1a; padding-top: 5px; margin-top: 5px; }
+            .sig-detail { font-size: 10px; color: #6b7280; }
+            .footer { margin-top: 30px; border-top: 1px solid #d1d5db; padding-top: 10px; font-size: 9px; color: #9ca3af; text-align: center; }
+        </style>
+
+        <div class="header">
+            <h1>' . e($empresa?->razon_social ?? 'SecuriForm') . '</h1>
+            <p>Acuerdo de Confidencialidad (NDA)</p>
+        </div>
+
+        <div class="meta">
+            <table>
+                <tr><td class="label">Documento:</td><td class="value">' . e($politica->titulo) . '</td></tr>
+                <tr><td class="label">Version:</td><td class="value">' . e($aceptacion->version_aceptada) . '</td></tr>
+                <tr><td class="label">Firmante:</td><td class="value">' . e($firmante->name) . '</td></tr>
+                <tr><td class="label">DNI:</td><td class="value">' . e($firmante->dni ?? 'N/A') . '</td></tr>
+                <tr><td class="label">Puesto:</td><td class="value">' . e($firmante->puesto ?? 'N/A') . '</td></tr>
+                <tr><td class="label">Fecha firma:</td><td class="value">' . $aceptacion->fecha_aceptacion->format('d/m/Y H:i') . '</td></tr>'
+                . ($aceptacion->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">' . $aceptacion->fecha_expiracion->format('d/m/Y') . '</td></tr>' : '')
+                . '<tr><td class="label">Estado:</td><td class="value">' . ($aceptacion->estaVigente() ? 'Vigente' : 'Expirado') . '</td></tr>
+            </table>
+        </div>
+
+        <div class="content">' . $this->renderContenido($politica, $firmante) . '</div>
+
+        <div class="signatures">
+            <table width="100%"><tr>
+            <td width="48%" valign="top">
+                <div class="sig-box">
+                    <h4>Firma del empleador / Responsable</h4>';
+
+        if ($admin?->firma_guardada && str_starts_with($admin->firma_guardada, 'data:image')) {
+            $html .= '<img src="' . $admin->firma_guardada . '" class="sig-img">';
+        } else {
+            $html .= '<div style="height:50px;"></div>';
+        }
+        $html .= '<div class="sig-name">' . e($admin?->name ?? '________________________') . '</div>
+                    <div class="sig-detail">' . e($empresa?->razon_social ?? '') . '</div>
+                </div>
+            </td><td width="4%"></td>
+            <td width="48%" valign="top">
+                <div class="sig-box">
+                    <h4>Firma del trabajador</h4>';
+
+        if ($aceptacion->firma_imagen && str_starts_with($aceptacion->firma_imagen, 'data:image')) {
+            $html .= '<img src="' . $aceptacion->firma_imagen . '" class="sig-img">';
+            $html .= '<div class="sig-name">' . e($aceptacion->firma_nombre) . '</div>';
+            if ($aceptacion->firma_cargo) {
+                $html .= '<div class="sig-detail">' . e($aceptacion->firma_cargo) . '</div>';
+            }
+            $html .= '<div class="sig-detail">Firmado: ' . $aceptacion->fecha_aceptacion->format('d/m/Y H:i') . '</div>';
+            $html .= '<div class="sig-detail">IP: ' . e($aceptacion->ip_address) . '</div>';
+        } else {
+            $html .= '<div style="height:50px;"></div>
+                    <div class="sig-name">________________________</div>';
+        }
+
+        $html .= '</div></td></tr></table></div>
+
+        <div class="footer">
+            ' . e($empresa?->razon_social ?? '') . ' &mdash; Generado el ' . now()->format('d/m/Y H:i') . '
+            <br>Este documento es confidencial y de uso interno.
+        </div>';
+
+        $mpdf = new Mpdf([
+            'margin_top' => 20,
+            'margin_bottom' => 20,
+            'margin_left' => 20,
+            'margin_right' => 20,
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        $mpdf->SetTitle('NDA - ' . $firmante->name . ' - ' . $politica->titulo);
+        $mpdf->WriteHTML($html);
+
+        $filename = 'nda_' . Str::slug($firmante->name) . '_v' . $aceptacion->version_aceptada . '.pdf';
+        $path = storage_path('app/temp/' . $filename);
+
+        if (! is_dir(storage_path('app/temp'))) {
+            mkdir(storage_path('app/temp'), 0755, true);
+        }
+
+        $mpdf->Output($path, \Mpdf\Output\Destination::FILE);
+
+        return response()->download($path, $filename)->deleteFileAfterSend();
+    }
+
+    /**
+     * Render policy content. For NDAs, parse markdown and replace placeholders.
+     */
+    private function renderContenido(Politica $politica, $user): string
+    {
+        $contenido = $politica->contenido;
+
+        if ($politica->es_nda) {
+            $contenido = str_replace(
+                ['{nombre_completo}', '{dni}', '{direccion}', '{telefono}', '{puesto}'],
+                [
+                    e($user->name),
+                    e($user->dni ?? '___________'),
+                    e($user->direccion ?? '___________'),
+                    e($user->telefono ?? '___________'),
+                    e($user->puesto ?? '___________'),
+                ],
+                $contenido
+            );
+
+            return Str::markdown($contenido);
+        }
+
+        return $contenido;
     }
 }

--- a/app/Http/Middleware/EnsurePoliciesAccepted.php
+++ b/app/Http/Middleware/EnsurePoliciesAccepted.php
@@ -28,9 +28,11 @@ class EnsurePoliciesAccepted
             return $next($request);
         }
 
-        // Skip if already on acceptance page or auth routes
+        // Skip if already on acceptance/data-completion page or auth routes
         $path = $request->path();
-        if (str_contains($path, 'aceptar-politicas') || str_contains($path, 'logout')) {
+        if (str_contains($path, 'aceptar-politicas')
+            || str_contains($path, 'completar-datos-nda')
+            || str_contains($path, 'logout')) {
             return $next($request);
         }
 
@@ -39,6 +41,14 @@ class EnsurePoliciesAccepted
         if ($pendientes->isNotEmpty()) {
             $tenant = Filament::getTenant();
             $ruc = $tenant?->ruc ?? $user->empresa?->ruc ?? '';
+
+            // If there's a pending NDA and user is missing personal data, redirect to complete data first
+            $hasNdaPendiente = $pendientes->contains(fn ($p) => $p->es_nda);
+            $datosFaltantes = empty($user->dni) || empty($user->direccion) || empty($user->telefono) || empty($user->puesto);
+
+            if ($hasNdaPendiente && $datosFaltantes) {
+                return redirect("/admin/{$ruc}/completar-datos-nda");
+            }
 
             return redirect("/admin/{$ruc}/aceptar-politicas");
         }

--- a/app/Models/AceptacionPolitica.php
+++ b/app/Models/AceptacionPolitica.php
@@ -19,12 +19,14 @@ class AceptacionPolitica extends Model
         'firma_imagen',
         'firma_nombre',
         'firma_cargo',
+        'fecha_expiracion',
     ];
 
     protected function casts(): array
     {
         return [
             'fecha_aceptacion' => 'datetime',
+            'fecha_expiracion' => 'datetime',
         ];
     }
 
@@ -36,5 +38,10 @@ class AceptacionPolitica extends Model
     public function politica(): BelongsTo
     {
         return $this->belongsTo(Politica::class, 'politica_id');
+    }
+
+    public function estaVigente(): bool
+    {
+        return $this->fecha_expiracion === null || $this->fecha_expiracion->isFuture();
     }
 }

--- a/app/Models/Politica.php
+++ b/app/Models/Politica.php
@@ -23,6 +23,8 @@ class Politica extends Model
         'version',
         'obligatoria',
         'activa',
+        'es_nda',
+        'vigencia_meses',
     ];
 
     protected function casts(): array
@@ -30,6 +32,8 @@ class Politica extends Model
         return [
             'obligatoria' => 'boolean',
             'activa' => 'boolean',
+            'es_nda' => 'boolean',
+            'vigencia_meses' => 'integer',
         ];
     }
 
@@ -70,17 +74,38 @@ class Politica extends Model
         return $this->hasMany(PoliticaVersion::class, 'politica_id')->orderByDesc('created_at');
     }
 
+    public function scopeNdas($query)
+    {
+        return $query->where('es_nda', true);
+    }
+
     /**
-     * Get obligatory active policies that a user hasn't accepted (or accepted an older version).
+     * Get obligatory active policies that a user hasn't accepted (or accepted an older version),
+     * including NDAs whose acceptance has expired.
      */
     public static function pendientesPara(int $userId, int $empresaId): \Illuminate\Database\Eloquent\Collection
     {
         return static::where('empresa_id', $empresaId)
             ->where('obligatoria', true)
             ->where('activa', true)
-            ->whereDoesntHave('aceptaciones', function ($q) use ($userId) {
-                $q->where('user_id', $userId)
-                  ->whereColumn('aceptaciones_politica.version_aceptada', 'politicas.version');
+            ->where(function ($query) use ($userId) {
+                // Regular policies: not accepted at current version
+                $query->whereDoesntHave('aceptaciones', function ($q) use ($userId) {
+                    $q->where('user_id', $userId)
+                      ->whereColumn('aceptaciones_politica.version_aceptada', 'politicas.version');
+                })
+                // OR NDAs with expired acceptance
+                ->orWhere(function ($q) use ($userId) {
+                    $q->where('es_nda', true)
+                      ->whereDoesntHave('aceptaciones', function ($sub) use ($userId) {
+                          $sub->where('user_id', $userId)
+                              ->whereColumn('aceptaciones_politica.version_aceptada', 'politicas.version')
+                              ->where(function ($vigencia) {
+                                  $vigencia->whereNull('fecha_expiracion')
+                                           ->orWhere('fecha_expiracion', '>', now());
+                              });
+                      });
+                });
             })
             ->get();
     }

--- a/database/migrations/2026_04_07_000005_add_nda_fields_to_politicas_table.php
+++ b/database/migrations/2026_04_07_000005_add_nda_fields_to_politicas_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('politicas', function (Blueprint $table) {
+            $table->boolean('es_nda')->default(false)->after('activa');
+            $table->unsignedSmallInteger('vigencia_meses')->nullable()->after('es_nda');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('politicas', function (Blueprint $table) {
+            $table->dropColumn(['es_nda', 'vigencia_meses']);
+        });
+    }
+};

--- a/database/migrations/2026_04_07_000006_add_vigencia_to_aceptaciones_politica.php
+++ b/database/migrations/2026_04_07_000006_add_vigencia_to_aceptaciones_politica.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('aceptaciones_politica', function (Blueprint $table) {
+            $table->dateTime('fecha_expiracion')->nullable()->after('user_agent');
+            $table->index(['user_id', 'politica_id', 'fecha_expiracion'], 'aceptaciones_vigencia_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('aceptaciones_politica', function (Blueprint $table) {
+            $table->dropIndex('aceptaciones_vigencia_idx');
+            $table->dropColumn('fecha_expiracion');
+        });
+    }
+};

--- a/resources/views/filament/pages/aceptar-politicas.blade.php
+++ b/resources/views/filament/pages/aceptar-politicas.blade.php
@@ -1,4 +1,19 @@
 <x-filament-panels::page>
+    <style>
+        .wiki-content h1 { font-size:1.5em; font-weight:700; margin:0 0 .6em; }
+        .wiki-content h2 { font-size:1.25em; font-weight:600; margin:1.2em 0 .5em; }
+        .wiki-content h3 { font-size:1.1em; font-weight:600; margin:1em 0 .4em; }
+        .wiki-content p { margin:0 0 .8em; }
+        .wiki-content ul, .wiki-content ol { padding-left:1.5em; margin:0 0 .8em; }
+        .wiki-content li { margin:0 0 .3em; }
+        .wiki-content table { width:100%; border-collapse:collapse; margin:1em 0; font-size:.9em; }
+        .wiki-content th, .wiki-content td { border:1px solid rgba(128,128,128,.25); padding:6px 10px; text-align:left; }
+        .wiki-content th { font-weight:600; }
+        .wiki-content strong { font-weight:700; }
+        .wiki-content em { font-style:italic; }
+        .wiki-content blockquote { border-left:3px solid rgba(128,128,128,.3); padding-left:12px; margin:0 0 .8em; font-style:italic; }
+    </style>
+
     @if ($politicaActual)
         <div style="display:grid; grid-template-columns: 3fr 2fr; gap:20px; height:calc(100vh - 9rem);">
 
@@ -7,10 +22,24 @@
 
                 <div style="padding:16px 20px; border-bottom:1px solid rgba(128,128,128,0.15); display:flex; align-items:center; justify-content:space-between;">
                     <div style="display:flex; align-items:center; gap:10px;">
-                        <x-heroicon-o-shield-check style="width:20px; height:20px;" class="text-primary-600 dark:text-primary-400" />
+                        @if ($politicaActual->es_nda)
+                            <x-heroicon-o-lock-closed style="width:20px; height:20px;" class="text-warning-600 dark:text-warning-400" />
+                        @else
+                            <x-heroicon-o-shield-check style="width:20px; height:20px;" class="text-primary-600 dark:text-primary-400" />
+                        @endif
                         <div>
-                            <div class="text-sm font-semibold text-gray-900 dark:text-white">{{ $politicaActual->titulo }}</div>
-                            <div class="text-xs text-gray-500 dark:text-gray-400">v{{ $politicaActual->version }} · {{ $politicaActual->created_at->format('d/m/Y') }}</div>
+                            <div class="text-sm font-semibold text-gray-900 dark:text-white">
+                                {{ $politicaActual->titulo }}
+                                @if ($politicaActual->es_nda)
+                                    <span style="font-size:10px; padding:2px 6px; border-radius:4px; margin-left:6px;" class="bg-warning-100 text-warning-700 dark:bg-warning-500/10 dark:text-warning-400">NDA</span>
+                                @endif
+                            </div>
+                            <div class="text-xs text-gray-500 dark:text-gray-400">
+                                v{{ $politicaActual->version }} · {{ $politicaActual->created_at->format('d/m/Y') }}
+                                @if ($politicaActual->es_nda && $politicaActual->vigencia_meses)
+                                    · Vigencia: {{ $politicaActual->vigencia_meses }} meses
+                                @endif
+                            </div>
                         </div>
                     </div>
                     <a href="{{ route('politicas.pdf', $politicaActual) }}" target="_blank" class="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" style="white-space:nowrap;">
@@ -19,8 +48,8 @@
                 </div>
 
                 <div style="flex:1; overflow-y:auto; padding:24px;">
-                    <div class="prose prose-sm dark:prose-invert max-w-none">
-                        {!! $politicaActual->contenido !!}
+                    <div class="wiki-content" style="font-size:14px; line-height:1.7; color:inherit;">
+                        {!! $this->getContenidoRenderizado() !!}
                     </div>
                 </div>
             </div>

--- a/resources/views/filament/pages/completar-datos-nda.blade.php
+++ b/resources/views/filament/pages/completar-datos-nda.blade.php
@@ -1,0 +1,68 @@
+<x-filament-panels::page>
+    @php
+        $nda = $this->getNdaPendiente();
+    @endphp
+
+    <div style="max-width:540px; margin:0 auto;">
+        <div style="border-radius:12px; overflow:hidden;" class="bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+
+            {{-- Header --}}
+            <div style="padding:20px 24px; border-bottom:1px solid rgba(128,128,128,0.15); text-align:center;">
+                <div style="width:48px; height:48px; border-radius:12px; display:inline-flex; align-items:center; justify-content:center; margin-bottom:12px;" class="bg-warning-50 dark:bg-warning-500/10">
+                    <x-heroicon-o-identification style="width:24px; height:24px;" class="text-warning-600 dark:text-warning-400" />
+                </div>
+                <div class="text-base font-semibold text-gray-900 dark:text-white">Datos personales requeridos</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400" style="margin-top:4px;">
+                    @if ($nda)
+                        Para firmar <strong>{{ $nda->titulo }}</strong> necesitamos tus datos personales.
+                    @else
+                        Completa tus datos personales para continuar.
+                    @endif
+                </div>
+            </div>
+
+            {{-- Form --}}
+            <div style="padding:24px; display:flex; flex-direction:column; gap:16px;">
+
+                <div>
+                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300" style="display:block; margin-bottom:4px;">DNI / Documento de identidad *</label>
+                    <input type="text" wire:model="dni" placeholder="Ej: 12345678"
+                           class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
+                    @error('dni') <span class="text-xs text-danger-600 dark:text-danger-400">{{ $message }}</span> @enderror
+                </div>
+
+                <div>
+                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300" style="display:block; margin-bottom:4px;">Direccion *</label>
+                    <input type="text" wire:model="direccion" placeholder="Ej: Av. Javier Prado 1234, Lima"
+                           class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
+                    @error('direccion') <span class="text-xs text-danger-600 dark:text-danger-400">{{ $message }}</span> @enderror
+                </div>
+
+                <div>
+                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300" style="display:block; margin-bottom:4px;">Telefono *</label>
+                    <input type="text" wire:model="telefono" placeholder="Ej: 987654321"
+                           class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
+                    @error('telefono') <span class="text-xs text-danger-600 dark:text-danger-400">{{ $message }}</span> @enderror
+                </div>
+
+                <div>
+                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300" style="display:block; margin-bottom:4px;">Puesto / Cargo *</label>
+                    <input type="text" wire:model="puesto" placeholder="Ej: Asistente Legal"
+                           class="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-white/10 dark:bg-white/5 dark:text-white">
+                    @error('puesto') <span class="text-xs text-danger-600 dark:text-danger-400">{{ $message }}</span> @enderror
+                </div>
+            </div>
+
+            {{-- Footer --}}
+            <div style="padding:16px 24px; border-top:1px solid rgba(128,128,128,0.15);">
+                <x-filament::button wire:click="guardar" wire:loading.attr="disabled" icon="heroicon-m-check" class="w-full">
+                    Guardar y continuar
+                </x-filament::button>
+            </div>
+        </div>
+
+        <div style="text-align:center; margin-top:12px;">
+            <p class="text-xs text-gray-400 dark:text-gray-500">Estos datos se usaran para completar tu acuerdo de confidencialidad.</p>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/resources/politicas/pages/view-nda-firmantes.blade.php
+++ b/resources/views/filament/resources/politicas/pages/view-nda-firmantes.blade.php
@@ -1,0 +1,17 @@
+<x-filament-panels::page>
+    <div style="margin-bottom:16px; padding:16px 20px; border-radius:10px; display:flex; align-items:center; gap:12px;" class="bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+        <x-heroicon-o-lock-closed style="width:24px; height:24px;" class="text-warning-600 dark:text-warning-400" />
+        <div>
+            <div class="text-sm font-semibold text-gray-900 dark:text-white">{{ $this->record->titulo }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+                v{{ $this->record->version }}
+                @if ($this->record->vigencia_meses)
+                    · Vigencia: {{ $this->record->vigencia_meses }} meses
+                @endif
+                · {{ $this->record->aceptaciones()->count() }} firma(s) registrada(s)
+            </div>
+        </div>
+    </div>
+
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,3 +30,7 @@ Route::get('/logos/{path}', function (string $path) {
 Route::get('/politicas/{politica}/pdf', [\App\Http\Controllers\PoliticaPdfController::class, 'download'])
     ->middleware('auth')
     ->name('politicas.pdf');
+
+Route::get('/politicas/{politica}/nda/{aceptacion}/pdf', [\App\Http\Controllers\PoliticaPdfController::class, 'downloadNdaFirmante'])
+    ->middleware('auth')
+    ->name('politicas.nda-firmante-pdf');


### PR DESCRIPTION
## Summary
- **SEN-100**: Migrations for `es_nda`/`vigencia_meses` on politicas, `fecha_expiracion` on aceptaciones. Updated `Politica::pendientesPara()` for expired NDA detection
- **SEN-101**: PoliticaResource NDA toggle, vigencia field, conditional Markdown/Rich editor, forced obligatoria for NDAs
- **SEN-102**: CompletarDatosNda page — users must fill personal data (DNI, direccion, telefono, puesto) before signing NDAs. Middleware updated for NDA data check
- **SEN-103**: AceptarPoliticas renders NDA as markdown with placeholders replaced ({nombre_completo}, {dni}, etc). Calculates fecha_expiracion on acceptance
- **SEN-104**: NDA-specific PDF with firmante data, downloadNdaFirmante endpoint, ViewNdaFirmantes page with per-user PDF download, NDA column in table

closes SEN-100, closes SEN-101, closes SEN-102, closes SEN-103, closes SEN-104

## Test plan
- [ ] Create NDA policy with markdown content and placeholders
- [ ] Verify user without personal data is redirected to CompletarDatosNda
- [ ] Complete personal data and verify redirect to AceptarPoliticas
- [ ] Verify NDA content renders with placeholders replaced
- [ ] Sign NDA and verify fecha_expiracion is calculated
- [ ] Admin: verify firmantes table shows signed NDAs
- [ ] Admin: download per-firmante NDA PDF and verify content
- [ ] Verify expired NDA triggers re-signing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)