### PR TITLE
[EP-18] feat: Interconexión Activos ↔ Formatos F07, F08, F12, F13

### DIFF
--- a/app/Console/Commands/CheckBackupAlarms.php
+++ b/app/Console/Commands/CheckBackupAlarms.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\BackupEjecucion;
+use App\Models\BackupProgramacion;
+use App\Models\EmailTemplate;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class CheckBackupAlarms extends Command
+{
+    protected $signature = 'backups:check-alarms';
+
+    protected $description = 'Check for upcoming and overdue backup schedules and send email alerts';
+
+    public function handle(): void
+    {
+        $this->checkProximos();
+        $this->checkAtrasados();
+    }
+
+    private function checkProximos(): void
+    {
+        $proximos = BackupProgramacion::where('activo', true)
+            ->whereDate('proximo_backup', now()->addDay()->toDateString())
+            ->get();
+
+        foreach ($proximos as $prog) {
+            $admins = User::where('empresa_id', $prog->empresa_id)
+                ->role('admin_empresa')
+                ->get();
+
+            $template = EmailTemplate::findBySlug('backup-proximo');
+
+            if ($template && $admins->isNotEmpty()) {
+                $vars = [
+                    'nombre_backup' => $prog->nombre,
+                    'fecha_programada' => $prog->proximo_backup->format('d/m/Y'),
+                    'equipo' => $prog->equipo?->codigo_interno ?? 'General',
+                    'empresa' => $prog->empresa?->razon_social ?? '',
+                ];
+
+                $subject = $template->renderAsunto($vars);
+                $body = $template->renderContenido($vars);
+
+                foreach ($admins as $admin) {
+                    Mail::raw($body, function ($message) use ($admin, $subject) {
+                        $message->to($admin->email)->subject($subject);
+                    });
+                }
+            }
+
+            $this->info("Alerta proximo: {$prog->nombre} ({$prog->empresa?->razon_social})");
+        }
+    }
+
+    private function checkAtrasados(): void
+    {
+        $atrasados = BackupProgramacion::where('activo', true)
+            ->whereDate('proximo_backup', '<', now()->toDateString())
+            ->get();
+
+        foreach ($atrasados as $prog) {
+            // Avoid duplicate atrasado entries for the same date
+            $yaRegistrado = BackupEjecucion::where('programacion_id', $prog->id)
+                ->where('estado', 'atrasado')
+                ->whereDate('created_at', now()->toDateString())
+                ->exists();
+
+            if ($yaRegistrado) {
+                continue;
+            }
+
+            BackupEjecucion::create([
+                'programacion_id' => $prog->id,
+                'fecha_ejecucion' => now(),
+                'ejecutado_por' => $prog->creado_por,
+                'estado' => 'atrasado',
+                'notas' => 'Backup atrasado detectado automaticamente.',
+            ]);
+
+            $admins = User::where('empresa_id', $prog->empresa_id)
+                ->role('admin_empresa')
+                ->get();
+
+            $template = EmailTemplate::findBySlug('backup-atrasado');
+
+            if ($template && $admins->isNotEmpty()) {
+                $vars = [
+                    'nombre_backup' => $prog->nombre,
+                    'fecha_programada' => $prog->proximo_backup->format('d/m/Y'),
+                    'dias_atraso' => (string) $prog->proximo_backup->diffInDays(now()),
+                    'equipo' => $prog->equipo?->codigo_interno ?? 'General',
+                    'empresa' => $prog->empresa?->razon_social ?? '',
+                ];
+
+                $subject = $template->renderAsunto($vars);
+                $body = $template->renderContenido($vars);
+
+                foreach ($admins as $admin) {
+                    Mail::raw($body, function ($message) use ($admin, $subject) {
+                        $message->to($admin->email)->subject($subject);
+                    });
+                }
+            }
+
+            $this->warn("Alerta atrasado: {$prog->nombre} ({$prog->empresa?->razon_social})");
+        }
+    }
+}

