### PR TITLE
fix(SEN-117): allow ticket creator to reopen resolved ticket

### DIFF
--- a/app/Filament/Resources/Tickets/Pages/ViewTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/ViewTicket.php
@@ -299,7 +299,9 @@ class ViewTicket extends ViewRecord
                         ->success()
                         ->send();
                 })
-                ->visible(fn () => $this->record->puedeReabrirse() && auth()->user()->can('editar_tickets')),
+                ->visible(fn () => $this->record->puedeReabrirse() && (
+                    auth()->user()->can('editar_tickets') || auth()->id() === $this->record->creado_por
+                )),
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Allow the ticket creator (not just agents) to reopen their own resolved ticket within the 7-day window
- Previously only users with `editar_tickets` permission could see the "Reabrir" button
- Now the condition also checks `auth()->id() === $this->record->creado_por`

## Test plan
- [ ] Login as a regular user who created a ticket
- [ ] Resolve the ticket (via agent)
- [ ] Verify the "Reabrir ticket" button appears for the creator
- [ ] Verify the button does NOT appear after 7 days
- [ ] Verify agents can still reopen tickets as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)