### PR TITLE
feat(SEN-118): add ViewEmpresa page with metrics and relation managers

### DIFF
--- a/app/Filament/Resources/Empresas/EmpresaResource.php
+++ b/app/Filament/Resources/Empresas/EmpresaResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Empresas;
 use App\Filament\Resources\Empresas\Pages\CreateEmpresa;
 use App\Filament\Resources\Empresas\Pages\EditEmpresa;
 use App\Filament\Resources\Empresas\Pages\ListEmpresas;
+use App\Filament\Resources\Empresas\Pages\ViewEmpresa;
 use App\Filament\Resources\Empresas\Schemas\EmpresaForm;
 use App\Filament\Resources\Empresas\Tables\EmpresasTable;
 use App\Models\Empresa;
@@ -49,6 +50,7 @@ class EmpresaResource extends Resource
     {
         return [
             RelationManagers\UsersRelationManager::class,
+            RelationManagers\RegistrosRelationManager::class,
         ];
     }
 
@@ -57,6 +59,7 @@ class EmpresaResource extends Resource
         return [
             'index' => ListEmpresas::route('/'),
             'create' => CreateEmpresa::route('/create'),
+            'view' => ViewEmpresa::route('/{record}'),
             'edit' => EditEmpresa::route('/{record}/edit'),
         ];
     }

--- a/app/Filament/Resources/Empresas/Pages/ViewEmpresa.php
+++ b/app/Filament/Resources/Empresas/Pages/ViewEmpresa.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\Pages;
+
+use App\Filament\Resources\Empresas\EmpresaResource;
+use App\Models\Registro;
+use App\Models\Ticket;
+use App\Models\User;
+use Filament\Actions\EditAction;
+use Filament\Infolists\Components\ImageEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Pages\ViewRecord;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class ViewEmpresa extends ViewRecord
+{
+    protected static string $resource = EmpresaResource::class;
+
+    public function getTitle(): string
+    {
+        return $this->record->razon_social;
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+        ];
+    }
+
+    public function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->schema([
+                Section::make('Métricas')
+                    ->columns(4)
+                    ->columnSpanFull()
+                    ->schema([
+                        TextEntry::make('registros_mes')
+                            ->label('Registros este mes')
+                            ->state(fn () => Registro::withoutGlobalScopes()
+                                ->where('empresa_id', $this->record->id)
+                                ->whereMonth('created_at', now()->month)
+                                ->whereYear('created_at', now()->year)
+                                ->count()
+                            )
+                            ->badge()
+                            ->color('success'),
+                        TextEntry::make('tickets_abiertos')
+                            ->label('Tickets abiertos')
+                            ->state(fn () => Ticket::withoutGlobalScopes()
+                                ->where('empresa_id', $this->record->id)
+                                ->whereNotIn('estado', ['resuelto', 'cerrado'])
+                                ->count()
+                            )
+                            ->badge()
+                            ->color(fn ($state) => $state > 0 ? 'warning' : 'success'),
+                        TextEntry::make('usuarios_activos')
+                            ->label('Usuarios activos')
+                            ->state(fn () => User::withoutGlobalScopes()
+                                ->where('empresa_id', $this->record->id)
+                                ->where('estado', 'activo')
+                                ->count()
+                            )
+                            ->badge()
+                            ->color('info'),
+                        TextEntry::make('ultimo_acceso')
+                            ->label('Último acceso')
+                            ->state(fn () => User::withoutGlobalScopes()
+                                ->where('empresa_id', $this->record->id)
+                                ->whereNotNull('ultimo_acceso')
+                                ->max('ultimo_acceso')
+                            )
+                            ->dateTime('d/m/Y H:i')
+                            ->placeholder('Nunca'),
+                    ]),
+
+                Section::make('Datos de la empresa')
+                    ->columns(3)
+                    ->columnSpanFull()
+                    ->schema([
+                        ImageEntry::make('logo_path')
+                            ->label('Logo')
+                            ->disk('logos')
+                            ->height(60)
+                            ->defaultImageUrl(url('/images/placeholder.png')),
+                        TextEntry::make('ruc')
+                            ->label('RUC'),
+                        TextEntry::make('razon_social')
+                            ->label('Razón social'),
+                        TextEntry::make('email')
+                            ->label('Email'),
+                        TextEntry::make('telefono')
+                            ->label('Teléfono')
+                            ->placeholder('—'),
+                        TextEntry::make('direccion')
+                            ->label('Dirección')
+                            ->placeholder('—'),
+                        TextEntry::make('estado')
+                            ->label('Estado')
+                            ->badge()
+                            ->color(fn (string $state): string => match ($state) {
+                                'activo' => 'success',
+                                'inactivo' => 'danger',
+                                default => 'gray',
+                            }),
+                        TextEntry::make('created_at')
+                            ->label('Creada')
+                            ->dateTime('d/m/Y'),
+                    ]),
+
+                Section::make('Actividad mensual (últimos 6 meses)')
+                    ->columnSpanFull()
+                    ->schema([
+                        TextEntry::make('actividad_mensual')
+                            ->label('')
+                            ->state(function () {
+                                $meses = collect();
+                                for ($i = 5; $i >= 0; $i--) {
+                                    $fecha = now()->subMonths($i);
+                                    $registros = Registro::withoutGlobalScopes()
+                                        ->where('empresa_id', $this->record->id)
+                                        ->whereMonth('created_at', $fecha->month)
+                                        ->whereYear('created_at', $fecha->year)
+                                        ->count();
+                                    $tickets = Ticket::withoutGlobalScopes()
+                                        ->where('empresa_id', $this->record->id)
+                                        ->whereMonth('created_at', $fecha->month)
+                                        ->whereYear('created_at', $fecha->year)
+                                        ->count();
+                                    $meses->push($fecha->translatedFormat('M Y') . ": {$registros} registros, {$tickets} tickets");
+                                }
+                                return $meses->implode(' | ');
+                            }),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Empresas/RelationManagers/RegistrosRelationManager.php
+++ b/app/Filament/Resources/Empresas/RelationManagers/RegistrosRelationManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Filament\Resources\Empresas\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class RegistrosRelationManager extends RelationManager
+{
+    protected static string $relationship = 'registros';
+
+    protected static ?string $title = 'Registros recientes';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('numero_registro')
+                    ->label('Número')
+                    ->searchable(),
+                TextColumn::make('tipo_formato')
+                    ->label('Formato')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => strtoupper($state)),
+                TextColumn::make('creador.name')
+                    ->label('Creado por'),
+                TextColumn::make('created_at')
+                    ->label('Fecha')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ViewEmpresa` page with key stats: registros del mes, tickets abiertos, usuarios activos, último acceso
- Add 6-month activity summary showing registros + tickets per month
- Add `RegistrosRelationManager` showing recent registros for the empresa
- Register view page route and new relation manager in `EmpresaResource`

## Test plan
- [ ] Navigate to Empresas list as super_admin
- [ ] Click on an empresa to see the new View page
- [ ] Verify stats show correct counts (registros, tickets, users, last access)
- [ ] Verify 6-month activity summary displays data
- [ ] Verify Users relation manager tab shows empresa users
- [ ] Verify Registros relation manager tab shows recent registros
- [ ] Verify Edit button in header navigates to edit page

🤖 Generated with [Claude Code](https://claude.com/claude-code)