### PR TITLE
feat(SEN-119): add compliance panel for policy acceptance tracking

### DIFF
--- a/app/Filament/Pages/PanelCumplimiento.php
+++ b/app/Filament/Pages/PanelCumplimiento.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Jobs\SendEmailJob;
+use App\Models\AceptacionPolitica;
+use App\Models\Politica;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Collection;
+
+class PanelCumplimiento extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedShieldCheck;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Seguridad';
+
+    protected static ?string $navigationLabel = 'Cumplimiento';
+
+    protected static ?string $title = 'Panel de Cumplimiento';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static string $view = 'filament.pages.panel-cumplimiento';
+
+    public ?int $selectedPoliticaId = null;
+
+    public static function canAccess(): bool
+    {
+        $user = auth()->user();
+
+        return $user && ($user->hasRole('super_admin') || $user->hasRole('admin_empresa'));
+    }
+
+    public function getStats(): array
+    {
+        $empresaId = Filament::getTenant()?->id;
+        if (! $empresaId) {
+            return ['total_politicas' => 0, 'cumplimiento_general' => 0, 'usuarios_pendientes' => 0];
+        }
+
+        $politicas = Politica::withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('activa', true)
+            ->where('obligatoria', true)
+            ->get();
+
+        $totalPoliticas = $politicas->count();
+
+        if ($totalPoliticas === 0) {
+            return ['total_politicas' => 0, 'cumplimiento_general' => 100, 'usuarios_pendientes' => 0];
+        }
+
+        $usuarios = User::withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('estado', 'activo')
+            ->get();
+
+        $totalUsuarios = $usuarios->count();
+        if ($totalUsuarios === 0) {
+            return ['total_politicas' => $totalPoliticas, 'cumplimiento_general' => 100, 'usuarios_pendientes' => 0];
+        }
+
+        $totalPares = $totalPoliticas * $totalUsuarios;
+        $aceptados = 0;
+        $usuariosPendientes = collect();
+
+        foreach ($politicas as $politica) {
+            foreach ($usuarios as $usuario) {
+                if ($politica->aceptadaPor($usuario->id)) {
+                    $aceptados++;
+                } else {
+                    $usuariosPendientes->push($usuario->id);
+                }
+            }
+        }
+
+        return [
+            'total_politicas' => $totalPoliticas,
+            'cumplimiento_general' => $totalPares > 0 ? round(($aceptados / $totalPares) * 100) : 0,
+            'usuarios_pendientes' => $usuariosPendientes->unique()->count(),
+        ];
+    }
+
+    public function getPoliticas(): Collection
+    {
+        $empresaId = Filament::getTenant()?->id;
+        if (! $empresaId) {
+            return collect();
+        }
+
+        $politicas = Politica::withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('activa', true)
+            ->where('obligatoria', true)
+            ->orderBy('titulo')
+            ->get();
+
+        $totalUsuarios = User::withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('estado', 'activo')
+            ->count();
+
+        return $politicas->map(function ($politica) use ($totalUsuarios) {
+            $aceptados = $politica->aceptaciones()
+                ->where('version_aceptada', $politica->version)
+                ->distinct('user_id')
+                ->count('user_id');
+
+            $porcentaje = $totalUsuarios > 0 ? round(($aceptados / $totalUsuarios) * 100) : 0;
+
+            return (object) [
+                'id' => $politica->id,
+                'titulo' => $politica->titulo,
+                'version' => $politica->version,
+                'es_nda' => $politica->es_nda,
+                'aceptados' => $aceptados,
+                'total_usuarios' => $totalUsuarios,
+                'porcentaje' => $porcentaje,
+            ];
+        });
+    }
+
+    public function getDetallePolitica(): ?Collection
+    {
+        if (! $this->selectedPoliticaId) {
+            return null;
+        }
+
+        $empresaId = Filament::getTenant()?->id;
+        if (! $empresaId) {
+            return null;
+        }
+
+        $politica = Politica::withoutGlobalScopes()->find($this->selectedPoliticaId);
+        if (! $politica) {
+            return null;
+        }
+
+        $usuarios = User::withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('estado', 'activo')
+            ->orderBy('name')
+            ->get();
+
+        return $usuarios->map(function ($usuario) use ($politica) {
+            $aceptacion = AceptacionPolitica::where('user_id', $usuario->id)
+                ->where('politica_id', $politica->id)
+                ->where('version_aceptada', $politica->version)
+                ->latest('fecha_aceptacion')
+                ->first();
+
+            $estado = 'pendiente';
+            if ($aceptacion) {
+                if ($aceptacion->fecha_expiracion && $aceptacion->fecha_expiracion->isPast()) {
+                    $estado = 'vencida';
+                } else {
+                    $estado = 'aceptada';
+                }
+            }
+
+            return (object) [
+                'user_id' => $usuario->id,
+                'name' => $usuario->name,
+                'email' => $usuario->email,
+                'estado' => $estado,
+                'fecha_aceptacion' => $aceptacion?->fecha_aceptacion?->format('d/m/Y H:i'),
+                'fecha_expiracion' => $aceptacion?->fecha_expiracion?->format('d/m/Y'),
+            ];
+        });
+    }
+
+    public function selectPolitica(int $politicaId): void
+    {
+        $this->selectedPoliticaId = $politicaId;
+    }
+
+    public function enviarRecordatorio(int $userId): void
+    {
+        $user = User::withoutGlobalScopes()->find($userId);
+        if (! $user) {
+            return;
+        }
+
+        $loginUrl = url('admin/' . Filament::getTenant()?->ruc . '/login');
+
+        dispatch(SendEmailJob::fromTemplate(
+            destinatario: $user->email,
+            nombreDestino: $user->name,
+            templateSlug: 'recordatorio_politica',
+            templateVariables: [
+                'nombre' => $user->name,
+                'enlace_login' => $loginUrl,
+            ],
+            saludo: "Hola {$user->name},",
+            actionUrl: $loginUrl,
+            actionLabel: 'Iniciar sesión',
+        ));
+
+        Notification::make()
+            ->title('Recordatorio enviado')
+            ->body("Se envió email a {$user->email}")
+            ->success()
+            ->send();
+    }
+
+    public function enviarRecordatorioMasivo(): void
+    {
+        $detalle = $this->getDetallePolitica();
+        if (! $detalle) {
+            return;
+        }
+
+        $pendientes = $detalle->filter(fn ($u) => $u->estado !== 'aceptada');
+        $count = 0;
+
+        foreach ($pendientes as $usuario) {
+            $this->enviarRecordatorio($usuario->user_id);
+            $count++;
+        }
+
+        Notification::make()
+            ->title('Recordatorios enviados')
+            ->body("Se enviaron {$count} emails a usuarios pendientes")
+            ->success()
+            ->send();
+    }
+}