--- a/app/Filament/Pages/ReporteInventarioSoportes.php
+++ b/app/Filament/Pages/ReporteInventarioSoportes.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\Equipo;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Mpdf\Mpdf;
+
+class ReporteInventarioSoportes extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedArchiveBox;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
+
+    protected static ?string $navigationLabel = 'Inventario Soportes (F07)';
+
+    protected static ?string $title = 'Formato 7 — Inventario de Soportes';
+
+    protected string $view = 'filament.pages.reporte-inventario-soportes';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'categoria' => '',
+            'clasificacion_soporte' => '',
+            'estado' => 'activo',
+        ]);
+    }
+
+    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    {
+        return $form
+            ->schema([
+                Select::make('categoria')
+                    ->label('Categoria')
+                    ->options([
+                        '' => 'Todas',
+                        'tecnologico' => 'Tecnologico',
+                        'no_tecnologico' => 'No tecnologico',
+                    ]),
+                Select::make('clasificacion_soporte')
+                    ->label('Clasificacion soporte')
+                    ->options([
+                        '' => 'Todas',
+                        'hdd_interno' => 'HDD interno',
+                        'hdd_externo' => 'HDD externo',
+                        'usb' => 'USB',
+                        'servidor' => 'Servidor',
+                        'nube' => 'Nube',
+                        'dvd' => 'DVD / CD',
+                        'expediente_fisico' => 'Expediente fisico',
+                        'otro' => 'Otro',
+                    ]),
+                Select::make('estado')
+                    ->label('Estado')
+                    ->options([
+                        '' => 'Todos',
+                        'activo' => 'Activo',
+                        'mantenimiento' => 'En mantenimiento',
+                        'obsoleto' => 'Obsoleto',
+                        'dado_de_baja' => 'Dado de baja',
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse|null
+    {
+        $tenant = Filament::getTenant();
+
+        $query = Equipo::withoutGlobalScopes()
+            ->where('empresa_id', $tenant->id);
+
+        if (! empty($this->data['categoria'])) {
+            $query->where('categoria', $this->data['categoria']);
+        }
+        if (! empty($this->data['clasificacion_soporte'])) {
+            $query->where('clasificacion_soporte', $this->data['clasificacion_soporte']);
+        }
+        if (! empty($this->data['estado'])) {
+            $query->where('estado', $this->data['estado']);
+        }
+
+        $equipos = $query->orderBy('codigo_interno')->get();
+
+        if ($equipos->isEmpty()) {
+            Notification::make()
+                ->title('Sin resultados')
+                ->body('No se encontraron activos con los filtros seleccionados.')
+                ->warning()
+                ->send();
+
+            return null;
+        }
+
+        $mpdf = new Mpdf([
+            'format' => 'A4-L',
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        if ($tenant->logo_path) {
+            $logoPath = storage_path('app/' . $tenant->logo_path);
+            if (file_exists($logoPath)) {
+                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
+            }
+        }
+
+        $this->buildReport($mpdf, $tenant, $equipos);
+
+        return response()->streamDownload(function () use ($mpdf) {
+            echo $mpdf->Output('', 'S');
+        }, 'inventario_soportes_F07_' . now()->format('Ymd') . '.pdf', ['Content-Type' => 'application/pdf']);
+    }
+
+    private function buildReport(Mpdf $mpdf, $tenant, $equipos): void
+    {
+        $logoHtml = '';
+        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
+            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
+        }
+
+        $style = '
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 9px; color: #333; }
+            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
+            h2 { font-size: 13px; margin-top: 15px; color: #333; }
+            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+            th, td { border: 1px solid #ddd; padding: 4px 6px; text-align: left; }
+            th { background: #f3f4f6; font-weight: bold; font-size: 8px; }
+            .summary { margin-top: 12px; padding: 8px 12px; background: #f9fafb; border: 1px solid #e5e7eb; font-size: 10px; }
+            .badge { display: inline-block; padding: 1px 6px; border-radius: 8px; font-size: 8px; font-weight: bold; }
+            .badge-tec { background: #dbeafe; color: #1d4ed8; }
+            .badge-notec { background: #fef3c7; color: #d97706; }
+            .footer { margin-top: 20px; font-size: 8px; color: #888; }
+        </style>';
+
+        $tecCount = $equipos->where('categoria', 'tecnologico')->count();
+        $noTecCount = $equipos->where('categoria', 'no_tecnologico')->count();
+
+        $rows = '';
+        foreach ($equipos as $eq) {
+            $catBadge = $eq->categoria === 'tecnologico'
+                ? '<span class="badge badge-tec">Tec</span>'
+                : '<span class="badge badge-notec">No tec</span>';
+
+            $rows .= '<tr>'
+                . '<td>' . e($eq->codigo_interno ?? '-') . '</td>'
+                . '<td>' . e($this->tipoLabel($eq->tipo)) . '</td>'
+                . '<td>' . $catBadge . '</td>'
+                . '<td>' . e($this->clasificacionLabel($eq->clasificacion_soporte)) . '</td>'
+                . '<td>' . e(trim(($eq->marca ?? '') . ' ' . ($eq->modelo ?? '')) ?: '-') . '</td>'
+                . '<td>' . e($eq->numero_serie ?? '-') . '</td>'
+                . '<td>' . e($eq->ubicacion ?? '-') . '</td>'
+                . '<td style="max-width:120px;">' . e(mb_substr($eq->contenido_datos ?? '-', 0, 80)) . '</td>'
+                . '<td>' . e(ucfirst($eq->nivel_sensibilidad ?? '-')) . '</td>'
+                . '<td>' . e(ucfirst($eq->estado)) . '</td>'
+                . '<td>' . ($eq->fecha_adquisicion?->format('d/m/Y') ?? '-') . '</td>'
+                . '</tr>';
+        }
+
+        $mpdf->WriteHTML($style . '
+            ' . $logoHtml . '
+            <h1>' . e($tenant->razon_social) . '</h1>
+            <p style="color:#666;">RUC: ' . e($tenant->ruc) . '</p>
+            <h2>Formato 7 — Inventario de Soportes</h2>
+            <p style="color:#666;">Politica: PSC000003 / PSC000004 | Generado: ' . now()->format('d/m/Y H:i') . '</p>
+
+            <div class="summary">
+                <strong>Resumen:</strong>
+                Total: ' . $equipos->count() . ' activos |
+                Tecnologicos: ' . $tecCount . ' |
+                No tecnologicos: ' . $noTecCount . '
+            </div>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Codigo</th>
+                        <th>Tipo</th>
+                        <th>Cat.</th>
+                        <th>Clasif. soporte</th>
+                        <th>Marca / Modelo</th>
+                        <th>N° Serie</th>
+                        <th>Ubicacion</th>
+                        <th>Contenido datos</th>
+                        <th>Sensibilidad</th>
+                        <th>Estado</th>
+                        <th>Adquisicion</th>
+                    </tr>
+                </thead>
+                <tbody>' . $rows . '</tbody>
+            </table>
+
+            <p class="footer">
+                Generado por: ' . e(auth()->user()->name) . ' | SecuriForm — PSC000003 / PSC000004
+            </p>');
+    }
+
+    private function tipoLabel(string $tipo): string
+    {
+        return match ($tipo) {
+            'pc_escritorio' => 'PC Escritorio',
+            'laptop' => 'Laptop',
+            'impresora' => 'Impresora',
+            'servidor' => 'Servidor',
+            'usb' => 'USB',
+            'disco_externo' => 'Disco externo',
+            'telefono' => 'Telefono',
+            'tablet' => 'Tablet',
+            'dispositivo_red' => 'Disp. red',
+            'dvd_cd' => 'DVD/CD',
+            'expediente_fisico' => 'Expediente',
+            'soporte_nube' => 'Cloud',
+            'otro' => 'Otro',
+            default => ucfirst(str_replace('_', ' ', $tipo)),
+        };
+    }
+
+    private function clasificacionLabel(?string $clas): string
+    {
+        if (! $clas) {
+            return '-';
+        }
+
+        return match ($clas) {
+            'hdd_interno' => 'HDD interno',
+            'hdd_externo' => 'HDD externo',
+            'usb' => 'USB',
+            'servidor' => 'Servidor',
+            'nube' => 'Nube',
+            'dvd' => 'DVD/CD',
+            'expediente_fisico' => 'Expediente',
+            'otro' => 'Otro',
+            default => ucfirst(str_replace('_', ' ', $clas)),
+        };
+    }
+}

--- a/app/Filament/Pages/ReporteMovimientosSoportes.php
+++ b/app/Filament/Pages/ReporteMovimientosSoportes.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\EquipoAsignacion;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Mpdf\Mpdf;
+
+class ReporteMovimientosSoportes extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedArrowsRightLeft;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
+
+    protected static ?string $navigationLabel = 'Movimientos Soportes (F08)';
+
+    protected static ?string $title = 'Formato 8 — Ingreso y Salida de Soportes';
+
+    protected string $view = 'filament.pages.reporte-movimientos-soportes';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'mes' => (string) now()->month,
+            'anio' => (string) now()->year,
+            'tipo_movimiento' => '',
+        ]);
+    }
+
+    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    {
+        $months = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $months[(string) $m] = now()->setMonth($m)->translatedFormat('F');
+        }
+
+        $years = [];
+        for ($y = now()->year; $y >= now()->year - 3; $y--) {
+            $years[(string) $y] = (string) $y;
+        }
+
+        return $form
+            ->schema([
+                Select::make('mes')
+                    ->label('Mes')
+                    ->options($months)
+                    ->required(),
+                Select::make('anio')
+                    ->label('Año')
+                    ->options($years)
+                    ->required(),
+                Select::make('tipo_movimiento')
+                    ->label('Tipo movimiento')
+                    ->options([
+                        '' => 'Todos',
+                        'ingreso_nuevo' => 'Ingreso nuevo',
+                        'asignacion' => 'Asignacion',
+                        'transferencia' => 'Transferencia',
+                        'devolucion' => 'Devolucion',
+                        'salida_mantenimiento' => 'Mantenimiento',
+                        'salida_homeoffice' => 'Home office',
+                        'salida_terceros' => 'A terceros',
+                        'baja' => 'Baja',
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse|null
+    {
+        $tenant = Filament::getTenant();
+        $month = (int) $this->data['mes'];
+        $year = (int) $this->data['anio'];
+
+        $query = EquipoAsignacion::query()
+            ->whereHas('equipo', fn ($q) => $q->withoutGlobalScopes()->where('empresa_id', $tenant->id))
+            ->whereMonth('fecha_inicio', $month)
+            ->whereYear('fecha_inicio', $year)
+            ->with(['equipo', 'user', 'asignador']);
+
+        if (! empty($this->data['tipo_movimiento'])) {
+            $query->where('tipo', $this->data['tipo_movimiento']);
+        }
+
+        $movimientos = $query->orderBy('fecha_inicio')->get();
+
+        if ($movimientos->isEmpty()) {
+            Notification::make()
+                ->title('Sin resultados')
+                ->body('No se encontraron movimientos en el periodo seleccionado.')
+                ->warning()
+                ->send();
+
+            return null;
+        }
+
+        $monthName = now()->setMonth($month)->translatedFormat('F');
+
+        $mpdf = new Mpdf([
+            'format' => 'A4-L',
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        if ($tenant->logo_path) {
+            $logoPath = storage_path('app/' . $tenant->logo_path);
+            if (file_exists($logoPath)) {
+                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
+            }
+        }
+
+        $this->buildReport($mpdf, $tenant, $movimientos, $monthName, $year);
+
+        $filename = "movimientos_soportes_F08_{$year}_{$month}.pdf";
+
+        return response()->streamDownload(function () use ($mpdf) {
+            echo $mpdf->Output('', 'S');
+        }, $filename, ['Content-Type' => 'application/pdf']);
+    }
+
+    private function buildReport(Mpdf $mpdf, $tenant, $movimientos, $monthName, $year): void
+    {
+        $logoHtml = '';
+        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
+            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
+        }
+
+        $style = '
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 9px; color: #333; }
+            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
+            h2 { font-size: 13px; margin-top: 15px; color: #333; }
+            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+            th, td { border: 1px solid #ddd; padding: 4px 6px; text-align: left; }
+            th { background: #f3f4f6; font-weight: bold; font-size: 8px; }
+            .summary { margin-top: 12px; padding: 8px 12px; background: #f9fafb; border: 1px solid #e5e7eb; font-size: 10px; }
+            .footer { margin-top: 20px; font-size: 8px; color: #888; }
+        </style>';
+
+        $tipoCount = $movimientos->groupBy('tipo')->map->count();
+
+        $rows = '';
+        foreach ($movimientos as $m) {
+            $rows .= '<tr>'
+                . '<td>' . $m->fecha_inicio->format('d/m/Y H:i') . '</td>'
+                . '<td>' . e($m->equipo?->codigo_interno ?? '-') . '</td>'
+                . '<td>' . e($this->tipoEquipoLabel($m->equipo?->tipo ?? '')) . '</td>'
+                . '<td>' . e($m->equipo?->numero_serie ?? '-') . '</td>'
+                . '<td>' . e($this->tipoMovimientoLabel($m->tipo)) . '</td>'
+                . '<td>' . e($m->user?->name ?? '-') . '</td>'
+                . '<td>' . e($m->empresa_tercera ?? '-') . '</td>'
+                . '<td style="max-width:100px;">' . e(mb_substr($m->motivo ?? '-', 0, 60)) . '</td>'
+                . '<td>' . e($m->condicion_entrega ?? '-') . '</td>'
+                . '<td>' . e($m->asignador?->name ?? '-') . '</td>'
+                . '</tr>';
+        }
+
+        $summaryParts = [];
+        foreach ($tipoCount as $tipo => $count) {
+            $summaryParts[] = $this->tipoMovimientoLabel($tipo) . ': ' . $count;
+        }
+
+        $mpdf->WriteHTML($style . '
+            ' . $logoHtml . '
+            <h1>' . e($tenant->razon_social) . '</h1>
+            <p style="color:#666;">RUC: ' . e($tenant->ruc) . '</p>
+            <h2>Formato 8 — Ingreso y Salida de Soportes</h2>
+            <p style="color:#666;">Periodo: ' . $monthName . ' ' . $year . ' | Politica: PSC000003</p>
+
+            <div class="summary">
+                <strong>Resumen:</strong> Total: ' . $movimientos->count() . ' movimientos | ' . implode(' | ', $summaryParts) . '
+            </div>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Fecha</th>
+                        <th>Codigo</th>
+                        <th>Tipo equipo</th>
+                        <th>N° Serie</th>
+                        <th>Movimiento</th>
+                        <th>Usuario</th>
+                        <th>Empresa tercera</th>
+                        <th>Motivo</th>
+                        <th>Condicion</th>
+                        <th>Realizado por</th>
+                    </tr>
+                </thead>
+                <tbody>' . $rows . '</tbody>
+            </table>
+
+            <p class="footer">
+                Generado: ' . now()->format('d/m/Y H:i') . ' | ' . e(auth()->user()->name) . ' | SecuriForm — PSC000003
+            </p>');
+    }
+
+    private function tipoMovimientoLabel(string $tipo): string
+    {
+        return match ($tipo) {
+            'ingreso_nuevo' => 'Ingreso nuevo',
+            'asignacion' => 'Asignacion',
+            'transferencia' => 'Transferencia',
+            'devolucion' => 'Devolucion',
+            'salida_mantenimiento' => 'Mantenimiento',
+            'salida_homeoffice' => 'Home office',
+            'salida_terceros' => 'A terceros',
+            'baja' => 'Baja',
+            default => ucfirst(str_replace('_', ' ', $tipo)),
+        };
+    }
+
+    private function tipoEquipoLabel(string $tipo): string
+    {
+        return match ($tipo) {
+            'pc_escritorio' => 'PC',
+            'laptop' => 'Laptop',
+            'impresora' => 'Impresora',
+            'servidor' => 'Servidor',
+            'usb' => 'USB',
+            'disco_externo' => 'Disco ext.',
+            'telefono' => 'Telefono',
+            'tablet' => 'Tablet',
+            'dispositivo_red' => 'Red',
+            'dvd_cd' => 'DVD/CD',
+            'expediente_fisico' => 'Expediente',
+            'soporte_nube' => 'Cloud',
+            'otro' => 'Otro',
+            default => $tipo,
+        };
+    }
+}

--- a/app/Filament/Resources/Backups/BackupProgramacionResource.php
+++ b/app/Filament/Resources/Backups/BackupProgramacionResource.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources\Backups;
+
+use App\Filament\Resources\Backups\Pages\CreateBackupProgramacion;
+use App\Filament\Resources\Backups\Pages\EditBackupProgramacion;
+use App\Filament\Resources\Backups\Pages\ListBackupProgramaciones;
+use App\Filament\Resources\Backups\Schemas\BackupProgramacionForm;
+use App\Filament\Resources\Backups\Tables\BackupProgramacionesTable;
+use App\Models\BackupProgramacion;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class BackupProgramacionResource extends Resource
+{
+    protected static ?string $model = BackupProgramacion::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCloudArrowUp;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Activos';
+
+    protected static ?string $modelLabel = 'Programacion de Backup';
+
+    protected static ?string $pluralModelLabel = 'Programaciones de Backup';
+
+    protected static ?string $slug = 'backup-programaciones';
+
+    protected static ?int $navigationSort = 3;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return BackupProgramacionForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return BackupProgramacionesTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListBackupProgramaciones::route('/'),
+            'create' => CreateBackupProgramacion::route('/create'),
+            'edit' => EditBackupProgramacion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Backups/Pages/CreateBackupProgramacion.php
+++ b/app/Filament/Resources/Backups/Pages/CreateBackupProgramacion.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Resources\Backups\Pages;
+
+use App\Filament\Resources\Backups\BackupProgramacionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBackupProgramacion extends CreateRecord
+{
+    protected static string $resource = BackupProgramacionResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['creado_por'] = auth()->id();
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/Backups/Pages/EditBackupProgramacion.php
+++ b/app/Filament/Resources/Backups/Pages/EditBackupProgramacion.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Resources\Backups\Pages;
+
+use App\Enums\TipoFormato;
+use App\Filament\Resources\Backups\BackupProgramacionResource;
+use App\Models\BackupEjecucion;
+use App\Models\Registro;
+use App\Services\RegistroNumberService;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\DB;
+
+class EditBackupProgramacion extends EditRecord
+{
+    protected static string $resource = BackupProgramacionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('marcar_ejecutado')
+                ->label('Marcar como ejecutado')
+                ->icon('heroicon-o-check-circle')
+                ->color('success')
+                ->form([
+                    Textarea::make('notas')
+                        ->label('Notas de ejecucion')
+                        ->rows(2)
+                        ->placeholder('Observaciones sobre la ejecucion del backup...'),
+                ])
+                ->action(function (array $data) {
+                    DB::transaction(function () use ($data) {
+                        $programacion = $this->record;
+                        $empresaId = Filament::getTenant()->id;
+
+                        // 1. Create F12 registro
+                        $tipo = TipoFormato::F12;
+                        $numero = RegistroNumberService::generate($empresaId, $tipo);
+
+                        $registro = Registro::create([
+                            'empresa_id' => $empresaId,
+                            'tipo_formato' => $tipo->value,
+                            'numero_registro' => $numero,
+                            'datos' => [
+                                'nombre_backup' => $programacion->nombre,
+                                'fecha_copia' => now()->toDateString(),
+                                'periodicidad' => $programacion->periodicidad,
+                                'descripcion_contenido' => $programacion->descripcion,
+                            ],
+                            'estado' => 'activo',
+                            'creado_por' => auth()->id(),
+                            'equipo_id' => $programacion->equipo_id,
+                        ]);
+
+                        // 2. Create ejecucion
+                        BackupEjecucion::create([
+                            'programacion_id' => $programacion->id,
+                            'fecha_ejecucion' => now(),
+                            'ejecutado_por' => auth()->id(),
+                            'estado' => 'ejecutado',
+                            'notas' => $data['notas'] ?? null,
+                            'registro_id' => $registro->id,
+                        ]);
+
+                        // 3. Advance next backup date
+                        $programacion->update([
+                            'proximo_backup' => $programacion->calcularProximoBackup(),
+                        ]);
+                    });
+
+                    Notification::make()
+                        ->title('Backup ejecutado')
+                        ->body('Se genero automaticamente un registro F12.')
+                        ->success()
+                        ->send();
+                })
+                ->visible(fn () => $this->record->activo),
+
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Backups/Pages/ListBackupProgramaciones.php
+++ b/app/Filament/Resources/Backups/Pages/ListBackupProgramaciones.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Backups\Pages;
+
+use App\Filament\Resources\Backups\BackupProgramacionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBackupProgramaciones extends ListRecords
+{
+    protected static string $resource = BackupProgramacionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Backups/Schemas/BackupProgramacionForm.php
+++ b/app/Filament/Resources/Backups/Schemas/BackupProgramacionForm.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Filament\Resources\Backups\Schemas;
+
+use App\Models\BackupEjecucion;
+use App\Models\BackupProgramacion;
+use App\Models\Equipo;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Illuminate\Support\HtmlString;
+
+class BackupProgramacionForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(1)
+            ->components([
+                Section::make('Programacion de backup')
+                    ->icon('heroicon-o-cloud-arrow-up')
+                    ->description('Define el nombre, equipo asociado, periodicidad y proxima fecha de ejecucion.')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('nombre')
+                            ->label('Nombre del backup')
+                            ->required()
+                            ->placeholder('Backup BD produccion, Backup archivos legales...')
+                            ->columnSpanFull(),
+                        Select::make('equipo_id')
+                            ->label('Equipo asociado (opcional)')
+                            ->options(fn () => Equipo::withoutGlobalScopes()
+                                ->where('empresa_id', Filament::getTenant()?->id)
+                                ->whereNotIn('estado', ['dado_de_baja'])
+                                ->pluck('codigo_interno', 'id'))
+                            ->searchable()
+                            ->placeholder('General (sin equipo especifico)'),
+                        Select::make('periodicidad')
+                            ->label('Periodicidad')
+                            ->options([
+                                'diaria' => 'Diaria',
+                                'semanal' => 'Semanal',
+                                'quincenal' => 'Quincenal',
+                                'mensual' => 'Mensual',
+                                'trimestral' => 'Trimestral',
+                                'puntual' => 'Puntual (una vez)',
+                            ])
+                            ->required(),
+                        DatePicker::make('proximo_backup')
+                            ->label('Proxima fecha de backup')
+                            ->required(),
+                        Toggle::make('activo')
+                            ->label('Activo')
+                            ->default(true)
+                            ->inline(false),
+                        Textarea::make('descripcion')
+                            ->label('Descripcion')
+                            ->rows(2)
+                            ->placeholder('Que datos respalda, donde se almacena...')
+                            ->columnSpanFull(),
+                    ]),
+
+                Section::make('Historial de ejecuciones')
+                    ->icon('heroicon-o-clock')
+                    ->description('Registro de todas las ejecuciones de este backup.')
+                    ->schema([
+                        Placeholder::make('ejecuciones_historial')
+                            ->label('')
+                            ->content(function ($record): HtmlString {
+                                if (! $record instanceof BackupProgramacion) {
+                                    return new HtmlString('<p class="text-sm text-gray-500">Guarda la programacion primero para ver el historial.</p>');
+                                }
+
+                                $ejecuciones = BackupEjecucion::where('programacion_id', $record->id)
+                                    ->with(['ejecutor', 'registro'])
+                                    ->orderBy('fecha_ejecucion', 'desc')
+                                    ->limit(20)
+                                    ->get();
+
+                                if ($ejecuciones->isEmpty()) {
+                                    return new HtmlString('<p class="text-sm text-gray-500">Sin ejecuciones registradas. Usa el boton "Marcar ejecutado" para registrar una.</p>');
+                                }
+
+                                $rows = '';
+                                foreach ($ejecuciones as $e) {
+                                    $estadoColor = match ($e->estado) {
+                                        'ejecutado' => 'success',
+                                        'pendiente' => 'warning',
+                                        'atrasado' => 'danger',
+                                        default => 'gray',
+                                    };
+                                    $regLink = $e->registro
+                                        ? '<a href="#" class="text-primary-600 dark:text-primary-400">' . e($e->registro->numero_registro) . '</a>'
+                                        : '-';
+                                    $rows .= '<tr class="border-b border-gray-100 dark:border-gray-800">'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . $e->fecha_ejecucion->format('d/m/Y H:i') . '</td>'
+                                        . '<td class="py-2 px-2 text-xs"><span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-' . $estadoColor . '-100 text-' . $estadoColor . '-700 dark:bg-' . $estadoColor . '-500/20 dark:text-' . $estadoColor . '-400">' . ucfirst($e->estado) . '</span></td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-700 dark:text-gray-300">' . e($e->ejecutor?->name ?? '-') . '</td>'
+                                        . '<td class="py-2 px-2 text-xs">' . $regLink . '</td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . e(mb_substr($e->notas ?? '', 0, 50)) . '</td>'
+                                        . '</tr>';
+                                }
+
+                                return new HtmlString(
+                                    '<table class="w-full text-left">'
+                                    . '<thead><tr class="border-b border-gray-200 dark:border-gray-700">'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Fecha</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Estado</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Ejecutado por</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Registro F12</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Notas</th>'
+                                    . '</tr></thead><tbody>' . $rows . '</tbody></table>'
+                                );
+                            })
+                            ->columnSpanFull(),
+                    ])
+                    ->visible(fn (string $operation): bool => $operation === 'edit')
+                    ->collapsible(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Backups/Tables/BackupProgramacionesTable.php
+++ b/app/Filament/Resources/Backups/Tables/BackupProgramacionesTable.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Filament\Resources\Backups\Tables;
+
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class BackupProgramacionesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('nombre')
+                    ->label('Nombre')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('equipo.codigo_interno')
+                    ->label('Equipo')
+                    ->placeholder('General')
+                    ->badge()
+                    ->color('info'),
+                TextColumn::make('periodicidad')
+                    ->label('Periodicidad')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'diaria' => 'danger',
+                        'semanal' => 'warning',
+                        'quincenal' => 'warning',
+                        'mensual' => 'info',
+                        'trimestral' => 'gray',
+                        'puntual' => 'gray',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => ucfirst($state)),
+                TextColumn::make('proximo_backup')
+                    ->label('Proximo backup')
+                    ->date('d/m/Y')
+                    ->sortable()
+                    ->color(function ($record): string {
+                        if (! $record->activo) {
+                            return 'gray';
+                        }
+                        if ($record->proximo_backup->isPast()) {
+                            return 'danger';
+                        }
+                        if ($record->proximo_backup->isToday() || $record->proximo_backup->isTomorrow()) {
+                            return 'warning';
+                        }
+
+                        return 'success';
+                    })
+                    ->weight('bold'),
+                IconColumn::make('activo')
+                    ->label('Activo')
+                    ->boolean(),
+                TextColumn::make('ejecuciones_count')
+                    ->label('Ejecuciones')
+                    ->counts('ejecuciones')
+                    ->badge()
+                    ->color('success'),
+            ])
+            ->defaultSort('proximo_backup', 'asc')
+            ->filters([
+                SelectFilter::make('activo')
+                    ->options(['1' => 'Activos', '0' => 'Inactivos']),
+                SelectFilter::make('periodicidad')
+                    ->options([
+                        'diaria' => 'Diaria',
+                        'semanal' => 'Semanal',
+                        'quincenal' => 'Quincenal',
+                        'mensual' => 'Mensual',
+                        'trimestral' => 'Trimestral',
+                        'puntual' => 'Puntual',
+                    ]),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Equipos/Pages/CreateEquipo.php
+++ b/app/Filament/Resources/Equipos/Pages/CreateEquipo.php
@@ -3,9 +3,22 @@
 namespace App\Filament\Resources\Equipos\Pages;
 
 use App\Filament\Resources\Equipos\EquipoResource;
+use App\Models\EquipoAsignacion;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateEquipo extends CreateRecord
 {
     protected static string $resource = EquipoResource::class;
+
+    protected function afterCreate(): void
+    {
+        EquipoAsignacion::create([
+            'equipo_id' => $this->record->id,
+            'user_id' => null,
+            'tipo' => 'ingreso_nuevo',
+            'fecha_inicio' => now(),
+            'fecha_fin' => now(),
+            'asignado_por' => auth()->id(),
+        ]);
+    }
 }

--- a/app/Filament/Resources/Equipos/Pages/EditEquipo.php
+++ b/app/Filament/Resources/Equipos/Pages/EditEquipo.php
@@ -384,6 +384,7 @@ class EditEquipo extends EditRecord
                             ],
                             'estado' => 'activo',
                             'creado_por' => auth()->id(),
+                            'equipo_id' => $this->record->id,
                         ]);
                     });
 

--- a/app/Filament/Resources/Equipos/Pages/EditEquipo.php
+++ b/app/Filament/Resources/Equipos/Pages/EditEquipo.php
@@ -167,6 +167,139 @@ class EditEquipo extends EditRecord
                 })
                 ->visible(fn () => $this->record->estaAsignado()),
 
+            Action::make('salida_mantenimiento')
+                ->label('Mantenimiento')
+                ->icon('heroicon-o-wrench-screwdriver')
+                ->color('warning')
+                ->form([
+                    Textarea::make('motivo')
+                        ->label('Motivo')
+                        ->required()
+                        ->rows(2),
+                    \Filament\Forms\Components\TextInput::make('empresa_tercera')
+                        ->label('Empresa tercera (si aplica)'),
+                    \Filament\Forms\Components\TextInput::make('ruc_tercero')
+                        ->label('RUC tercera'),
+                    \Filament\Forms\Components\TextInput::make('contacto_tercero')
+                        ->label('Contacto'),
+                    Textarea::make('notas')
+                        ->label('Notas')
+                        ->rows(2),
+                ])
+                ->action(function (array $data) {
+                    DB::transaction(function () use ($data) {
+                        $vigente = $this->record->asignacionVigente;
+                        if ($vigente) {
+                            $vigente->update(['fecha_fin' => now()]);
+                        }
+
+                        EquipoAsignacion::create([
+                            'equipo_id' => $this->record->id,
+                            'user_id' => $vigente?->user_id,
+                            'tipo' => 'salida_mantenimiento',
+                            'fecha_inicio' => now(),
+                            'motivo' => $data['motivo'],
+                            'empresa_tercera' => $data['empresa_tercera'] ?? null,
+                            'ruc_tercero' => $data['ruc_tercero'] ?? null,
+                            'contacto_tercero' => $data['contacto_tercero'] ?? null,
+                            'notas' => $data['notas'] ?? null,
+                            'asignado_por' => auth()->id(),
+                        ]);
+
+                        $this->record->update(['estado' => 'mantenimiento']);
+                    });
+
+                    Notification::make()->title('Enviado a mantenimiento')->success()->send();
+                })
+                ->visible(fn () => $this->record->estado === 'activo'),
+
+            Action::make('salida_homeoffice')
+                ->label('Home Office')
+                ->icon('heroicon-o-home')
+                ->color('info')
+                ->form([
+                    Select::make('user_id')
+                        ->label('Usuario')
+                        ->options(fn () => User::where('empresa_id', Filament::getTenant()?->id)
+                            ->where('estado', 'activo')
+                            ->pluck('name', 'id'))
+                        ->searchable()
+                        ->required(),
+                    Textarea::make('motivo')
+                        ->label('Motivo')
+                        ->rows(2),
+                    Textarea::make('notas')
+                        ->label('Notas')
+                        ->rows(2),
+                ])
+                ->action(function (array $data) {
+                    DB::transaction(function () use ($data) {
+                        $vigente = $this->record->asignacionVigente;
+                        if ($vigente) {
+                            $vigente->update(['fecha_fin' => now()]);
+                        }
+
+                        EquipoAsignacion::create([
+                            'equipo_id' => $this->record->id,
+                            'user_id' => $data['user_id'],
+                            'tipo' => 'salida_homeoffice',
+                            'fecha_inicio' => now(),
+                            'motivo' => $data['motivo'] ?? null,
+                            'notas' => $data['notas'] ?? null,
+                            'asignado_por' => auth()->id(),
+                        ]);
+                    });
+
+                    Notification::make()->title('Salida home office registrada')->success()->send();
+                })
+                ->visible(fn () => $this->record->estado === 'activo'),
+
+            Action::make('salida_terceros')
+                ->label('A terceros')
+                ->icon('heroicon-o-building-office')
+                ->color('warning')
+                ->form([
+                    \Filament\Forms\Components\TextInput::make('empresa_tercera')
+                        ->label('Empresa tercera')
+                        ->required(),
+                    \Filament\Forms\Components\TextInput::make('ruc_tercero')
+                        ->label('RUC')
+                        ->required(),
+                    \Filament\Forms\Components\TextInput::make('contacto_tercero')
+                        ->label('Contacto'),
+                    Textarea::make('motivo')
+                        ->label('Motivo')
+                        ->required()
+                        ->rows(2),
+                    Textarea::make('notas')
+                        ->label('Notas')
+                        ->rows(2),
+                ])
+                ->action(function (array $data) {
+                    DB::transaction(function () use ($data) {
+                        $vigente = $this->record->asignacionVigente;
+                        if ($vigente) {
+                            $vigente->update(['fecha_fin' => now()]);
+                        }
+
+                        EquipoAsignacion::create([
+                            'equipo_id' => $this->record->id,
+                            'user_id' => $vigente?->user_id,
+                            'tipo' => 'salida_terceros',
+                            'fecha_inicio' => now(),
+                            'motivo' => $data['motivo'],
+                            'empresa_tercera' => $data['empresa_tercera'],
+                            'ruc_tercero' => $data['ruc_tercero'],
+                            'contacto_tercero' => $data['contacto_tercero'] ?? null,
+                            'notas' => $data['notas'] ?? null,
+                            'asignado_por' => auth()->id(),
+                        ]);
+                    });
+
+                    Notification::make()->title('Salida a terceros registrada')->success()->send();
+                })
+                ->visible(fn () => $this->record->estado === 'activo'),
+
             Action::make('ejecutar_checklist')
                 ->label('Checklist')
                 ->icon('heroicon-o-clipboard-document-check')

--- a/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
+++ b/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
@@ -247,6 +247,57 @@ class EquipoForm
                     ->visible(fn (string $operation): bool => $operation === 'edit')
                     ->collapsible(),
 
+                Section::make('Registros asociados')
+                    ->icon('heroicon-o-document-text')
+                    ->description('Registros de seguridad vinculados a este equipo (F12, F13, etc.).')
+                    ->schema([
+                        Placeholder::make('registros_asociados')
+                            ->label('')
+                            ->content(function ($record): HtmlString {
+                                if (! $record instanceof Equipo) {
+                                    return new HtmlString('<p class="text-sm text-gray-500">Guarda el equipo primero.</p>');
+                                }
+
+                                $registros = \App\Models\Registro::where('equipo_id', $record->id)
+                                    ->orderBy('created_at', 'desc')
+                                    ->limit(20)
+                                    ->get();
+
+                                if ($registros->isEmpty()) {
+                                    return new HtmlString('<p class="text-sm text-gray-500">Sin registros asociados.</p>');
+                                }
+
+                                $rows = '';
+                                foreach ($registros as $r) {
+                                    $tipoBadgeColor = match ($r->tipo_formato) {
+                                        'F12' => 'info',
+                                        'F13' => 'danger',
+                                        default => 'gray',
+                                    };
+                                    $estadoColor = $r->estado === 'activo' ? 'success' : 'gray';
+                                    $rows .= '<tr class="border-b border-gray-100 dark:border-gray-800">'
+                                        . '<td class="py-2 px-2 text-xs text-gray-700 dark:text-gray-300">' . e($r->numero_registro) . '</td>'
+                                        . '<td class="py-2 px-2 text-xs"><span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-' . $tipoBadgeColor . '-100 text-' . $tipoBadgeColor . '-700 dark:bg-' . $tipoBadgeColor . '-500/20 dark:text-' . $tipoBadgeColor . '-400">' . e($r->tipo_formato) . '</span></td>'
+                                        . '<td class="py-2 px-2 text-xs"><span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-' . $estadoColor . '-100 text-' . $estadoColor . '-700 dark:bg-' . $estadoColor . '-500/20 dark:text-' . $estadoColor . '-400">' . ucfirst($r->estado) . '</span></td>'
+                                        . '<td class="py-2 px-2 text-xs text-gray-500">' . $r->created_at->format('d/m/Y H:i') . '</td>'
+                                        . '</tr>';
+                                }
+
+                                return new HtmlString(
+                                    '<table class="w-full text-left">'
+                                    . '<thead><tr class="border-b border-gray-200 dark:border-gray-700">'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">N° Registro</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Formato</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Estado</th>'
+                                    . '<th class="py-2 px-2 text-xs font-medium text-gray-500">Fecha</th>'
+                                    . '</tr></thead><tbody>' . $rows . '</tbody></table>'
+                                );
+                            })
+                            ->columnSpanFull(),
+                    ])
+                    ->visible(fn (string $operation): bool => $operation === 'edit')
+                    ->collapsible(),
+
                 Section::make('Historial de checklists')
                     ->icon('heroicon-o-clipboard-document-check')
                     ->description('Verificaciones de cumplimiento realizadas en este equipo.')

--- a/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
+++ b/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
@@ -203,6 +203,10 @@ class EquipoForm
                                         'transferencia' => 'warning',
                                         'devolucion' => 'gray',
                                         'baja' => 'danger',
+                                        'ingreso_nuevo' => 'info',
+                                        'salida_mantenimiento' => 'warning',
+                                        'salida_homeoffice' => 'info',
+                                        'salida_terceros' => 'danger',
                                         default => 'gray',
                                     };
                                     $tipoLabel = match ($a->tipo) {
@@ -210,6 +214,10 @@ class EquipoForm
                                         'transferencia' => 'Transferencia',
                                         'devolucion' => 'Devolucion',
                                         'baja' => 'Baja',
+                                        'ingreso_nuevo' => 'Ingreso nuevo',
+                                        'salida_mantenimiento' => 'Mantenimiento',
+                                        'salida_homeoffice' => 'Home office',
+                                        'salida_terceros' => 'A terceros',
                                         default => $a->tipo,
                                     };
                                     $rows .= '<tr class="border-b border-gray-100 dark:border-gray-800">'

--- a/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
+++ b/app/Filament/Resources/Equipos/Schemas/EquipoForm.php
@@ -29,12 +29,23 @@ class EquipoForm
                         Select::make('tipo')
                             ->label('Tipo de equipo')
                             ->options([
-                                'pc_escritorio' => 'PC de escritorio',
-                                'laptop' => 'Laptop',
-                                'impresora' => 'Impresora',
-                                'servidor' => 'Servidor',
-                                'usb' => 'Dispositivo USB',
-                                'otro' => 'Otro',
+                                'Tecnologicos' => [
+                                    'pc_escritorio' => 'PC de escritorio',
+                                    'laptop' => 'Laptop',
+                                    'impresora' => 'Impresora',
+                                    'servidor' => 'Servidor',
+                                    'usb' => 'Dispositivo USB',
+                                    'disco_externo' => 'Disco externo',
+                                    'telefono' => 'Telefono',
+                                    'tablet' => 'Tablet',
+                                    'dispositivo_red' => 'Dispositivo de red',
+                                ],
+                                'No tecnologicos' => [
+                                    'dvd_cd' => 'DVD / CD',
+                                    'expediente_fisico' => 'Expediente fisico',
+                                    'soporte_nube' => 'Servicio cloud',
+                                    'otro' => 'Otro',
+                                ],
                             ])
                             ->required()
                             ->live()
@@ -54,11 +65,44 @@ class EquipoForm
                             ->placeholder('ThinkPad T14, ProBook 450...'),
                     ]),
 
+                Section::make('Clasificacion de soporte')
+                    ->icon('heroicon-o-archive-box')
+                    ->description('Categoriza el activo segun el tipo de soporte de informacion.')
+                    ->columns(3)
+                    ->schema([
+                        Select::make('categoria')
+                            ->label('Categoria')
+                            ->options([
+                                'tecnologico' => 'Tecnologico',
+                                'no_tecnologico' => 'No tecnologico',
+                            ])
+                            ->default('tecnologico')
+                            ->required()
+                            ->live(),
+                        Select::make('clasificacion_soporte')
+                            ->label('Clasificacion de soporte')
+                            ->options([
+                                'hdd_interno' => 'HDD interno',
+                                'hdd_externo' => 'HDD externo',
+                                'usb' => 'USB',
+                                'servidor' => 'Servidor',
+                                'nube' => 'Nube',
+                                'dvd' => 'DVD / CD',
+                                'expediente_fisico' => 'Expediente fisico',
+                                'otro' => 'Otro',
+                            ]),
+                        Textarea::make('contenido_datos')
+                            ->label('Contenido de datos')
+                            ->placeholder('Descripcion de los datos que almacena este activo')
+                            ->rows(2)
+                            ->columnSpanFull(),
+                    ]),
+
                 Section::make('Especificaciones tecnicas')
                     ->icon('heroicon-o-cpu-chip')
-                    ->description('Detalles del hardware. Solo aplica para PCs, laptops y servidores.')
+                    ->description('Detalles del hardware. Solo aplica para equipos tecnologicos.')
                     ->columns(2)
-                    ->visible(fn (Get $get): bool => in_array($get('tipo'), ['pc_escritorio', 'laptop', 'servidor']))
+                    ->visible(fn (Get $get): bool => $get('categoria') === 'tecnologico' && in_array($get('tipo'), ['pc_escritorio', 'laptop', 'servidor', 'tablet', 'telefono', 'dispositivo_red']))
                     ->schema([
                         TextInput::make('sistema_operativo')
                             ->label('Sistema operativo')

--- a/app/Filament/Resources/Equipos/Tables/EquiposTable.php
+++ b/app/Filament/Resources/Equipos/Tables/EquiposTable.php
@@ -21,6 +21,20 @@ class EquiposTable
                     ->label('Codigo')
                     ->searchable()
                     ->sortable(),
+                TextColumn::make('categoria')
+                    ->label('Categoria')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'tecnologico' => 'info',
+                        'no_tecnologico' => 'warning',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'tecnologico' => 'Tecnologico',
+                        'no_tecnologico' => 'No tecnologico',
+                        default => $state,
+                    })
+                    ->toggleable(),
                 TextColumn::make('tipo')
                     ->label('Tipo')
                     ->badge()
@@ -30,6 +44,13 @@ class EquiposTable
                         'impresora' => 'gray',
                         'servidor' => 'warning',
                         'usb' => 'danger',
+                        'disco_externo' => 'danger',
+                        'telefono' => 'primary',
+                        'tablet' => 'primary',
+                        'dispositivo_red' => 'warning',
+                        'dvd_cd' => 'gray',
+                        'expediente_fisico' => 'gray',
+                        'soporte_nube' => 'info',
                         default => 'gray',
                     })
                     ->formatStateUsing(fn (string $state): string => match ($state) {
@@ -38,6 +59,13 @@ class EquiposTable
                         'impresora' => 'Impresora',
                         'servidor' => 'Servidor',
                         'usb' => 'USB',
+                        'disco_externo' => 'Disco externo',
+                        'telefono' => 'Telefono',
+                        'tablet' => 'Tablet',
+                        'dispositivo_red' => 'Disp. red',
+                        'dvd_cd' => 'DVD/CD',
+                        'expediente_fisico' => 'Expediente',
+                        'soporte_nube' => 'Cloud',
                         'otro' => 'Otro',
                         default => $state,
                     }),
@@ -94,6 +122,12 @@ class EquiposTable
             ])
             ->defaultSort('created_at', 'desc')
             ->filters([
+                SelectFilter::make('categoria')
+                    ->label('Categoria')
+                    ->options([
+                        'tecnologico' => 'Tecnologico',
+                        'no_tecnologico' => 'No tecnologico',
+                    ]),
                 SelectFilter::make('tipo')
                     ->label('Tipo')
                     ->options([
@@ -102,6 +136,13 @@ class EquiposTable
                         'impresora' => 'Impresora',
                         'servidor' => 'Servidor',
                         'usb' => 'USB',
+                        'disco_externo' => 'Disco externo',
+                        'telefono' => 'Telefono',
+                        'tablet' => 'Tablet',
+                        'dispositivo_red' => 'Disp. red',
+                        'dvd_cd' => 'DVD/CD',
+                        'expediente_fisico' => 'Expediente',
+                        'soporte_nube' => 'Cloud',
                         'otro' => 'Otro',
                     ]),
                 SelectFilter::make('estado')

--- a/app/Filament/Resources/Registros/Schemas/RegistroForm.php
+++ b/app/Filament/Resources/Registros/Schemas/RegistroForm.php
@@ -99,6 +99,20 @@ class RegistroForm
                         ->columns(2)
                         ->collapsible()
                         ->columnSpan(['default' => 1, 'lg' => 5]),
+
+                    // Equipo vinculado (solo F13)
+                    Section::make('Equipo vinculado')
+                        ->icon('heroicon-o-computer-desktop')
+                        ->description('Vincula este registro al equipo correspondiente.')
+                        ->schema([
+                            Select::make('equipo_id')
+                                ->label('Equipo')
+                                ->relationship('equipo', 'codigo_interno')
+                                ->searchable()
+                                ->placeholder('Seleccionar equipo (opcional)'),
+                        ])
+                        ->visible(fn (Get $get): bool => $get('tipo_formato') === 'F13')
+                        ->columnSpan(['default' => 1, 'lg' => 7]),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/Registros/Schemas/RegistroForm.php
+++ b/app/Filament/Resources/Registros/Schemas/RegistroForm.php
@@ -107,7 +107,7 @@ class RegistroForm
     {
         $groups = [
             'Datos y acceso' => [TipoFormato::F02, TipoFormato::F04, TipoFormato::F05, TipoFormato::F03],
-            'Soportes y activos' => [TipoFormato::F07, TipoFormato::F08, TipoFormato::F12, TipoFormato::F13],
+            'Soportes y activos' => [TipoFormato::F12, TipoFormato::F13], // F07 y F08 son ahora reportes, no registros
             'Incidencias' => [TipoFormato::F09, TipoFormato::F10, TipoFormato::F11],
             'Auditoria y control' => [TipoFormato::F01, TipoFormato::F06],
         ];

--- a/app/Models/BackupEjecucion.php
+++ b/app/Models/BackupEjecucion.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BackupEjecucion extends Model
+{
+    protected $table = 'backup_ejecuciones';
+
+    protected $fillable = [
+        'programacion_id',
+        'fecha_ejecucion',
+        'ejecutado_por',
+        'estado',
+        'notas',
+        'registro_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'fecha_ejecucion' => 'datetime',
+        ];
+    }
+
+    public function programacion(): BelongsTo
+    {
+        return $this->belongsTo(BackupProgramacion::class, 'programacion_id');
+    }
+
+    public function ejecutor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'ejecutado_por')->withoutGlobalScopes();
+    }
+
+    public function registro(): BelongsTo
+    {
+        return $this->belongsTo(Registro::class, 'registro_id');
+    }
+}

--- a/app/Models/BackupProgramacion.php
+++ b/app/Models/BackupProgramacion.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\BelongsToEmpresa;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class BackupProgramacion extends Model
+{
+    use BelongsToEmpresa, SoftDeletes;
+
+    protected $table = 'backup_programaciones';
+
+    protected $fillable = [
+        'empresa_id',
+        'equipo_id',
+        'nombre',
+        'periodicidad',
+        'proximo_backup',
+        'descripcion',
+        'activo',
+        'creado_por',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'proximo_backup' => 'date',
+            'activo' => 'boolean',
+        ];
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+
+    public function equipo(): BelongsTo
+    {
+        return $this->belongsTo(Equipo::class, 'equipo_id');
+    }
+
+    public function ejecuciones(): HasMany
+    {
+        return $this->hasMany(BackupEjecucion::class, 'programacion_id')->orderByDesc('fecha_ejecucion');
+    }
+
+    public function creador(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'creado_por')->withoutGlobalScopes();
+    }
+
+    public function calcularProximoBackup(): string
+    {
+        $fecha = $this->proximo_backup->copy();
+
+        return match ($this->periodicidad) {
+            'diaria' => $fecha->addDay()->toDateString(),
+            'semanal' => $fecha->addWeek()->toDateString(),
+            'quincenal' => $fecha->addWeeks(2)->toDateString(),
+            'mensual' => $fecha->addMonth()->toDateString(),
+            'trimestral' => $fecha->addMonths(3)->toDateString(),
+            'puntual' => $fecha->toDateString(), // no avanza
+            default => $fecha->addMonth()->toDateString(),
+        };
+    }
+
+    public function estaAtrasado(): bool
+    {
+        return $this->activo && $this->proximo_backup->isPast();
+    }
+
+    public function estaProximo(): bool
+    {
+        return $this->activo && $this->proximo_backup->isToday() || $this->proximo_backup->isTomorrow();
+    }
+}

--- a/app/Models/Equipo.php
+++ b/app/Models/Equipo.php
@@ -31,6 +31,9 @@ class Equipo extends Model
         'fecha_adquisicion',
         'fecha_garantia',
         'observaciones',
+        'categoria',
+        'contenido_datos',
+        'clasificacion_soporte',
     ];
 
     protected function casts(): array
@@ -84,5 +87,20 @@ class Equipo extends Model
     public function estaDisponible(): bool
     {
         return $this->estado === 'activo' && ! $this->estaAsignado();
+    }
+
+    public function registros(): HasMany
+    {
+        return $this->hasMany(Registro::class, 'equipo_id');
+    }
+
+    public function backupProgramaciones(): HasMany
+    {
+        return $this->hasMany(BackupProgramacion::class, 'equipo_id');
+    }
+
+    public function esTecnologico(): bool
+    {
+        return $this->categoria === 'tecnologico';
     }
 }

--- a/app/Models/EquipoAsignacion.php
+++ b/app/Models/EquipoAsignacion.php
@@ -19,6 +19,10 @@ class EquipoAsignacion extends Model
         'condicion_devolucion',
         'notas',
         'asignado_por',
+        'empresa_tercera',
+        'ruc_tercero',
+        'contacto_tercero',
+        'motivo',
     ];
 
     protected function casts(): array
@@ -46,6 +50,6 @@ class EquipoAsignacion extends Model
 
     public function esVigente(): bool
     {
-        return $this->fecha_fin === null && in_array($this->tipo, ['asignacion', 'transferencia']);
+        return $this->fecha_fin === null && in_array($this->tipo, ['asignacion', 'transferencia', 'salida_homeoffice']);
     }
 }

--- a/app/Models/Registro.php
+++ b/app/Models/Registro.php
@@ -19,6 +19,7 @@ class Registro extends Model
         'estado',
         'creado_por',
         'modificado_por',
+        'equipo_id',
     ];
 
     protected function casts(): array
@@ -41,5 +42,10 @@ class Registro extends Model
     public function modificador(): BelongsTo
     {
         return $this->belongsTo(User::class, 'modificado_por')->withoutGlobalScopes();
+    }
+
+    public function equipo(): BelongsTo
+    {
+        return $this->belongsTo(Equipo::class, 'equipo_id');
     }
 }

--- a/database/migrations/2026_04_07_100001_add_asset_fields_to_equipos_table.php
+++ b/database/migrations/2026_04_07_100001_add_asset_fields_to_equipos_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('equipos', function (Blueprint $table) {
+            $table->string('categoria')->default('tecnologico')->after('tipo');
+            $table->text('contenido_datos')->nullable()->after('observaciones');
+            $table->string('clasificacion_soporte')->nullable()->after('contenido_datos');
+
+            $table->index(['empresa_id', 'categoria']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('equipos', function (Blueprint $table) {
+            $table->dropIndex(['empresa_id', 'categoria']);
+            $table->dropColumn(['categoria', 'contenido_datos', 'clasificacion_soporte']);
+        });
+    }
+};

--- a/database/migrations/2026_04_07_100002_add_movement_fields_to_equipo_asignaciones_table.php
+++ b/database/migrations/2026_04_07_100002_add_movement_fields_to_equipo_asignaciones_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('equipo_asignaciones', function (Blueprint $table) {
+            $table->string('empresa_tercera')->nullable()->after('notas');
+            $table->string('ruc_tercero')->nullable()->after('empresa_tercera');
+            $table->string('contacto_tercero')->nullable()->after('ruc_tercero');
+            $table->text('motivo')->nullable()->after('contacto_tercero');
+
+            // Make user_id nullable for ingreso_nuevo (no user assigned)
+            $table->unsignedBigInteger('user_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('equipo_asignaciones', function (Blueprint $table) {
+            $table->dropColumn(['empresa_tercera', 'ruc_tercero', 'contacto_tercero', 'motivo']);
+            $table->unsignedBigInteger('user_id')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_07_100003_add_equipo_id_to_registros_table.php
+++ b/database/migrations/2026_04_07_100003_add_equipo_id_to_registros_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('registros', function (Blueprint $table) {
+            $table->unsignedBigInteger('equipo_id')->nullable()->after('modificado_por');
+            $table->foreign('equipo_id')->references('id')->on('equipos')->nullOnDelete();
+            $table->index('equipo_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('registros', function (Blueprint $table) {
+            $table->dropForeign(['equipo_id']);
+            $table->dropIndex(['equipo_id']);
+            $table->dropColumn('equipo_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_07_100004_create_backup_programaciones_table.php
+++ b/database/migrations/2026_04_07_100004_create_backup_programaciones_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('backup_programaciones', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('empresa_id');
+            $table->foreign('empresa_id')->references('id')->on('empresas')->cascadeOnDelete();
+            $table->unsignedBigInteger('equipo_id')->nullable();
+            $table->foreign('equipo_id')->references('id')->on('equipos')->nullOnDelete();
+            $table->string('nombre');
+            $table->string('periodicidad'); // diaria, semanal, quincenal, mensual, trimestral, puntual
+            $table->date('proximo_backup');
+            $table->text('descripcion')->nullable();
+            $table->boolean('activo')->default(true);
+            $table->unsignedBigInteger('creado_por');
+            $table->foreign('creado_por')->references('id')->on('users');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['empresa_id', 'activo']);
+            $table->index(['proximo_backup', 'activo']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('backup_programaciones');
+    }
+};

--- a/database/migrations/2026_04_07_100005_create_backup_ejecuciones_table.php
+++ b/database/migrations/2026_04_07_100005_create_backup_ejecuciones_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('backup_ejecuciones', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('programacion_id');
+            $table->foreign('programacion_id')->references('id')->on('backup_programaciones')->cascadeOnDelete();
+            $table->dateTime('fecha_ejecucion');
+            $table->unsignedBigInteger('ejecutado_por');
+            $table->foreign('ejecutado_por')->references('id')->on('users');
+            $table->string('estado'); // ejecutado, pendiente, atrasado
+            $table->text('notas')->nullable();
+            $table->unsignedBigInteger('registro_id')->nullable();
+            $table->foreign('registro_id')->references('id')->on('registros')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('backup_ejecuciones');
+    }
+};

--- a/database/seeders/BackupEmailTemplatesSeeder.php
+++ b/database/seeders/BackupEmailTemplatesSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\EmailTemplate;
+use Illuminate\Database\Seeder;
+
+class BackupEmailTemplatesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $templates = [
+            [
+                'slug' => 'backup-proximo',
+                'nombre' => 'Recordatorio de backup proximo',
+                'asunto' => 'Recordatorio: Backup programado para mañana — {{nombre_backup}}',
+                'contenido' => "Estimado administrador,\n\nLe recordamos que el backup \"{{nombre_backup}}\" esta programado para mañana {{fecha_programada}}.\n\nEquipo asociado: {{equipo}}\nEmpresa: {{empresa}}\n\nPor favor asegurese de que el backup se ejecute correctamente y marque la ejecucion en el sistema.\n\nSaludos,\nSecuriForm",
+                'variables_disponibles' => ['nombre_backup', 'fecha_programada', 'equipo', 'empresa'],
+            ],
+            [
+                'slug' => 'backup-atrasado',
+                'nombre' => 'Alerta de backup atrasado',
+                'asunto' => 'ALERTA: Backup atrasado — {{nombre_backup}}',
+                'contenido' => "Estimado administrador,\n\nEl backup \"{{nombre_backup}}\" esta ATRASADO.\n\nFecha programada: {{fecha_programada}}\nDias de atraso: {{dias_atraso}}\nEquipo asociado: {{equipo}}\nEmpresa: {{empresa}}\n\nEste backup no ha sido marcado como ejecutado. Por favor tome accion inmediata para cumplir con la politica de copias de seguridad (PSC000003/PSC000-15).\n\nSaludos,\nSecuriForm",
+                'variables_disponibles' => ['nombre_backup', 'fecha_programada', 'dias_atraso', 'equipo', 'empresa'],
+            ],
+        ];
+
+        foreach ($templates as $template) {
+            EmailTemplate::updateOrCreate(
+                ['slug' => $template['slug']],
+                [
+                    'nombre' => $template['nombre'],
+                    'asunto' => $template['asunto'],
+                    'contenido' => $template['contenido'],
+                    'variables_disponibles' => $template['variables_disponibles'],
+                    'plantilla_default_asunto' => $template['asunto'],
+                    'plantilla_default_contenido' => $template['contenido'],
+                    'activo' => true,
+                ]
+            );
+        }
+    }
+}

--- a/resources/views/filament/pages/reporte-inventario-soportes.blade.php
+++ b/resources/views/filament/pages/reporte-inventario-soportes.blade.php
@@ -1,0 +1,22 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <form wire:submit="generateReport">
+            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr auto; gap: 16px; align-items: end;">
+                {{ $this->form }}
+
+                <div style="padding-bottom: 2px;">
+                    <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
+                        Generar PDF
+                    </x-filament::button>
+                </div>
+            </div>
+        </form>
+    </x-filament::section>
+
+    <x-filament::section heading="Informacion" icon="heroicon-o-information-circle">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+            Genera un reporte PDF del inventario de soportes de informacion (Formato 7) segun las politicas PSC000003 y PSC000004.
+            Incluye activos tecnologicos y no tecnologicos con su clasificacion, ubicacion y nivel de sensibilidad.
+        </p>
+    </x-filament::section>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/reporte-movimientos-soportes.blade.php
+++ b/resources/views/filament/pages/reporte-movimientos-soportes.blade.php
@@ -1,0 +1,22 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <form wire:submit="generateReport">
+            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr auto; gap: 16px; align-items: end;">
+                {{ $this->form }}
+
+                <div style="padding-bottom: 2px;">
+                    <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
+                        Generar PDF
+                    </x-filament::button>
+                </div>
+            </div>
+        </form>
+    </x-filament::section>
+
+    <x-filament::section heading="Informacion" icon="heroicon-o-information-circle">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+            Genera un reporte PDF de movimientos de soportes (Formato 8) segun la politica PSC000003.
+            Incluye ingresos, asignaciones, transferencias, devoluciones, salidas a mantenimiento, home office y terceros.
+        </p>
+    </x-filament::section>
+</x-filament-panels::page>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('backups:check-alarms')->dailyAt('08:00');


### PR DESCRIPTION
## Summary
- **SEN-108**: 5 migrations (asset fields, movement fields, equipo_id on registros, backup_programaciones, backup_ejecuciones) + BackupProgramacion/BackupEjecucion models + Equipo/EquipoAsignacion/Registro model updates
- **SEN-109**: Expanded asset types (13 types grouped tech/non-tech), new categoria/clasificacion_soporte fields, conditional specs visibility
- **SEN-110**: F07 ReporteInventarioSoportes — PDF report from equipos table with filters (replaces manual F07 registro)
- **SEN-111**: F08 extended movements (mantenimiento, home office, terceros) + ingreso_nuevo on create + ReporteMovimientosSoportes PDF + F07/F08 hidden from registro catalog
- **SEN-112**: BackupProgramacionResource CRUD with "Marcar ejecutado" (auto-creates F12), color-coded dates, CheckBackupAlarms command (daily 08:00), email templates seeder
- **SEN-113**: F13 linked to equipo via equipo_id FK, "Registros asociados" section in EquipoForm, equipo_id Select in RegistroForm for F13

closes SEN-108, closes SEN-109, closes SEN-110, closes SEN-111, closes SEN-112, closes SEN-113

## Test plan
- [ ] Create tech and non-tech assets, verify conditional fields
- [ ] Generate F07 PDF report with filters, verify empty-result message
- [ ] Execute salida_mantenimiento/homeoffice/terceros actions
- [ ] Create new equipo, verify ingreso_nuevo auto-created
- [ ] Generate F08 PDF report by month
- [ ] Create backup programacion, mark as executed, verify F12 auto-created
- [ ] Verify proximo_backup advances per periodicidad
- [ ] Run `backups:check-alarms` command
- [ ] Dar de baja equipo, verify F13 has equipo_id
- [ ] From equipo edit, verify "Registros asociados" shows linked records
- [ ] From F13 registro, verify equipo_id Select works

🤖 Generated with [Claude Code](https://claude.com/claude-code)