--- a/resources/views/filament/pages/panel-cumplimiento.blade.php
+++ b/resources/views/filament/pages/panel-cumplimiento.blade.php
@@ -1,0 +1,161 @@
+<x-filament-panels::page>
+    {{-- Stats --}}
+    @php $stats = $this->getStats(); @endphp
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold text-primary-600">{{ $stats['total_politicas'] }}</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Politicas obligatorias activas</div>
+            </div>
+        </x-filament::section>
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold {{ $stats['cumplimiento_general'] >= 80 ? 'text-success-600' : ($stats['cumplimiento_general'] >= 50 ? 'text-warning-600' : 'text-danger-600') }}">
+                    {{ $stats['cumplimiento_general'] }}%
+                </div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Cumplimiento general</div>
+            </div>
+        </x-filament::section>
+        <x-filament::section>
+            <div class="text-center">
+                <div class="text-3xl font-bold {{ $stats['usuarios_pendientes'] > 0 ? 'text-warning-600' : 'text-success-600' }}">
+                    {{ $stats['usuarios_pendientes'] }}
+                </div>
+                <div class="text-sm text-gray-500 dark:text-gray-400">Usuarios con pendientes</div>
+            </div>
+        </x-filament::section>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {{-- Politicas list --}}
+        <x-filament::section heading="Politicas obligatorias">
+            @php $politicas = $this->getPoliticas(); @endphp
+
+            @if($politicas->isEmpty())
+                <div class="text-center py-8 text-gray-500 dark:text-gray-400">
+                    No hay politicas obligatorias activas
+                </div>
+            @else
+                <div class="space-y-2">
+                    @foreach($politicas as $politica)
+                        <button
+                            wire:click="selectPolitica({{ $politica->id }})"
+                            class="w-full text-left p-3 rounded-lg border transition-colors
+                                {{ $this->selectedPoliticaId === $politica->id
+                                    ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
+                                    : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800' }}"
+                        >
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <span class="font-medium text-gray-900 dark:text-gray-100">{{ $politica->titulo }}</span>
+                                    <span class="text-xs text-gray-500 ml-2">v{{ $politica->version }}</span>
+                                    @if($politica->es_nda)
+                                        <x-filament::badge size="sm" color="info" class="ml-1">NDA</x-filament::badge>
+                                    @endif
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="text-sm text-gray-500">{{ $politica->aceptados }}/{{ $politica->total_usuarios }}</span>
+                                    <x-filament::badge
+                                        size="sm"
+                                        :color="$politica->porcentaje >= 80 ? 'success' : ($politica->porcentaje >= 50 ? 'warning' : 'danger')"
+                                    >
+                                        {{ $politica->porcentaje }}%
+                                    </x-filament::badge>
+                                </div>
+                            </div>
+                        </button>
+                    @endforeach
+                </div>
+            @endif
+        </x-filament::section>
+
+        {{-- User detail --}}
+        <x-filament::section>
+            @php $detalle = $this->getDetallePolitica(); @endphp
+
+            @if(!$detalle)
+                <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+                    <x-filament::icon icon="heroicon-o-cursor-arrow-rays" class="w-12 h-12 mx-auto mb-3 opacity-50" />
+                    <p>Selecciona una politica para ver el detalle de cumplimiento</p>
+                </div>
+            @else
+                @php
+                    $politicaSeleccionada = $this->getPoliticas()->firstWhere('id', $this->selectedPoliticaId);
+                    $pendientes = $detalle->filter(fn ($u) => $u->estado !== 'aceptada');
+                @endphp
+
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                        {{ $politicaSeleccionada?->titulo ?? 'Detalle' }}
+                    </h3>
+                    @if($pendientes->isNotEmpty())
+                        <x-filament::button
+                            size="sm"
+                            color="warning"
+                            icon="heroicon-m-envelope"
+                            wire:click="enviarRecordatorioMasivo"
+                            wire:loading.attr="disabled"
+                        >
+                            Recordar a {{ $pendientes->count() }} pendientes
+                        </x-filament::button>
+                    @endif
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b dark:border-gray-700">
+                                <th class="text-left py-2 px-3 text-gray-500 dark:text-gray-400 font-medium">Usuario</th>
+                                <th class="text-left py-2 px-3 text-gray-500 dark:text-gray-400 font-medium">Estado</th>
+                                <th class="text-left py-2 px-3 text-gray-500 dark:text-gray-400 font-medium">Fecha</th>
+                                <th class="text-right py-2 px-3 text-gray-500 dark:text-gray-400 font-medium">Accion</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($detalle as $usuario)
+                                <tr class="border-b dark:border-gray-700/50">
+                                    <td class="py-2 px-3">
+                                        <div class="font-medium text-gray-900 dark:text-gray-100">{{ $usuario->name }}</div>
+                                        <div class="text-xs text-gray-500">{{ $usuario->email }}</div>
+                                    </td>
+                                    <td class="py-2 px-3">
+                                        @if($usuario->estado === 'aceptada')
+                                            <x-filament::badge size="sm" color="success">Aceptada</x-filament::badge>
+                                        @elseif($usuario->estado === 'vencida')
+                                            <x-filament::badge size="sm" color="danger">Vencida</x-filament::badge>
+                                        @else
+                                            <x-filament::badge size="sm" color="warning">Pendiente</x-filament::badge>
+                                        @endif
+                                    </td>
+                                    <td class="py-2 px-3 text-gray-500">
+                                        @if($usuario->fecha_aceptacion)
+                                            {{ $usuario->fecha_aceptacion }}
+                                            @if($usuario->fecha_expiracion)
+                                                <div class="text-xs">Vence: {{ $usuario->fecha_expiracion }}</div>
+                                            @endif
+                                        @else
+                                            —
+                                        @endif
+                                    </td>
+                                    <td class="py-2 px-3 text-right">
+                                        @if($usuario->estado !== 'aceptada')
+                                            <x-filament::button
+                                                size="xs"
+                                                color="gray"
+                                                icon="heroicon-m-envelope"
+                                                wire:click="enviarRecordatorio({{ $usuario->user_id }})"
+                                                wire:loading.attr="disabled"
+                                            >
+                                                Recordar
+                                            </x-filament::button>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </x-filament::section>
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- Add `PanelCumplimiento` page under Seguridad navigation group
- Stat cards: total obligatory policies, overall compliance %, pending users
- Interactive policy list with acceptance percentage (color-coded: green/yellow/red)
- Per-policy detail: table of users with status (aceptada/pendiente/vencida)
- Send individual or bulk email reminders to users with pending policies
- Accessible to `super_admin` and `admin_empresa` roles

## Test plan
- [ ] Login as admin_empresa, navigate to Seguridad > Cumplimiento
- [ ] Verify stats show correct counts
- [ ] Click a policy to see per-user acceptance detail
- [ ] Verify accepted users show green badge, pending show yellow, expired show red
- [ ] Test "Recordar" button sends individual email
- [ ] Test bulk "Recordar a N pendientes" button sends emails to all pending users
- [ ] Verify regular users (rol usuario) cannot access the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)