### PR TITLE
feat(SEN-120): centro de reportes + ZIP NDAs firmados

### DIFF
--- a/app/Filament/Pages/CentroReportes.php
+++ b/app/Filament/Pages/CentroReportes.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\AceptacionPolitica;
+use App\Models\Capacitacion;
+use App\Models\ChecklistEjecucion;
+use App\Models\ChecklistPlantilla;
+use App\Models\Equipo;
+use App\Models\EquipoAsignacion;
+use App\Models\Politica;
+use App\Models\Registro;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Mpdf\Mpdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class CentroReportes extends Page
+{
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa', 'agente_helpdesk']) ?? false;
+    }
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentChartBar;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
+
+    protected static ?int $navigationSort = -10;
+
+    protected static ?string $navigationLabel = 'Centro de Reportes';
+
+    protected static ?string $title = 'Centro de Reportes';
+
+    protected string $view = 'filament.pages.centro-reportes';
+
+    public function getReportes(): array
+    {
+        return [
+            [
+                'title' => 'Incidencias y Resoluciones',
+                'desc' => 'F09 + F10 — Notificaciones y resoluciones de incidencias de seguridad.',
+                'icon' => 'heroicon-o-shield-exclamation',
+                'color' => '#dc2626',
+                'url' => ReporteIncidencias::getUrl(),
+                'roles' => ['super_admin', 'admin_empresa', 'agente_helpdesk'],
+            ],
+            [
+                'title' => 'Capacitaciones',
+                'desc' => 'Capacitaciones de ciberseguridad y cumplimiento por usuario.',
+                'icon' => 'heroicon-o-academic-cap',
+                'color' => '#7c3aed',
+                'url' => ReporteCapacitaciones::getUrl(),
+                'roles' => ['super_admin', 'admin_empresa'],
+            ],
+            [
+                'title' => 'Inventario de Soportes (F07)',
+                'desc' => 'Inventario completo de equipos y soportes de informacion.',
+                'icon' => 'heroicon-o-archive-box',
+                'color' => '#0369a1',
+                'url' => ReporteInventarioSoportes::getUrl(),
+                'roles' => ['super_admin', 'admin_empresa'],
+            ],
+            [
+                'title' => 'Movimientos de Soportes (F08)',
+                'desc' => 'Ingresos, asignaciones, transferencias, mantenimientos, bajas.',
+                'icon' => 'heroicon-o-arrows-right-left',
+                'color' => '#059669',
+                'url' => ReporteMovimientosSoportes::getUrl(),
+                'roles' => ['super_admin', 'admin_empresa'],
+            ],
+            [
+                'title' => 'Destruccion de Activos (F13)',
+                'desc' => 'Registro de destruccion de activos con metodo y autorizacion.',
+                'icon' => 'heroicon-o-trash',
+                'color' => '#d97706',
+                'url' => ReporteDestruccionActivos::getUrl(),
+                'roles' => ['super_admin', 'admin_empresa'],
+            ],
+            [
+                'title' => 'Checklists de Equipos',
+                'desc' => 'Plantillas y ejecuciones de verificacion sobre equipos.',
+                'icon' => 'heroicon-o-clipboard-document-check',
+                'color' => '#0891b2',
+                'url' => ReporteChecklists::getUrl(),
+                'roles' => ['super_admin', 'admin_empresa'],
+            ],
+        ];
+    }
+
+    public function getReportesVisibles(): array
+    {
+        $user = auth()->user();
+
+        return array_values(array_filter($this->getReportes(), fn ($r) => $user?->hasRole($r['roles'])));
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('reporte_completo')
+                ->label('Reporte completo (PDF)')
+                ->icon('heroicon-o-document-arrow-down')
+                ->color('primary')
+                ->size('lg')
+                ->action(fn () => $this->generateReporteCompleto()),
+        ];
+    }
+
+    public function generateReporteCompleto(): StreamedResponse
+    {
+        $tenant = Filament::getTenant();
+
+        $mpdf = new Mpdf([
+            'format' => 'A4',
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        if ($tenant->logo_path) {
+            $logoPath = storage_path('app/'.$tenant->logo_path);
+            if (file_exists($logoPath)) {
+                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
+            }
+        }
+
+        $this->buildCompleto($mpdf, $tenant);
+
+        $filename = 'reporte_completo_'.now()->format('Ymd_His').'.pdf';
+
+        return response()->streamDownload(function () use ($mpdf) {
+            echo $mpdf->Output('', 'S');
+        }, $filename, ['Content-Type' => 'application/pdf']);
+    }
+
+    private function buildCompleto(Mpdf $mpdf, $tenant): void
+    {
+        $logoHtml = '';
+        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
+            $logoHtml = '<img src="var:logo" style="height:60px;margin-bottom:8px;" /><br>';
+        }
+
+        $style = '
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
+            h1 { color: #4338ca; font-size: 18px; margin-bottom: 2px; }
+            h2 { font-size: 14px; margin-top: 18px; color: #1e1b4b; border-bottom: 2px solid #4338ca; padding-bottom: 4px; }
+            h3 { font-size: 12px; margin-top: 12px; color: #555; }
+            table { width: 100%; border-collapse: collapse; margin-top: 6px; }
+            th, td { border: 1px solid #ddd; padding: 4px 6px; text-align: left; }
+            th { background: #f3f4f6; font-weight: bold; font-size: 9px; }
+            .cover { text-align: center; padding: 80px 20px 20px; }
+            .cover h1 { font-size: 26px; }
+            .cover .subtitle { font-size: 14px; color: #6b7280; margin-top: 16px; }
+            .cover .meta { margin-top: 60px; font-size: 11px; color: #4b5563; }
+            .stat-grid table { margin-top: 8px; }
+            .stat-grid td { text-align: center; padding: 8px 6px; background: #f9fafb; border: 1px solid #e5e7eb; }
+            .stat-number { font-size: 20px; font-weight: bold; color: #4338ca; }
+            .stat-label { font-size: 9px; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
+            .section { margin-top: 20px; }
+            .footer { margin-top: 30px; font-size: 9px; color: #888; }
+        </style>';
+
+        // ═══ COVER PAGE ═══
+        $mpdf->WriteHTML($style.'
+            <div class="cover">
+                '.$logoHtml.'
+                <h1>'.e($tenant->razon_social).'</h1>
+                <p style="color:#666;">RUC: '.e($tenant->ruc).'</p>
+                <div class="subtitle">Reporte completo de seguridad de la informacion</div>
+                <div class="meta">
+                    Generado el '.now()->format('d/m/Y H:i').'<br>
+                    Por: '.e(auth()->user()->name).'
+                </div>
+            </div>');
+
+        // ═══ EXECUTIVE SUMMARY ═══
+        $mpdf->AddPage();
+
+        $countF09 = Registro::withoutGlobalScopes()->where('empresa_id', $tenant->id)->where('tipo_formato', 'F09')->count();
+        $countF10 = Registro::withoutGlobalScopes()->where('empresa_id', $tenant->id)->where('tipo_formato', 'F10')->count();
+        $countF13 = Registro::withoutGlobalScopes()->where('empresa_id', $tenant->id)->where('tipo_formato', 'F13')->count();
+        $countCap = Capacitacion::withoutGlobalScopes()->where('empresa_id', $tenant->id)->count();
+        $equipoIds = Equipo::withoutGlobalScopes()->where('empresa_id', $tenant->id)->pluck('id');
+        $countEq = $equipoIds->count();
+        $countMov = EquipoAsignacion::whereIn('equipo_id', $equipoIds)->count();
+        $countCheckPlant = ChecklistPlantilla::withoutGlobalScopes()->where('empresa_id', $tenant->id)->count();
+        $countCheckEjec = ChecklistEjecucion::whereIn('equipo_id', $equipoIds)->count();
+        $countPolitica = Politica::withoutGlobalScopes()->where('empresa_id', $tenant->id)->count();
+        $countFirmados = AceptacionPolitica::whereHas('politica', fn ($q) => $q->withoutGlobalScopes()->where('empresa_id', $tenant->id))
+            ->whereNotNull('firma_imagen')
+            ->count();
+
+        $mpdf->WriteHTML($style.'
+            <h1>Resumen ejecutivo</h1>
+            <p style="color:#666;">Estado consolidado al '.now()->format('d/m/Y').'</p>
+
+            <div class="stat-grid">
+                <table>
+                    <tr>
+                        <td><div class="stat-number">'.$countF09.'</div><div class="stat-label">Incidencias F09</div></td>
+                        <td><div class="stat-number">'.$countF10.'</div><div class="stat-label">Resoluciones F10</div></td>
+                        <td><div class="stat-number">'.$countF13.'</div><div class="stat-label">Destrucciones F13</div></td>
+                        <td><div class="stat-number">'.$countCap.'</div><div class="stat-label">Capacitaciones</div></td>
+                    </tr>
+                    <tr>
+                        <td><div class="stat-number">'.$countEq.'</div><div class="stat-label">Equipos en inventario</div></td>
+                        <td><div class="stat-number">'.$countMov.'</div><div class="stat-label">Movimientos F08</div></td>
+                        <td><div class="stat-number">'.$countCheckPlant.'</div><div class="stat-label">Plantillas checklist</div></td>
+                        <td><div class="stat-number">'.$countCheckEjec.'</div><div class="stat-label">Ejecuciones checklist</div></td>
+                    </tr>
+                    <tr>
+                        <td colspan="2"><div class="stat-number">'.$countPolitica.'</div><div class="stat-label">Politicas / NDA</div></td>
+                        <td colspan="2"><div class="stat-number">'.$countFirmados.'</div><div class="stat-label">Documentos firmados</div></td>
+                    </tr>
+                </table>
+            </div>');
+
+        // ═══ INCIDENCIAS ═══
+        $incidencias = Registro::withoutGlobalScopes()->where('empresa_id', $tenant->id)->where('tipo_formato', 'F09')->with('creador')->orderBy('created_at', 'desc')->get();
+        $resoluciones = Registro::withoutGlobalScopes()->where('empresa_id', $tenant->id)->where('tipo_formato', 'F10')->with('creador')->orderBy('created_at', 'desc')->get();
+
+        $tasaRes = $incidencias->count() > 0 ? round($resoluciones->count() / $incidencias->count() * 100) : 0;
+
+        $incRows = '';
+        foreach ($incidencias as $i) {
+            $datos = $i->datos ?? [];
+            $incRows .= '<tr>
+                <td>'.e($i->numero_registro).'</td>
+                <td>'.e($datos['tipo_incidencia'] ?? '-').'</td>
+                <td>'.e($datos['severidad'] ?? '-').'</td>
+                <td>'.e($i->creador?->name ?? '-').'</td>
+                <td>'.$i->created_at->format('d/m/Y').'</td>
+            </tr>';
+        }
+
+        $resRows = '';
+        foreach ($resoluciones as $r) {
+            $datos = $r->datos ?? [];
+            $resRows .= '<tr>
+                <td>'.e($r->numero_registro).'</td>
+                <td>'.e($datos['incidencia_ref'] ?? '-').'</td>
+                <td>'.e($datos['clasificacion'] ?? '-').'</td>
+                <td>'.e($r->creador?->name ?? '-').'</td>
+                <td>'.$r->created_at->format('d/m/Y').'</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h2>1. Incidencias y resoluciones</h2>
+            <p>Tasa de resolucion: <strong>'.$tasaRes.'%</strong></p>
+            <h3>F09 — Incidencias ('.$incidencias->count().')</h3>
+            <table>
+                <tr><th>N°</th><th>Tipo</th><th>Severidad</th><th>Reporto</th><th>Fecha</th></tr>
+                '.($incRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin registros</td></tr>').'
+            </table>
+            <h3>F10 — Resoluciones ('.$resoluciones->count().')</h3>
+            <table>
+                <tr><th>N°</th><th>Ref F09</th><th>Clasificacion</th><th>Ejecuto</th><th>Fecha</th></tr>
+                '.($resRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin registros</td></tr>').'
+            </table>');
+
+        // ═══ CAPACITACIONES ═══
+        $mpdf->AddPage();
+        $capacitaciones = Capacitacion::withoutGlobalScopes()->where('empresa_id', $tenant->id)->with('asistencias')->orderBy('fecha', 'desc')->get();
+        $capRows = '';
+        foreach ($capacitaciones as $c) {
+            $totalA = $c->asistencias->count();
+            $asistieron = $c->asistencias->where('asistio', true)->count();
+            $pct = $totalA > 0 ? round($asistieron / $totalA * 100) : 0;
+            $capRows .= '<tr>
+                <td>'.e($c->tema).'</td>
+                <td>'.$c->fecha->format('d/m/Y').'</td>
+                <td>'.e($c->modalidad?->label() ?? '-').'</td>
+                <td>'.e($c->expositor).'</td>
+                <td>'.$asistieron.'/'.$totalA.' ('.$pct.'%)</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h2>2. Capacitaciones de ciberseguridad</h2>
+            <table>
+                <tr><th>Tema</th><th>Fecha</th><th>Modalidad</th><th>Expositor</th><th>Asistencia</th></tr>
+                '.($capRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin capacitaciones</td></tr>').'
+            </table>');
+
+        // ═══ INVENTARIO ═══
+        $mpdf->AddPage();
+        $equipos = Equipo::withoutGlobalScopes()->where('empresa_id', $tenant->id)->orderBy('codigo_interno')->get();
+        $eqRows = '';
+        foreach ($equipos as $eq) {
+            $eqRows .= '<tr>
+                <td>'.e($eq->codigo_interno ?? '-').'</td>
+                <td>'.e($eq->tipo).'</td>
+                <td>'.e(trim(($eq->marca ?? '').' '.($eq->modelo ?? '')) ?: '-').'</td>
+                <td>'.e($eq->numero_serie ?? '-').'</td>
+                <td>'.e($eq->ubicacion ?? '-').'</td>
+                <td>'.e($eq->estado ?? '-').'</td>
+                <td>'.e($eq->nivel_sensibilidad ?? '-').'</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h2>3. Inventario de soportes (F07)</h2>
+            <table>
+                <tr><th>Codigo</th><th>Tipo</th><th>Marca/Modelo</th><th>S/N</th><th>Ubicacion</th><th>Estado</th><th>Sensibilidad</th></tr>
+                '.($eqRows ?: '<tr><td colspan="7" style="text-align:center;color:#999;">Sin equipos</td></tr>').'
+            </table>');
+
+        // ═══ MOVIMIENTOS ═══
+        $mpdf->AddPage();
+        $movimientos = EquipoAsignacion::whereIn('equipo_id', $equipoIds)->with(['equipo', 'user'])->orderBy('fecha_inicio', 'desc')->get();
+        $movRows = '';
+        foreach ($movimientos as $m) {
+            $movRows .= '<tr>
+                <td>'.$m->fecha_inicio->format('d/m/Y').'</td>
+                <td>'.e($m->equipo?->codigo_interno ?? '-').'</td>
+                <td>'.e($m->tipo).'</td>
+                <td>'.e($m->user?->name ?? '-').'</td>
+                <td>'.e(mb_substr($m->motivo ?? '-', 0, 50)).'</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h2>4. Movimientos de soportes (F08)</h2>
+            <table>
+                <tr><th>Fecha</th><th>Equipo</th><th>Tipo</th><th>Usuario</th><th>Motivo</th></tr>
+                '.($movRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin movimientos</td></tr>').'
+            </table>');
+
+        // ═══ DESTRUCCION ═══
+        $destrucciones = Registro::withoutGlobalScopes()->where('empresa_id', $tenant->id)->where('tipo_formato', 'F13')->with('creador')->orderBy('created_at', 'desc')->get();
+        $destRows = '';
+        foreach ($destrucciones as $d) {
+            $datos = $d->datos ?? [];
+            $destRows .= '<tr>
+                <td>'.e($d->numero_registro).'</td>
+                <td>'.e($datos['fecha_destruccion'] ?? '-').'</td>
+                <td>'.e($datos['metodo'] ?? '-').'</td>
+                <td>'.e($datos['responsable'] ?? '-').'</td>
+                <td>'.$d->created_at->format('d/m/Y').'</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h3>Destruccion de activos (F13) — '.$destrucciones->count().'</h3>
+            <table>
+                <tr><th>N°</th><th>Fecha destruccion</th><th>Metodo</th><th>Responsable</th><th>Registrado</th></tr>
+                '.($destRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin destrucciones</td></tr>').'
+            </table>');
+
+        // ═══ CHECKLISTS ═══
+        $mpdf->AddPage();
+        $ejecuciones = ChecklistEjecucion::whereIn('equipo_id', $equipoIds)->with(['plantilla', 'equipo', 'ejecutor'])->orderBy('fecha_ejecucion', 'desc')->get();
+        $ejecRows = '';
+        foreach ($ejecuciones as $e) {
+            $cumple = $e->itemsCumplen();
+            $totalI = $e->totalItems();
+            $pct = $totalI > 0 ? round($cumple / $totalI * 100) : 0;
+            $ejecRows .= '<tr>
+                <td>'.$e->fecha_ejecucion->format('d/m/Y').'</td>
+                <td>'.e($e->plantilla?->nombre ?? '-').'</td>
+                <td>'.e($e->equipo?->codigo_interno ?? '-').'</td>
+                <td>'.e($e->ejecutor?->name ?? '-').'</td>
+                <td>'.$cumple.'/'.$totalI.' ('.$pct.'%)</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h2>5. Checklists de equipos</h2>
+            <table>
+                <tr><th>Fecha</th><th>Plantilla</th><th>Equipo</th><th>Ejecutor</th><th>Score</th></tr>
+                '.($ejecRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin ejecuciones</td></tr>').'
+            </table>');
+
+        // ═══ POLITICAS / NDAs ═══
+        $mpdf->AddPage();
+        $politicas = Politica::withoutGlobalScopes()->where('empresa_id', $tenant->id)->withCount(['aceptaciones'])->get();
+        $polRows = '';
+        foreach ($politicas as $p) {
+            $firmados = AceptacionPolitica::where('politica_id', $p->id)->whereNotNull('firma_imagen')->count();
+            $polRows .= '<tr>
+                <td>'.e($p->titulo).'</td>
+                <td>'.e($p->version).'</td>
+                <td>'.($p->es_nda ? 'NDA' : 'Politica').'</td>
+                <td>'.($p->activa ? 'Activa' : 'Inactiva').'</td>
+                <td>'.$firmados.'</td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            <h2>6. Politicas y NDAs</h2>
+            <table>
+                <tr><th>Titulo</th><th>Version</th><th>Tipo</th><th>Estado</th><th>Firmados</th></tr>
+                '.($polRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin politicas</td></tr>').'
+            </table>
+
+            <p class="footer">
+                Reporte completo generado: '.now()->format('d/m/Y H:i').' | '.e(auth()->user()->name).' | SecuriForm
+            </p>');
+    }
+}

--- a/app/Filament/Pages/ReporteCapacitaciones.php
+++ b/app/Filament/Pages/ReporteCapacitaciones.php
@@ -27,6 +27,8 @@ class ReporteCapacitaciones extends Page implements HasForms
 
     protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?string $navigationLabel = 'Reporte Capacitaciones';
 
     protected static ?string $title = 'Reporte de Capacitaciones';

--- a/app/Filament/Pages/ReporteCapacitaciones.php
+++ b/app/Filament/Pages/ReporteCapacitaciones.php
@@ -6,12 +6,13 @@ use App\Models\Capacitacion;
 use App\Models\CapacitacionAsistencia;
 use App\Models\User;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Mpdf\Mpdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ReporteCapacitaciones extends Page implements HasForms
 {
@@ -28,7 +29,7 @@ class ReporteCapacitaciones extends Page implements HasForms
 
     protected static ?string $navigationLabel = 'Reporte Capacitaciones';
 
-    protected static ?string $title = 'Reporte Mensual de Capacitaciones';
+    protected static ?string $title = 'Reporte de Capacitaciones';
 
     protected string $view = 'filament.pages.reporte-capacitaciones';
 
@@ -36,48 +37,22 @@ class ReporteCapacitaciones extends Page implements HasForms
 
     public function mount(): void
     {
-        $this->form->fill([
-            'mes' => (string) now()->month,
-            'anio' => (string) now()->year,
-        ]);
+        $this->form->fill();
     }
 
-    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    public function form(Schema $form): Schema
     {
-        $months = [];
-        for ($m = 1; $m <= 12; $m++) {
-            $months[(string) $m] = now()->setMonth($m)->translatedFormat('F');
-        }
-
-        $years = [];
-        for ($y = now()->year; $y >= now()->year - 3; $y--) {
-            $years[(string) $y] = (string) $y;
-        }
-
         return $form
-            ->schema([
-                Select::make('mes')
-                    ->label('Mes')
-                    ->options($months)
-                    ->required(),
-                Select::make('anio')
-                    ->label('Año')
-                    ->options($years)
-                    ->required(),
-            ])
+            ->schema([])
             ->statePath('data');
     }
 
-    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse
+    public function generateReport(): StreamedResponse
     {
         $tenant = Filament::getTenant();
-        $month = (int) $this->data['mes'];
-        $year = (int) $this->data['anio'];
 
         $capacitaciones = Capacitacion::withoutGlobalScopes()
             ->where('empresa_id', $tenant->id)
-            ->whereMonth('fecha', $month)
-            ->whereYear('fecha', $year)
             ->with(['asistencias', 'asistencias.user'])
             ->orderBy('fecha')
             ->get();
@@ -87,37 +62,35 @@ class ReporteCapacitaciones extends Page implements HasForms
             ->orderBy('name')
             ->get();
 
-        $monthName = now()->setMonth($month)->translatedFormat('F');
-
         $mpdf = new Mpdf([
             'format' => 'A4',
             'tempDir' => storage_path('app/temp'),
         ]);
 
         if ($tenant->logo_path) {
-            $logoPath = storage_path('app/' . $tenant->logo_path);
+            $logoPath = storage_path('app/'.$tenant->logo_path);
             if (file_exists($logoPath)) {
                 $mpdf->imageVars['logo'] = file_get_contents($logoPath);
             }
         }
 
-        $this->buildReportPages($mpdf, $tenant, $capacitaciones, $users, $monthName, $year);
+        $this->buildReportPages($mpdf, $tenant, $capacitaciones, $users);
 
-        $filename = "reporte_capacitaciones_{$year}_{$month}.pdf";
+        $filename = 'reporte_capacitaciones_'.now()->format('Ymd').'.pdf';
 
         return response()->streamDownload(function () use ($mpdf) {
             echo $mpdf->Output('', 'S');
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReportPages(Mpdf $mpdf, $tenant, $capacitaciones, $users, $monthName, $year): void
+    private function buildReportPages(Mpdf $mpdf, $tenant, $capacitaciones, $users): void
     {
         $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
+        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
             $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
         }
 
-        $style = "
+        $style = '
         <style>
             body { font-family: Arial, sans-serif; font-size: 10px; }
             h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
@@ -129,7 +102,7 @@ class ReporteCapacitaciones extends Page implements HasForms
             .summary { margin-top: 15px; padding: 10px; background: #f9fafb; border: 1px solid #e5e7eb; }
             .cap-header { background: #f0f0ff; padding: 10px; border: 1px solid #ddd; margin-bottom: 10px; }
             .footer { margin-top: 30px; font-size: 9px; color: #888; }
-        </style>";
+        </style>';
 
         // ═══ PAGE 1: Resumen general ═══
         $totalCap = $capacitaciones->count();
@@ -145,14 +118,14 @@ class ReporteCapacitaciones extends Page implements HasForms
             $asistieron = $c->asistencias->where('asistio', true)->count();
             $pct = $total > 0 ? round(($asistieron / $total) * 100) : 0;
             $capRows .= '<tr>
-                <td>' . e($c->tema) . '</td>
-                <td>' . $c->fecha->format('d/m/Y') . '</td>
-                <td>' . substr($c->hora_inicio, 0, 5) . '</td>
-                <td>' . $c->duracion_minutos . ' min</td>
-                <td>' . e($c->modalidad->label()) . '</td>
-                <td>' . e($c->expositor) . '</td>
-                <td>' . $asistieron . '/' . $total . '</td>
-                <td>' . $pct . '%</td>
+                <td>'.e($c->tema).'</td>
+                <td>'.$c->fecha->format('d/m/Y').'</td>
+                <td>'.substr($c->hora_inicio, 0, 5).'</td>
+                <td>'.$c->duracion_minutos.' min</td>
+                <td>'.e($c->modalidad->label()).'</td>
+                <td>'.e($c->expositor).'</td>
+                <td>'.$asistieron.'/'.$total.'</td>
+                <td>'.$pct.'%</td>
             </tr>';
         }
 
@@ -164,22 +137,22 @@ class ReporteCapacitaciones extends Page implements HasForms
                 ->count();
             $pctUser = $totalCap > 0 ? round(($asistidas / $totalCap) * 100) : 0;
             $userRows .= '<tr>
-                <td>' . e($u->name) . '</td>
-                <td>' . e($u->puesto ?? '—') . '</td>
-                <td>' . e($u->dni ?? '—') . '</td>
-                <td>' . $asistidas . '/' . $totalCap . '</td>
-                <td>' . $pctUser . '%</td>
+                <td>'.e($u->name).'</td>
+                <td>'.e($u->puesto ?? '—').'</td>
+                <td>'.e($u->dni ?? '—').'</td>
+                <td>'.$asistidas.'/'.$totalCap.'</td>
+                <td>'.$pctUser.'%</td>
             </tr>';
         }
 
-        $mpdf->WriteHTML($style . "
+        $mpdf->WriteHTML($style."
             {$logoHtml}
-            <h1>" . e($tenant->razon_social) . "</h1>
-            <p style='color:#666;'>RUC: " . e($tenant->ruc) . "</p>
-            <p><strong>Reporte de Capacitaciones de Ciberseguridad — {$monthName} {$year}</strong></p>
+            <h1>".e($tenant->razon_social)."</h1>
+            <p style='color:#666;'>RUC: ".e($tenant->ruc)."</p>
+            <p><strong>Reporte completo de Capacitaciones de Ciberseguridad</strong></p>
 
             <div class='summary'>
-                <strong>Resumen del periodo:</strong>
+                <strong>Resumen general:</strong>
                 Total capacitaciones: {$totalCap} |
                 Presenciales: {$presenciales} |
                 Virtuales: {$virtuales} |
@@ -199,7 +172,7 @@ class ReporteCapacitaciones extends Page implements HasForms
             </table>
 
             <p class='footer'>
-                Generado: " . now()->format('d/m/Y H:i') . ' | Admin: ' . e(auth()->user()->name) . ' | SecuriForm
+                Generado: ".now()->format('d/m/Y H:i').' | Admin: '.e(auth()->user()->name).' | SecuriForm
             </p>');
 
         // ═══ PAGES 2+: Una hoja por capacitación con sus asistentes ═══
@@ -218,30 +191,30 @@ class ReporteCapacitaciones extends Page implements HasForms
                 $fechaConf = $a->fecha_confirmacion?->format('d/m/Y H:i') ?? '—';
 
                 $asistenciaRows .= '<tr>
-                    <td>' . e($a->user?->name ?? '—') . '</td>
-                    <td>' . e($a->user?->dni ?? '—') . '</td>
-                    <td>' . e($a->user?->puesto ?? '—') . '</td>
-                    <td style="color:' . $estadoColor . '; font-weight:bold;">' . $estado . '</td>
-                    <td>' . e($confirmador) . '</td>
-                    <td>' . $fechaConf . '</td>
+                    <td>'.e($a->user?->name ?? '—').'</td>
+                    <td>'.e($a->user?->dni ?? '—').'</td>
+                    <td>'.e($a->user?->puesto ?? '—').'</td>
+                    <td style="color:'.$estadoColor.'; font-weight:bold;">'.$estado.'</td>
+                    <td>'.e($confirmador).'</td>
+                    <td>'.$fechaConf.'</td>
                 </tr>';
             }
 
-            $mpdf->WriteHTML($style . "
+            $mpdf->WriteHTML($style."
                 {$logoHtml}
-                <h1>" . e($tenant->razon_social) . "</h1>
-                <p style='color:#666;'>RUC: " . e($tenant->ruc) . "</p>
+                <h1>".e($tenant->razon_social)."</h1>
+                <p style='color:#666;'>RUC: ".e($tenant->ruc)."</p>
 
                 <div class='cap-header'>
-                    <h2 style='margin:0 0 6px;'>" . e($c->tema) . "</h2>
+                    <h2 style='margin:0 0 6px;'>".e($c->tema)."</h2>
                     <table style='border:none; margin:0;'>
                         <tr style='border:none;'>
-                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Fecha:</strong> " . $c->fecha->format('d/m/Y') . "</td>
-                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Hora:</strong> " . substr($c->hora_inicio, 0, 5) . " (" . $c->duracion_minutos . " min)</td>
-                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Modalidad:</strong> " . e($c->modalidad->label()) . "</td>
+                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Fecha:</strong> ".$c->fecha->format('d/m/Y')."</td>
+                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Hora:</strong> ".substr($c->hora_inicio, 0, 5).' ('.$c->duracion_minutos." min)</td>
+                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Modalidad:</strong> ".e($c->modalidad->label())."</td>
                         </tr>
                         <tr style='border:none;'>
-                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Expositor:</strong> " . e($c->expositor) . "</td>
+                            <td style='border:none; padding:2px 20px 2px 0;'><strong>Expositor:</strong> ".e($c->expositor)."</td>
                             <td style='border:none; padding:2px 20px 2px 0;'><strong>Asistencia:</strong> {$asistieron}/{$total} ({$pct}%)</td>
                             <td style='border:none;'></td>
                         </tr>
@@ -255,7 +228,7 @@ class ReporteCapacitaciones extends Page implements HasForms
                 </table>
 
                 <p class='footer'>
-                    Generado: " . now()->format('d/m/Y H:i') . ' | Admin: ' . e(auth()->user()->name) . ' | SecuriForm
+                    Generado: ".now()->format('d/m/Y H:i').' | Admin: '.e(auth()->user()->name).' | SecuriForm
                 </p>');
         }
     }

--- a/app/Filament/Pages/ReporteChecklists.php
+++ b/app/Filament/Pages/ReporteChecklists.php
@@ -28,6 +28,8 @@ class ReporteChecklists extends Page implements HasForms
 
     protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?string $navigationLabel = 'Reporte Checklists';
 
     protected static ?string $title = 'Reporte de Checklists de Equipos';

--- a/app/Filament/Pages/ReporteChecklists.php
+++ b/app/Filament/Pages/ReporteChecklists.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\ChecklistEjecucion;
+use App\Models\ChecklistPlantilla;
+use App\Models\Equipo;
+use Filament\Facades\Filament;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Mpdf\Mpdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ReporteChecklists extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedClipboardDocumentCheck;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
+
+    protected static ?string $navigationLabel = 'Reporte Checklists';
+
+    protected static ?string $title = 'Reporte de Checklists de Equipos';
+
+    protected string $view = 'filament.pages.reporte-checklists';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->schema([])
+            ->statePath('data');
+    }
+
+    public function generateReport(): ?StreamedResponse
+    {
+        $tenant = Filament::getTenant();
+
+        $plantillas = ChecklistPlantilla::withoutGlobalScopes()
+            ->where('empresa_id', $tenant->id)
+            ->orderBy('nombre')
+            ->get();
+
+        $equipoIds = Equipo::withoutGlobalScopes()
+            ->where('empresa_id', $tenant->id)
+            ->pluck('id');
+
+        $ejecuciones = ChecklistEjecucion::query()
+            ->whereIn('equipo_id', $equipoIds)
+            ->with(['plantilla', 'equipo', 'ejecutor'])
+            ->orderBy('fecha_ejecucion', 'desc')
+            ->get();
+
+        if ($ejecuciones->isEmpty() && $plantillas->isEmpty()) {
+            Notification::make()
+                ->title('Sin resultados')
+                ->body('No hay checklists ni ejecuciones registradas para esta empresa.')
+                ->warning()
+                ->send();
+
+            return null;
+        }
+
+        $mpdf = new Mpdf([
+            'format' => 'A4',
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        if ($tenant->logo_path) {
+            $logoPath = storage_path('app/'.$tenant->logo_path);
+            if (file_exists($logoPath)) {
+                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
+            }
+        }
+
+        $this->buildReport($mpdf, $tenant, $plantillas, $ejecuciones);
+
+        $filename = 'reporte_checklists_'.now()->format('Ymd').'.pdf';
+
+        return response()->streamDownload(function () use ($mpdf) {
+            echo $mpdf->Output('', 'S');
+        }, $filename, ['Content-Type' => 'application/pdf']);
+    }
+
+    private function buildReport(Mpdf $mpdf, $tenant, $plantillas, $ejecuciones): void
+    {
+        $logoHtml = '';
+        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
+            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
+        }
+
+        $style = '
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
+            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
+            h2 { font-size: 13px; margin-top: 20px; color: #333; }
+            h3 { font-size: 11px; margin-top: 12px; color: #555; }
+            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+            th, td { border: 1px solid #ddd; padding: 5px; text-align: left; }
+            th { background: #f3f4f6; font-weight: bold; }
+            .summary { margin-top: 12px; padding: 10px; background: #f9fafb; border: 1px solid #e5e7eb; }
+            .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 9px; font-weight: bold; }
+            .badge-ok { background: #d1fae5; color: #059669; }
+            .badge-warn { background: #fef3c7; color: #d97706; }
+            .badge-bad { background: #fee2e2; color: #dc2626; }
+            .ficha { border: 1px solid #ddd; border-radius: 4px; margin-top: 12px; }
+            .ficha-header { background: #f0f0ff; padding: 8px 10px; border-bottom: 1px solid #ddd; }
+            .ficha-body { padding: 10px; }
+            .footer { margin-top: 30px; font-size: 9px; color: #888; }
+        </style>';
+
+        $totalEjec = $ejecuciones->count();
+        $totalEq = $ejecuciones->pluck('equipo_id')->unique()->count();
+
+        $plantillaRows = '';
+        foreach ($plantillas as $p) {
+            $ejecsPlantilla = $ejecuciones->where('checklist_plantilla_id', $p->id);
+            $plantillaRows .= '<tr>
+                <td>'.e($p->nombre).'</td>
+                <td>'.e($p->periodicidad ?? '-').'</td>
+                <td style="text-align:center;">'.count($p->items ?? []).'</td>
+                <td style="text-align:center;">'.$ejecsPlantilla->count().'</td>
+                <td>'.($p->activa ? '<span class="badge badge-ok">Activa</span>' : '<span class="badge badge-bad">Inactiva</span>').'</td>
+            </tr>';
+        }
+
+        $ejecRows = '';
+        foreach ($ejecuciones as $e) {
+            $cumple = $e->itemsCumplen();
+            $total = $e->totalItems();
+            $pct = $total > 0 ? round($cumple / $total * 100) : 0;
+            $estClass = $pct >= 80 ? 'badge-ok' : ($pct >= 50 ? 'badge-warn' : 'badge-bad');
+
+            $ejecRows .= '<tr>
+                <td>'.$e->fecha_ejecucion->format('d/m/Y H:i').'</td>
+                <td>'.e($e->plantilla?->nombre ?? '-').'</td>
+                <td>'.e($e->equipo?->codigo_interno ?? '-').'</td>
+                <td>'.e(trim(($e->equipo?->marca ?? '').' '.($e->equipo?->modelo ?? '')) ?: '-').'</td>
+                <td>'.e($e->ejecutor?->name ?? '-').'</td>
+                <td>'.e($e->estado ?? '-').'</td>
+                <td><span class="badge '.$estClass.'">'.$cumple.'/'.$total.' ('.$pct.'%)</span></td>
+            </tr>';
+        }
+
+        $mpdf->WriteHTML($style.'
+            '.$logoHtml.'
+            <h1>'.e($tenant->razon_social).'</h1>
+            <p style="color:#666;">RUC: '.e($tenant->ruc).'</p>
+            <p><strong>Reporte completo de Checklists de Equipos</strong></p>
+
+            <div class="summary">
+                <strong>Resumen:</strong>
+                Plantillas: '.$plantillas->count().' |
+                Ejecuciones: '.$totalEjec.' |
+                Equipos verificados: '.$totalEq.'
+            </div>
+
+            <h2>Plantillas de checklist</h2>
+            <table>
+                <tr><th>Nombre</th><th>Periodicidad</th><th style="text-align:center;">Items</th><th style="text-align:center;">Ejecuciones</th><th>Estado</th></tr>
+                '.($plantillaRows ?: '<tr><td colspan="5" style="text-align:center;color:#999;">Sin plantillas</td></tr>').'
+            </table>
+
+            <h2>Historial de ejecuciones — '.$totalEjec.'</h2>
+            <table>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Plantilla</th>
+                    <th>Codigo equipo</th>
+                    <th>Marca/Modelo</th>
+                    <th>Ejecutado por</th>
+                    <th>Estado</th>
+                    <th>Score</th>
+                </tr>
+                '.($ejecRows ?: '<tr><td colspan="7" style="text-align:center;color:#999;">Sin ejecuciones</td></tr>').'
+            </table>
+
+            <p class="footer">
+                Generado: '.now()->format('d/m/Y H:i').' | '.e(auth()->user()->name).' | SecuriForm
+            </p>');
+
+        // Detalle por ejecucion
+        foreach ($ejecuciones as $e) {
+            $mpdf->AddPage();
+
+            $cumple = $e->itemsCumplen();
+            $total = $e->totalItems();
+            $pct = $total > 0 ? round($cumple / $total * 100) : 0;
+            $estClass = $pct >= 80 ? 'badge-ok' : ($pct >= 50 ? 'badge-warn' : 'badge-bad');
+
+            $itemsRows = '';
+            foreach (($e->resultados ?? []) as $idx => $r) {
+                $cumpleVal = ! empty($r['cumple']);
+                $itemsRows .= '<tr>
+                    <td style="text-align:center;width:30px;">'.($idx + 1).'</td>
+                    <td>'.e($r['item'] ?? $r['nombre'] ?? '-').'</td>
+                    <td style="text-align:center;width:60px;">'.($cumpleVal ? '<span class="badge badge-ok">Si</span>' : '<span class="badge badge-bad">No</span>').'</td>
+                    <td>'.e($r['observacion'] ?? $r['observaciones'] ?? '').'</td>
+                </tr>';
+            }
+
+            $mpdf->WriteHTML($style.'
+                '.$logoHtml.'
+                <h1>'.e($tenant->razon_social).'</h1>
+                <p style="color:#666;">RUC: '.e($tenant->ruc).'</p>
+
+                <div class="ficha">
+                    <div class="ficha-header">
+                        <h2 style="margin:0;">Ejecucion de Checklist</h2>
+                        <p style="margin:4px 0 0; color:#666;">'.e($e->plantilla?->nombre ?? '-').' — '.$e->fecha_ejecucion->format('d/m/Y H:i').'</p>
+                    </div>
+                    <div class="ficha-body">
+                        <table style="border:none;">
+                            <tr style="border:none;">
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Equipo:</strong> '.e($e->equipo?->codigo_interno ?? '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Marca/Modelo:</strong> '.e(trim(($e->equipo?->marca ?? '').' '.($e->equipo?->modelo ?? '')) ?: '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>S/N:</strong> '.e($e->equipo?->numero_serie ?? '-').'</td>
+                            </tr>
+                            <tr style="border:none;">
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Ejecutor:</strong> '.e($e->ejecutor?->name ?? '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Estado:</strong> '.e($e->estado ?? '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Score:</strong> <span class="badge '.$estClass.'">'.$cumple.'/'.$total.' ('.$pct.'%)</span></td>
+                            </tr>
+                        </table>
+
+                        <h3>Items verificados</h3>
+                        <table>
+                            <tr><th style="width:30px;">#</th><th>Item</th><th style="width:60px;">Cumple</th><th>Observaciones</th></tr>
+                            '.($itemsRows ?: '<tr><td colspan="4" style="text-align:center;color:#999;">Sin items</td></tr>').'
+                        </table>
+                        '.(! empty($e->observaciones_generales) ? '
+                        <h3>Observaciones generales</h3>
+                        <p style="padding:6px 8px;background:#fafafa;border:1px solid #eee;">'.nl2br(e($e->observaciones_generales)).'</p>' : '').'
+                    </div>
+                </div>
+
+                <p class="footer">
+                    Generado: '.now()->format('d/m/Y H:i').' | SecuriForm
+                </p>');
+        }
+    }
+}

--- a/app/Filament/Pages/ReporteDestruccionActivos.php
+++ b/app/Filament/Pages/ReporteDestruccionActivos.php
@@ -5,14 +5,15 @@ namespace App\Filament\Pages;
 use App\Models\Equipo;
 use App\Models\Registro;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Mpdf\Mpdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ReporteDestruccionActivos extends Page implements HasForms
 {
@@ -40,25 +41,17 @@ class ReporteDestruccionActivos extends Page implements HasForms
     public function mount(): void
     {
         $this->form->fill([
-            'fecha_desde' => now()->startOfYear()->format('Y-m-d'),
-            'fecha_hasta' => now()->format('Y-m-d'),
             'metodo' => '',
             'motivo' => '',
         ]);
     }
 
-    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    public function form(Schema $form): Schema
     {
         return $form
             ->schema([
-                DatePicker::make('fecha_desde')
-                    ->label('Desde')
-                    ->required(),
-                DatePicker::make('fecha_hasta')
-                    ->label('Hasta')
-                    ->required(),
                 Select::make('metodo')
-                    ->label('Metodo de destruccion')
+                    ->label('Metodo de destruccion (opcional)')
                     ->options([
                         '' => 'Todos',
                         'borrado_seguro' => 'Borrado seguro',
@@ -69,7 +62,7 @@ class ReporteDestruccionActivos extends Page implements HasForms
                         'proveedor_certificado' => 'Proveedor certificado',
                     ]),
                 Select::make('motivo')
-                    ->label('Motivo de baja')
+                    ->label('Motivo de baja (opcional)')
                     ->options([
                         '' => 'Todos',
                         'obsoleto' => 'Obsoleto',
@@ -82,17 +75,13 @@ class ReporteDestruccionActivos extends Page implements HasForms
             ->statePath('data');
     }
 
-    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse|null
+    public function generateReport(): ?StreamedResponse
     {
         $tenant = Filament::getTenant();
-        $fechaDesde = $this->data['fecha_desde'];
-        $fechaHasta = $this->data['fecha_hasta'];
 
         $query = Registro::withoutGlobalScopes()
             ->where('empresa_id', $tenant->id)
             ->where('tipo_formato', 'F13')
-            ->whereDate('created_at', '>=', $fechaDesde)
-            ->whereDate('created_at', '<=', $fechaHasta)
             ->with(['creador', 'equipo']);
 
         if (! empty($this->data['metodo'])) {
@@ -135,25 +124,25 @@ class ReporteDestruccionActivos extends Page implements HasForms
         ]);
 
         if ($tenant->logo_path) {
-            $logoPath = storage_path('app/' . $tenant->logo_path);
+            $logoPath = storage_path('app/'.$tenant->logo_path);
             if (file_exists($logoPath)) {
                 $mpdf->imageVars['logo'] = file_get_contents($logoPath);
             }
         }
 
-        $this->buildReport($mpdf, $tenant, $registros, $equipos, $fechaDesde, $fechaHasta);
+        $this->buildReport($mpdf, $tenant, $registros, $equipos);
 
-        $filename = 'destruccion_activos_F13_' . now()->format('Ymd') . '.pdf';
+        $filename = 'destruccion_activos_F13_'.now()->format('Ymd').'.pdf';
 
         return response()->streamDownload(function () use ($mpdf) {
             echo $mpdf->Output('', 'S');
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReport(Mpdf $mpdf, $tenant, $registros, $equipos, $fechaDesde, $fechaHasta): void
+    private function buildReport(Mpdf $mpdf, $tenant, $registros, $equipos): void
     {
         $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
+        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
             $logoHtml = '<img src="var:logo" style="height:36px;margin-bottom:4px;" /><br>';
         }
 
@@ -193,9 +182,6 @@ class ReporteDestruccionActivos extends Page implements HasForms
             .equipo-box strong { color: #0369a1; }
             .footer { margin-top: 10px; font-size: 7px; color: #888; }
         </style>';
-
-        $desde = date('d/m/Y', strtotime($fechaDesde));
-        $hasta = date('d/m/Y', strtotime($fechaHasta));
 
         // ═══ Statistics ═══
         $total = $registros->count();
@@ -242,19 +228,19 @@ class ReporteDestruccionActivos extends Page implements HasForms
         $metodoRows = '';
         foreach ($porMetodo as $metodo => $count) {
             $pct = round($count / $total * 100);
-            $metodoRows .= '<tr><td>' . e($this->metodoLabel($metodo)) . '</td><td style="text-align:center;">' . $count . '</td><td style="text-align:center;">' . $pct . '%</td></tr>';
+            $metodoRows .= '<tr><td>'.e($this->metodoLabel($metodo)).'</td><td style="text-align:center;">'.$count.'</td><td style="text-align:center;">'.$pct.'%</td></tr>';
         }
 
         $mesRows = '';
         foreach ($porMes as $mes => $count) {
-            $mesLabel = date('M Y', strtotime($mes . '-01'));
-            $mesRows .= '<tr><td>' . $mesLabel . '</td><td style="text-align:center;">' . $count . '</td></tr>';
+            $mesLabel = date('M Y', strtotime($mes.'-01'));
+            $mesRows .= '<tr><td>'.$mesLabel.'</td><td style="text-align:center;">'.$count.'</td></tr>';
         }
 
         $motivoRows = '';
         foreach ($motivos as $motivo => $count) {
             if ($count > 0) {
-                $motivoRows .= '<tr><td>' . e($this->motivoLabel($motivo)) . '</td><td style="text-align:center;">' . $count . '</td></tr>';
+                $motivoRows .= '<tr><td>'.e($this->motivoLabel($motivo)).'</td><td style="text-align:center;">'.$count.'</td></tr>';
             }
         }
 
@@ -269,51 +255,51 @@ class ReporteDestruccionActivos extends Page implements HasForms
             $equipoInfo = '-';
             if ($eq) {
                 $equipoInfo = e(trim("{$eq->tipo} {$eq->marca} {$eq->modelo}"))
-                    . '<br><span style="font-size:7px;color:#666;">'
-                    . e($eq->codigo_interno ?? '') . ' | S/N: ' . e($eq->numero_serie ?? '-')
-                    . '</span>';
+                    .'<br><span style="font-size:7px;color:#666;">'
+                    .e($eq->codigo_interno ?? '').' | S/N: '.e($eq->numero_serie ?? '-')
+                    .'</span>';
             }
 
             $rows .= '<tr>'
-                . '<td>' . e($r->numero_registro) . '</td>'
-                . '<td>' . e($datos['fecha_destruccion'] ?? '-') . '</td>'
-                . '<td>' . $metodoBadge . '</td>'
-                . '<td style="max-width:150px;">' . $equipoInfo . '</td>'
-                . '<td style="max-width:120px;">' . e(mb_substr($datos['descripcion_activo'] ?? '-', 0, 80)) . '</td>'
-                . '<td>' . e($datos['responsable'] ?? '-') . '</td>'
-                . '<td>' . e($datos['autoriza'] ?? '-') . '</td>'
-                . '<td>' . e($r->creador?->name ?? '-') . '</td>'
-                . '<td>' . $r->created_at->format('d/m/Y') . '</td>'
-                . '</tr>';
+                .'<td>'.e($r->numero_registro).'</td>'
+                .'<td>'.e($datos['fecha_destruccion'] ?? '-').'</td>'
+                .'<td>'.$metodoBadge.'</td>'
+                .'<td style="max-width:150px;">'.$equipoInfo.'</td>'
+                .'<td style="max-width:120px;">'.e(mb_substr($datos['descripcion_activo'] ?? '-', 0, 80)).'</td>'
+                .'<td>'.e($datos['responsable'] ?? '-').'</td>'
+                .'<td>'.e($datos['autoriza'] ?? '-').'</td>'
+                .'<td>'.e($r->creador?->name ?? '-').'</td>'
+                .'<td>'.$r->created_at->format('d/m/Y').'</td>'
+                .'</tr>';
         }
 
-        $mpdf->WriteHTML($style . '
-            ' . $logoHtml . '
-            <h1>' . e($tenant->razon_social) . ' <span style="font-size:9px;color:#666;font-weight:normal;">RUC: ' . e($tenant->ruc) . '</span></h1>
+        $mpdf->WriteHTML($style.'
+            '.$logoHtml.'
+            <h1>'.e($tenant->razon_social).' <span style="font-size:9px;color:#666;font-weight:normal;">RUC: '.e($tenant->ruc).'</span></h1>
             <h2>Formato 13 — Registro de Destruccion de Activos</h2>
-            <p style="color:#666;font-size:8px;margin:0;">Politica: PSC000003 / PSC000004 | Periodo: ' . $desde . ' - ' . $hasta . ' | Generado: ' . now()->format('d/m/Y H:i') . '</p>
+            <p style="color:#666;font-size:8px;margin:0;">Reporte completo | Politica: PSC000003 / PSC000004 | Generado: '.now()->format('d/m/Y H:i').'</p>
 
             <div class="stat-grid">
                 <table>
                     <tr>
                         <td style="border:1px solid #e5e7eb;background:#f9fafb;">
-                            <div class="stat-number">' . $total . '</div>
+                            <div class="stat-number">'.$total.'</div>
                             <div class="stat-label">Total destrucciones</div>
                         </td>
                         <td style="border:1px solid #e5e7eb;background:#f9fafb;">
-                            <div class="stat-number">' . $conEquipo . '</div>
+                            <div class="stat-number">'.$conEquipo.'</div>
                             <div class="stat-label">Con equipo vinculado</div>
                         </td>
                         <td style="border:1px solid #e5e7eb;background:#f9fafb;">
-                            <div class="stat-number">' . $tecCount . '</div>
+                            <div class="stat-number">'.$tecCount.'</div>
                             <div class="stat-label">Activos tecnologicos</div>
                         </td>
                         <td style="border:1px solid #e5e7eb;background:#f9fafb;">
-                            <div class="stat-number">' . $noTecCount . '</div>
+                            <div class="stat-number">'.$noTecCount.'</div>
                             <div class="stat-label">Activos no tecnologicos</div>
                         </td>
                         <td style="border:1px solid #e5e7eb;background:#f9fafb;">
-                            <div class="stat-number">' . $sinEquipo . '</div>
+                            <div class="stat-number">'.$sinEquipo.'</div>
                             <div class="stat-label">Sin equipo vinculado</div>
                         </td>
                     </tr>
@@ -325,26 +311,26 @@ class ReporteDestruccionActivos extends Page implements HasForms
                     <h3>Por metodo de destruccion</h3>
                     <table>
                         <tr><th>Metodo</th><th style="text-align:center;">Cantidad</th><th style="text-align:center;">%</th></tr>
-                        ' . $metodoRows . '
+                        '.$metodoRows.'
                     </table>
                 </div>
                 <div style="width:30%;padding-left:10px;">
                     <h3>Por motivo de baja</h3>
                     <table>
                         <tr><th>Motivo</th><th style="text-align:center;">Cant.</th></tr>
-                        ' . $motivoRows . '
+                        '.$motivoRows.'
                     </table>
                 </div>
                 <div style="width:30%;padding-left:10px;">
                     <h3>Tendencia mensual</h3>
                     <table>
                         <tr><th>Mes</th><th style="text-align:center;">Cant.</th></tr>
-                        ' . $mesRows . '
+                        '.$mesRows.'
                     </table>
                 </div>
             </div>
 
-            <h2>Detalle de registros F13 — ' . $total . ' resultados</h2>
+            <h2>Detalle de registros F13 — '.$total.' resultados</h2>
             <table>
                 <thead>
                     <tr>
@@ -359,11 +345,11 @@ class ReporteDestruccionActivos extends Page implements HasForms
                         <th>Fecha reg.</th>
                     </tr>
                 </thead>
-                <tbody>' . $rows . '</tbody>
+                <tbody>'.$rows.'</tbody>
             </table>
 
             <p class="footer">
-                Generado por: ' . e(auth()->user()->name) . ' | SecuriForm — PSC000003 / PSC000004
+                Generado por: '.e(auth()->user()->name).' | SecuriForm — PSC000003 / PSC000004
             </p>');
 
         // ═══ PAGE 2+: Individual detail cards per F13 registro ═══
@@ -382,131 +368,131 @@ class ReporteDestruccionActivos extends Page implements HasForms
 
                 $equipoSection = '
                 <div class="equipo-box">
-                    <strong>Equipo vinculado: ' . e($eq->codigo_interno) . '</strong><br>
+                    <strong>Equipo vinculado: '.e($eq->codigo_interno).'</strong><br>
                     <div class="grid-3" style="margin-top:6px;">
                         <div class="field">
                             <div class="field-label">Tipo</div>
-                            <div class="field-value">' . e($this->tipoLabel($eq->tipo)) . '</div>
+                            <div class="field-value">'.e($this->tipoLabel($eq->tipo)).'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">Marca / Modelo</div>
-                            <div class="field-value">' . e(trim("{$eq->marca} {$eq->modelo}") ?: '-') . '</div>
+                            <div class="field-value">'.e(trim("{$eq->marca} {$eq->modelo}") ?: '-').'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">N° Serie</div>
-                            <div class="field-value">' . e($eq->numero_serie ?? '-') . '</div>
+                            <div class="field-value">'.e($eq->numero_serie ?? '-').'</div>
                         </div>
                     </div>
                     <div class="grid-3" style="margin-top:4px;">
                         <div class="field">
                             <div class="field-label">Categoria</div>
-                            <div class="field-value">' . ($eq->categoria === 'tecnologico' ? '<span class="badge badge-info">Tecnologico</span>' : '<span class="badge badge-warning">No tecnologico</span>') . '</div>
+                            <div class="field-value">'.($eq->categoria === 'tecnologico' ? '<span class="badge badge-info">Tecnologico</span>' : '<span class="badge badge-warning">No tecnologico</span>').'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">Clasif. soporte</div>
-                            <div class="field-value">' . e($this->clasificacionLabel($eq->clasificacion_soporte)) . '</div>
+                            <div class="field-value">'.e($this->clasificacionLabel($eq->clasificacion_soporte)).'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">Sensibilidad</div>
-                            <div class="field-value">' . e(ucfirst($eq->nivel_sensibilidad ?? '-')) . '</div>
+                            <div class="field-value">'.e(ucfirst($eq->nivel_sensibilidad ?? '-')).'</div>
                         </div>
                     </div>
                     <div class="grid-3" style="margin-top:4px;">
                         <div class="field">
                             <div class="field-label">Ubicacion</div>
-                            <div class="field-value">' . e($eq->ubicacion ?? '-') . '</div>
+                            <div class="field-value">'.e($eq->ubicacion ?? '-').'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">Fecha adquisicion</div>
-                            <div class="field-value">' . ($eq->fecha_adquisicion?->format('d/m/Y') ?? '-') . '</div>
+                            <div class="field-value">'.($eq->fecha_adquisicion?->format('d/m/Y') ?? '-').'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">Estado actual</div>
-                            <div class="field-value"><span class="badge badge-danger">' . e(ucfirst(str_replace('_', ' ', $eq->estado))) . '</span></div>
+                            <div class="field-value"><span class="badge badge-danger">'.e(ucfirst(str_replace('_', ' ', $eq->estado))).'</span></div>
                         </div>
                     </div>'
-                    . ($eq->contenido_datos ? '
+                    .($eq->contenido_datos ? '
                     <div class="field" style="margin-top:4px;">
                         <div class="field-label">Contenido / Datos almacenados</div>
-                        <div class="field-value-long">' . e($eq->contenido_datos) . '</div>
+                        <div class="field-value-long">'.e($eq->contenido_datos).'</div>
                     </div>' : '')
-                    . ($asignacionVigente ? '
+                    .($asignacionVigente ? '
                     <div class="grid-2" style="margin-top:4px;">
                         <div class="field">
                             <div class="field-label">Fecha de baja</div>
-                            <div class="field-value">' . ($asignacionVigente->fecha_inicio?->format('d/m/Y H:i') ?? '-') . '</div>
+                            <div class="field-value">'.($asignacionVigente->fecha_inicio?->format('d/m/Y H:i') ?? '-').'</div>
                         </div>
                         <div class="field">
                             <div class="field-label">Notas de baja</div>
-                            <div class="field-value">' . e($asignacionVigente->notas ?? '-') . '</div>
+                            <div class="field-value">'.e($asignacionVigente->notas ?? '-').'</div>
                         </div>
                     </div>' : '')
-                    . '
+                    .'
                 </div>';
             }
 
-            $mpdf->WriteHTML($style . '
-                ' . $logoHtml . '
-                <h1>' . e($tenant->razon_social) . '</h1>
-                <p style="color:#666;">RUC: ' . e($tenant->ruc) . '</p>
+            $mpdf->WriteHTML($style.'
+                '.$logoHtml.'
+                <h1>'.e($tenant->razon_social).'</h1>
+                <p style="color:#666;">RUC: '.e($tenant->ruc).'</p>
 
                 <div class="ficha">
                     <div class="ficha-header">
                         <h2 style="margin:0;">F13 — Destruccion de Activo</h2>
-                        <p style="margin:4px 0 0; color:#666;">N° ' . e($r->numero_registro) . ' | Politica: PSC000003 / PSC000004</p>
+                        <p style="margin:4px 0 0; color:#666;">N° '.e($r->numero_registro).' | Politica: PSC000003 / PSC000004</p>
                     </div>
                     <div class="ficha-body">
                         <div class="grid-3">
                             <div class="field">
                                 <div class="field-label">Fecha de destruccion</div>
-                                <div class="field-value">' . e($datos['fecha_destruccion'] ?? '-') . '</div>
+                                <div class="field-value">'.e($datos['fecha_destruccion'] ?? '-').'</div>
                             </div>
                             <div class="field">
                                 <div class="field-label">Metodo de destruccion</div>
-                                <div class="field-value">' . $metodoBadge . '</div>
+                                <div class="field-value">'.$metodoBadge.'</div>
                             </div>
                             <div class="field">
                                 <div class="field-label">Proxima revision</div>
-                                <div class="field-value">' . e($datos['proxima_revision'] ?? 'No programada') . '</div>
+                                <div class="field-value">'.e($datos['proxima_revision'] ?? 'No programada').'</div>
                             </div>
                         </div>
                         <div class="grid-2">
                             <div class="field">
                                 <div class="field-label">Responsable de la destruccion</div>
-                                <div class="field-value">' . e($datos['responsable'] ?? '-') . '</div>
+                                <div class="field-value">'.e($datos['responsable'] ?? '-').'</div>
                             </div>
                             <div class="field">
                                 <div class="field-label">Autorizado por</div>
-                                <div class="field-value">' . e($datos['autoriza'] ?? '-') . '</div>
+                                <div class="field-value">'.e($datos['autoriza'] ?? '-').'</div>
                             </div>
                         </div>
                         <div class="field">
                             <div class="field-label">Descripcion del activo destruido</div>
-                            <div class="field-value-long">' . nl2br(e($datos['descripcion_activo'] ?? '-')) . '</div>
+                            <div class="field-value-long">'.nl2br(e($datos['descripcion_activo'] ?? '-')).'</div>
                         </div>
-                        ' . (! empty($datos['observaciones']) ? '
+                        '.(! empty($datos['observaciones']) ? '
                         <div class="field">
                             <div class="field-label">Observaciones / Motivo de baja</div>
-                            <div class="field-value-long">' . nl2br(e($datos['observaciones'])) . '</div>
-                        </div>' : '') . '
+                            <div class="field-value-long">'.nl2br(e($datos['observaciones'])).'</div>
+                        </div>' : '').'
 
-                        ' . $equipoSection . '
+                        '.$equipoSection.'
 
                         <div class="grid-2" style="margin-top:10px;">
                             <div class="field">
                                 <div class="field-label">Registrado por</div>
-                                <div class="field-value">' . e($r->creador?->name ?? '-') . '</div>
+                                <div class="field-value">'.e($r->creador?->name ?? '-').'</div>
                             </div>
                             <div class="field">
                                 <div class="field-label">Fecha de registro</div>
-                                <div class="field-value">' . $r->created_at->format('d/m/Y H:i') . '</div>
+                                <div class="field-value">'.$r->created_at->format('d/m/Y H:i').'</div>
                             </div>
                         </div>
                     </div>
                 </div>
 
                 <p class="footer">
-                    Generado: ' . now()->format('d/m/Y H:i') . ' | SecuriForm — PSC000003 / PSC000004
+                    Generado: '.now()->format('d/m/Y H:i').' | SecuriForm — PSC000003 / PSC000004
                 </p>');
         }
     }
@@ -545,7 +531,7 @@ class ReporteDestruccionActivos extends Page implements HasForms
             default => 'badge-warning',
         };
 
-        return '<span class="badge ' . $class . '">' . e($this->metodoLabel($metodo)) . '</span>';
+        return '<span class="badge '.$class.'">'.e($this->metodoLabel($metodo)).'</span>';
     }
 
     private function motivoLabel(string $motivo): string

--- a/app/Filament/Pages/ReporteDestruccionActivos.php
+++ b/app/Filament/Pages/ReporteDestruccionActivos.php
@@ -28,6 +28,8 @@ class ReporteDestruccionActivos extends Page implements HasForms
 
     protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?string $navigationLabel = 'Destruccion Activos (F13)';
 
     protected static ?string $title = 'Formato 13 — Destruccion de Activos';

--- a/app/Filament/Pages/ReporteIncidencias.php
+++ b/app/Filament/Pages/ReporteIncidencias.php
@@ -25,6 +25,8 @@ class ReporteIncidencias extends Page implements HasForms
 
     protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?string $navigationLabel = 'Reporte Incidencias';
 
     protected static ?string $title = 'Reporte de Incidencias';

--- a/app/Filament/Pages/ReporteIncidencias.php
+++ b/app/Filament/Pages/ReporteIncidencias.php
@@ -2,15 +2,15 @@
 
 namespace App\Filament\Pages;
 
-use App\Enums\TipoFormato;
 use App\Models\Registro;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Mpdf\Mpdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ReporteIncidencias extends Page implements HasForms
 {
@@ -27,7 +27,7 @@ class ReporteIncidencias extends Page implements HasForms
 
     protected static ?string $navigationLabel = 'Reporte Incidencias';
 
-    protected static ?string $title = 'Reporte Mensual de Incidencias';
+    protected static ?string $title = 'Reporte de Incidencias';
 
     protected string $view = 'filament.pages.reporte-incidencias';
 
@@ -35,61 +35,33 @@ class ReporteIncidencias extends Page implements HasForms
 
     public function mount(): void
     {
-        $this->form->fill([
-            'mes' => (string) now()->month,
-            'anio' => (string) now()->year,
-        ]);
+        $this->form->fill();
     }
 
-    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    public function form(Schema $form): Schema
     {
-        $months = [];
-        for ($m = 1; $m <= 12; $m++) {
-            $months[(string) $m] = now()->setMonth($m)->translatedFormat('F');
-        }
-
-        $years = [];
-        for ($y = now()->year; $y >= now()->year - 3; $y--) {
-            $years[(string) $y] = (string) $y;
-        }
-
         return $form
-            ->schema([
-                Select::make('mes')
-                    ->label('Mes')
-                    ->options($months)
-                    ->required(),
-                Select::make('anio')
-                    ->label('Año')
-                    ->options($years)
-                    ->required(),
-            ])
+            ->schema([])
             ->statePath('data');
     }
 
-    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse
+    public function generateReport(): StreamedResponse
     {
         $tenant = Filament::getTenant();
-        $month = (int) $this->data['mes'];
-        $year = (int) $this->data['anio'];
 
         $incidencias = Registro::withoutGlobalScopes()
             ->where('empresa_id', $tenant->id)
             ->where('tipo_formato', 'F09')
-            ->whereMonth('created_at', $month)
-            ->whereYear('created_at', $year)
             ->with('creador')
+            ->orderBy('created_at', 'desc')
             ->get();
 
         $resoluciones = Registro::withoutGlobalScopes()
             ->where('empresa_id', $tenant->id)
             ->where('tipo_formato', 'F10')
-            ->whereMonth('created_at', $month)
-            ->whereYear('created_at', $year)
             ->with('creador')
+            ->orderBy('created_at', 'desc')
             ->get();
-
-        $monthName = now()->setMonth($month)->translatedFormat('F');
 
         $mpdf = new Mpdf([
             'format' => 'A4',
@@ -97,29 +69,29 @@ class ReporteIncidencias extends Page implements HasForms
         ]);
 
         if ($tenant->logo_path) {
-            $logoPath = storage_path('app/' . $tenant->logo_path);
+            $logoPath = storage_path('app/'.$tenant->logo_path);
             if (file_exists($logoPath)) {
                 $mpdf->imageVars['logo'] = file_get_contents($logoPath);
             }
         }
 
-        $this->buildReportPages($mpdf, $tenant, $incidencias, $resoluciones, $monthName, $year);
+        $this->buildReportPages($mpdf, $tenant, $incidencias, $resoluciones);
 
-        $filename = "reporte_incidencias_{$year}_{$month}.pdf";
+        $filename = 'reporte_incidencias_'.now()->format('Ymd').'.pdf';
 
         return response()->streamDownload(function () use ($mpdf) {
             echo $mpdf->Output('', 'S');
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReportPages(Mpdf $mpdf, $tenant, $incidencias, $resoluciones, $monthName, $year): void
+    private function buildReportPages(Mpdf $mpdf, $tenant, $incidencias, $resoluciones): void
     {
         $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
+        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
             $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
         }
 
-        $style = "
+        $style = '
         <style>
             body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
             h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
@@ -145,21 +117,23 @@ class ReporteIncidencias extends Page implements HasForms
             .badge-media { background: #fef3c7; color: #d97706; }
             .badge-baja { background: #d1fae5; color: #059669; }
             .footer { margin-top: 30px; font-size: 9px; color: #888; }
-        </style>";
+        </style>';
 
         // ═══ PAGE 1: Resumen general ═══
         $incTable = '';
         foreach ($incidencias as $i) {
             $datos = $i->datos ?? [];
             $sev = $datos['severidad'] ?? '-';
-            $sevClass = match ($sev) { 'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja' };
+            $sevClass = match ($sev) {
+                'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja'
+            };
             $incTable .= '<tr>
-                <td>' . e($i->numero_registro) . '</td>
-                <td>' . e($this->labelFor('tipo_incidencia', $datos['tipo_incidencia'] ?? '-')) . '</td>
-                <td><span class="badge ' . $sevClass . '">' . ucfirst($sev) . '</span></td>
-                <td>' . e($datos['sistema_equipo'] ?? '-') . '</td>
-                <td>' . e($i->creador?->name ?? '-') . '</td>
-                <td>' . $i->created_at->format('d/m/Y') . '</td>
+                <td>'.e($i->numero_registro).'</td>
+                <td>'.e($this->labelFor('tipo_incidencia', $datos['tipo_incidencia'] ?? '-')).'</td>
+                <td><span class="badge '.$sevClass.'">'.ucfirst($sev).'</span></td>
+                <td>'.e($datos['sistema_equipo'] ?? '-').'</td>
+                <td>'.e($i->creador?->name ?? '-').'</td>
+                <td>'.$i->created_at->format('d/m/Y').'</td>
             </tr>';
         }
 
@@ -167,23 +141,25 @@ class ReporteIncidencias extends Page implements HasForms
         foreach ($resoluciones as $r) {
             $datos = $r->datos ?? [];
             $clas = $datos['clasificacion'] ?? '-';
-            $clasClass = match ($clas) { 'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja' };
+            $clasClass = match ($clas) {
+                'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja'
+            };
             $resTable .= '<tr>
-                <td>' . e($r->numero_registro) . '</td>
-                <td>' . e($datos['incidencia_ref'] ?? '-') . '</td>
-                <td><span class="badge ' . $clasClass . '">' . ucfirst($clas) . '</span></td>
-                <td>' . e($r->creador?->name ?? '-') . '</td>
-                <td>' . $r->created_at->format('d/m/Y') . '</td>
+                <td>'.e($r->numero_registro).'</td>
+                <td>'.e($datos['incidencia_ref'] ?? '-').'</td>
+                <td><span class="badge '.$clasClass.'">'.ucfirst($clas).'</span></td>
+                <td>'.e($r->creador?->name ?? '-').'</td>
+                <td>'.$r->created_at->format('d/m/Y').'</td>
             </tr>';
         }
 
         $tasaRes = $incidencias->count() > 0 ? round($resoluciones->count() / $incidencias->count() * 100) : 0;
 
-        $mpdf->WriteHTML($style . "
+        $mpdf->WriteHTML($style."
             {$logoHtml}
-            <h1>" . e($tenant->razon_social) . "</h1>
-            <p style='color:#666;'>RUC: " . e($tenant->ruc) . "</p>
-            <p><strong>Reporte Mensual de Incidencias de Seguridad — {$monthName} {$year}</strong></p>
+            <h1>".e($tenant->razon_social)."</h1>
+            <p style='color:#666;'>RUC: ".e($tenant->ruc)."</p>
+            <p><strong>Reporte completo de Incidencias de Seguridad</strong></p>
 
             <div class='summary'>
                 <strong>Resumen:</strong>
@@ -205,7 +181,7 @@ class ReporteIncidencias extends Page implements HasForms
             </table>
 
             <p class='footer'>
-                Generado: " . now()->format('d/m/Y H:i') . ' | Admin: ' . e(auth()->user()->name) . ' | SecuriForm — PSC000001 / PSC000-25
+                Generado: ".now()->format('d/m/Y H:i').' | Admin: '.e(auth()->user()->name).' | SecuriForm — PSC000001 / PSC000-25
             </p>');
 
         // ═══ PAGES 2+: Ficha detallada por cada incidencia (F09) ═══
@@ -213,74 +189,76 @@ class ReporteIncidencias extends Page implements HasForms
             $mpdf->AddPage();
             $datos = $i->datos ?? [];
             $sev = $datos['severidad'] ?? '-';
-            $sevClass = match ($sev) { 'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja' };
+            $sevClass = match ($sev) {
+                'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja'
+            };
 
-            $mpdf->WriteHTML($style . "
+            $mpdf->WriteHTML($style."
                 {$logoHtml}
-                <h1>" . e($tenant->razon_social) . "</h1>
-                <p style='color:#666;'>RUC: " . e($tenant->ruc) . "</p>
+                <h1>".e($tenant->razon_social)."</h1>
+                <p style='color:#666;'>RUC: ".e($tenant->ruc)."</p>
 
                 <div class='ficha'>
                     <div class='ficha-header'>
                         <h2 style='margin:0;'>F09 — Notificacion de Incidencia</h2>
-                        <p style='margin:4px 0 0; color:#666;'>N° " . e($i->numero_registro) . " | Politica: PSC000001 / PSC000-25</p>
+                        <p style='margin:4px 0 0; color:#666;'>N° ".e($i->numero_registro)." | Politica: PSC000001 / PSC000-25</p>
                     </div>
                     <div class='ficha-body'>
                         <div class='grid-3'>
                             <div class='field'>
                                 <div class='field-label'>Fecha / Hora del evento</div>
-                                <div class='field-value'>" . e($datos['fecha_evento'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['fecha_evento'] ?? '-')."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Tipo de incidencia</div>
-                                <div class='field-value'>" . e($this->labelFor('tipo_incidencia', $datos['tipo_incidencia'] ?? '-')) . "</div>
+                                <div class='field-value'>".e($this->labelFor('tipo_incidencia', $datos['tipo_incidencia'] ?? '-'))."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Severidad</div>
-                                <div class='field-value'><span class='badge {$sevClass}'>" . ucfirst($sev) . "</span></div>
+                                <div class='field-value'><span class='badge {$sevClass}'>".ucfirst($sev)."</span></div>
                             </div>
                         </div>
                         <div class='grid-2'>
                             <div class='field'>
                                 <div class='field-label'>Sistema / Equipo / Lugar</div>
-                                <div class='field-value'>" . e($datos['sistema_equipo'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['sistema_equipo'] ?? '-')."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Banco de datos</div>
-                                <div class='field-value'>" . e($datos['banco_datos'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['banco_datos'] ?? '-')."</div>
                             </div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Personas notificadas</div>
-                            <div class='field-value'>" . e(is_array($datos['personas_notificadas'] ?? null) ? implode(', ', $datos['personas_notificadas']) : ($datos['personas_notificadas'] ?? '-')) . "</div>
+                            <div class='field-value'>".e(is_array($datos['personas_notificadas'] ?? null) ? implode(', ', $datos['personas_notificadas']) : ($datos['personas_notificadas'] ?? '-'))."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Descripcion</div>
-                            <div class='field-value-long'>" . nl2br(e(strip_tags($datos['descripcion'] ?? '-'))) . "</div>
+                            <div class='field-value-long'>".nl2br(e(strip_tags($datos['descripcion'] ?? '-')))."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Medidas inmediatas</div>
-                            <div class='field-value-long'>" . nl2br(e($datos['medidas_inmediatas'] ?? '-')) . "</div>
+                            <div class='field-value-long'>".nl2br(e($datos['medidas_inmediatas'] ?? '-'))."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Impacto potencial</div>
-                            <div class='field-value-long'>" . nl2br(e($datos['impacto_potencial'] ?? '-')) . "</div>
+                            <div class='field-value-long'>".nl2br(e($datos['impacto_potencial'] ?? '-'))."</div>
                         </div>
                         <div class='grid-2'>
                             <div class='field'>
                                 <div class='field-label'>Comunica (nombre y cargo)</div>
-                                <div class='field-value'>" . e($datos['comunica_nombre'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['comunica_nombre'] ?? '-')."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Registrado por</div>
-                                <div class='field-value'>" . e($i->creador?->name ?? '-') . " | " . $i->created_at->format('d/m/Y H:i') . "</div>
+                                <div class='field-value'>".e($i->creador?->name ?? '-').' | '.$i->created_at->format('d/m/Y H:i')."</div>
                             </div>
                         </div>
                     </div>
                 </div>
 
                 <p class='footer'>
-                    Generado: " . now()->format('d/m/Y H:i') . ' | SecuriForm
+                    Generado: ".now()->format('d/m/Y H:i').' | SecuriForm
                 </p>');
         }
 
@@ -289,68 +267,70 @@ class ReporteIncidencias extends Page implements HasForms
             $mpdf->AddPage();
             $datos = $r->datos ?? [];
             $clas = $datos['clasificacion'] ?? '-';
-            $clasClass = match ($clas) { 'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja' };
+            $clasClass = match ($clas) {
+                'alta' => 'badge-alta', 'media' => 'badge-media', default => 'badge-baja'
+            };
 
-            $mpdf->WriteHTML($style . "
+            $mpdf->WriteHTML($style."
                 {$logoHtml}
-                <h1>" . e($tenant->razon_social) . "</h1>
-                <p style='color:#666;'>RUC: " . e($tenant->ruc) . "</p>
+                <h1>".e($tenant->razon_social)."</h1>
+                <p style='color:#666;'>RUC: ".e($tenant->ruc)."</p>
 
                 <div class='ficha'>
                     <div class='ficha-header'>
                         <h2 style='margin:0;'>F10 — Resolucion de Incidencia</h2>
-                        <p style='margin:4px 0 0; color:#666;'>N° " . e($r->numero_registro) . " | Politica: PSC000-25</p>
+                        <p style='margin:4px 0 0; color:#666;'>N° ".e($r->numero_registro)." | Politica: PSC000-25</p>
                     </div>
                     <div class='ficha-body'>
                         <div class='grid-3'>
                             <div class='field'>
                                 <div class='field-label'>N° Incidencia (referencia F09)</div>
-                                <div class='field-value'>" . e($datos['incidencia_ref'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['incidencia_ref'] ?? '-')."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Fecha / Hora de cierre</div>
-                                <div class='field-value'>" . e($datos['fecha_cierre'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['fecha_cierre'] ?? '-')."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Clasificacion</div>
-                                <div class='field-value'><span class='badge {$clasClass}'>" . ucfirst($clas) . "</span></div>
+                                <div class='field-value'><span class='badge {$clasClass}'>".ucfirst($clas)."</span></div>
                             </div>
                         </div>
                         <div class='grid-2'>
                             <div class='field'>
                                 <div class='field-label'>Ejecuto (nombre y cargo)</div>
-                                <div class='field-value'>" . e($datos['ejecuto'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['ejecuto'] ?? '-')."</div>
                             </div>
                             <div class='field'>
                                 <div class='field-label'>Firma responsable de seguridad</div>
-                                <div class='field-value'>" . e($datos['firma_responsable'] ?? '-') . "</div>
+                                <div class='field-value'>".e($datos['firma_responsable'] ?? '-')."</div>
                             </div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Requirio recuperacion</div>
-                            <div class='field-value'>" . (($datos['requirio_recuperacion'] ?? false) ? 'Si' : 'No') . "</div>
+                            <div class='field-value'>".(($datos['requirio_recuperacion'] ?? false) ? 'Si' : 'No')."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Medidas adoptadas</div>
-                            <div class='field-value-long'>" . nl2br(e($datos['medidas_adoptadas'] ?? '-')) . "</div>
+                            <div class='field-value-long'>".nl2br(e($datos['medidas_adoptadas'] ?? '-'))."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Resultado / Verificacion</div>
-                            <div class='field-value-long'>" . nl2br(e($datos['resultado_verificacion'] ?? '-')) . "</div>
+                            <div class='field-value-long'>".nl2br(e($datos['resultado_verificacion'] ?? '-'))."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Acciones preventivas</div>
-                            <div class='field-value-long'>" . nl2br(e($datos['acciones_preventivas'] ?? '-')) . "</div>
+                            <div class='field-value-long'>".nl2br(e($datos['acciones_preventivas'] ?? '-'))."</div>
                         </div>
                         <div class='field'>
                             <div class='field-label'>Registrado por</div>
-                            <div class='field-value'>" . e($r->creador?->name ?? '-') . " | " . $r->created_at->format('d/m/Y H:i') . "</div>
+                            <div class='field-value'>".e($r->creador?->name ?? '-').' | '.$r->created_at->format('d/m/Y H:i')."</div>
                         </div>
                     </div>
                 </div>
 
                 <p class='footer'>
-                    Generado: " . now()->format('d/m/Y H:i') . ' | SecuriForm
+                    Generado: ".now()->format('d/m/Y H:i').' | SecuriForm
                 </p>');
         }
     }

--- a/app/Filament/Pages/ReporteInventarioSoportes.php
+++ b/app/Filament/Pages/ReporteInventarioSoportes.php
@@ -25,6 +25,8 @@ class ReporteInventarioSoportes extends Page implements HasForms
 
     protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?string $navigationLabel = 'Inventario Soportes (F07)';
 
     protected static ?string $title = 'Formato 7 — Inventario de Soportes';

--- a/app/Filament/Pages/ReporteMovimientosSoportes.php
+++ b/app/Filament/Pages/ReporteMovimientosSoportes.php
@@ -9,8 +9,10 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Mpdf\Mpdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ReporteMovimientosSoportes extends Page implements HasForms
 {
@@ -36,36 +38,16 @@ class ReporteMovimientosSoportes extends Page implements HasForms
     public function mount(): void
     {
         $this->form->fill([
-            'mes' => (string) now()->month,
-            'anio' => (string) now()->year,
             'tipo_movimiento' => '',
         ]);
     }
 
-    public function form(\Filament\Schemas\Schema $form): \Filament\Schemas\Schema
+    public function form(Schema $form): Schema
     {
-        $months = [];
-        for ($m = 1; $m <= 12; $m++) {
-            $months[(string) $m] = now()->setMonth($m)->translatedFormat('F');
-        }
-
-        $years = [];
-        for ($y = now()->year; $y >= now()->year - 3; $y--) {
-            $years[(string) $y] = (string) $y;
-        }
-
         return $form
             ->schema([
-                Select::make('mes')
-                    ->label('Mes')
-                    ->options($months)
-                    ->required(),
-                Select::make('anio')
-                    ->label('Año')
-                    ->options($years)
-                    ->required(),
                 Select::make('tipo_movimiento')
-                    ->label('Tipo movimiento')
+                    ->label('Tipo movimiento (opcional)')
                     ->options([
                         '' => 'Todos',
                         'ingreso_nuevo' => 'Ingreso nuevo',
@@ -81,16 +63,12 @@ class ReporteMovimientosSoportes extends Page implements HasForms
             ->statePath('data');
     }
 
-    public function generateReport(): \Symfony\Component\HttpFoundation\StreamedResponse|null
+    public function generateReport(): ?StreamedResponse
     {
         $tenant = Filament::getTenant();
-        $month = (int) $this->data['mes'];
-        $year = (int) $this->data['anio'];
 
         $query = EquipoAsignacion::query()
             ->whereHas('equipo', fn ($q) => $q->withoutGlobalScopes()->where('empresa_id', $tenant->id))
-            ->whereMonth('fecha_inicio', $month)
-            ->whereYear('fecha_inicio', $year)
             ->with(['equipo', 'user', 'asignador']);
 
         if (! empty($this->data['tipo_movimiento'])) {
@@ -102,14 +80,12 @@ class ReporteMovimientosSoportes extends Page implements HasForms
         if ($movimientos->isEmpty()) {
             Notification::make()
                 ->title('Sin resultados')
-                ->body('No se encontraron movimientos en el periodo seleccionado.')
+                ->body('No se encontraron movimientos.')
                 ->warning()
                 ->send();
 
             return null;
         }
-
-        $monthName = now()->setMonth($month)->translatedFormat('F');
 
         $mpdf = new Mpdf([
             'format' => 'A4-L',
@@ -117,25 +93,25 @@ class ReporteMovimientosSoportes extends Page implements HasForms
         ]);
 
         if ($tenant->logo_path) {
-            $logoPath = storage_path('app/' . $tenant->logo_path);
+            $logoPath = storage_path('app/'.$tenant->logo_path);
             if (file_exists($logoPath)) {
                 $mpdf->imageVars['logo'] = file_get_contents($logoPath);
             }
         }
 
-        $this->buildReport($mpdf, $tenant, $movimientos, $monthName, $year);
+        $this->buildReport($mpdf, $tenant, $movimientos);
 
-        $filename = "movimientos_soportes_F08_{$year}_{$month}.pdf";
+        $filename = 'movimientos_soportes_F08_'.now()->format('Ymd').'.pdf';
 
         return response()->streamDownload(function () use ($mpdf) {
             echo $mpdf->Output('', 'S');
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReport(Mpdf $mpdf, $tenant, $movimientos, $monthName, $year): void
+    private function buildReport(Mpdf $mpdf, $tenant, $movimientos): void
     {
         $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
+        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
             $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
         }
 
@@ -156,33 +132,33 @@ class ReporteMovimientosSoportes extends Page implements HasForms
         $rows = '';
         foreach ($movimientos as $m) {
             $rows .= '<tr>'
-                . '<td>' . $m->fecha_inicio->format('d/m/Y H:i') . '</td>'
-                . '<td>' . e($m->equipo?->codigo_interno ?? '-') . '</td>'
-                . '<td>' . e($this->tipoEquipoLabel($m->equipo?->tipo ?? '')) . '</td>'
-                . '<td>' . e($m->equipo?->numero_serie ?? '-') . '</td>'
-                . '<td>' . e($this->tipoMovimientoLabel($m->tipo)) . '</td>'
-                . '<td>' . e($m->user?->name ?? '-') . '</td>'
-                . '<td>' . e($m->empresa_tercera ?? '-') . '</td>'
-                . '<td style="max-width:100px;">' . e(mb_substr($m->motivo ?? '-', 0, 60)) . '</td>'
-                . '<td>' . e($m->condicion_entrega ?? '-') . '</td>'
-                . '<td>' . e($m->asignador?->name ?? '-') . '</td>'
-                . '</tr>';
+                .'<td>'.$m->fecha_inicio->format('d/m/Y H:i').'</td>'
+                .'<td>'.e($m->equipo?->codigo_interno ?? '-').'</td>'
+                .'<td>'.e($this->tipoEquipoLabel($m->equipo?->tipo ?? '')).'</td>'
+                .'<td>'.e($m->equipo?->numero_serie ?? '-').'</td>'
+                .'<td>'.e($this->tipoMovimientoLabel($m->tipo)).'</td>'
+                .'<td>'.e($m->user?->name ?? '-').'</td>'
+                .'<td>'.e($m->empresa_tercera ?? '-').'</td>'
+                .'<td style="max-width:100px;">'.e(mb_substr($m->motivo ?? '-', 0, 60)).'</td>'
+                .'<td>'.e($m->condicion_entrega ?? '-').'</td>'
+                .'<td>'.e($m->asignador?->name ?? '-').'</td>'
+                .'</tr>';
         }
 
         $summaryParts = [];
         foreach ($tipoCount as $tipo => $count) {
-            $summaryParts[] = $this->tipoMovimientoLabel($tipo) . ': ' . $count;
+            $summaryParts[] = $this->tipoMovimientoLabel($tipo).': '.$count;
         }
 
-        $mpdf->WriteHTML($style . '
-            ' . $logoHtml . '
-            <h1>' . e($tenant->razon_social) . '</h1>
-            <p style="color:#666;">RUC: ' . e($tenant->ruc) . '</p>
+        $mpdf->WriteHTML($style.'
+            '.$logoHtml.'
+            <h1>'.e($tenant->razon_social).'</h1>
+            <p style="color:#666;">RUC: '.e($tenant->ruc).'</p>
             <h2>Formato 8 — Ingreso y Salida de Soportes</h2>
-            <p style="color:#666;">Periodo: ' . $monthName . ' ' . $year . ' | Politica: PSC000003</p>
+            <p style="color:#666;">Reporte completo | Politica: PSC000003</p>
 
             <div class="summary">
-                <strong>Resumen:</strong> Total: ' . $movimientos->count() . ' movimientos | ' . implode(' | ', $summaryParts) . '
+                <strong>Resumen:</strong> Total: '.$movimientos->count().' movimientos | '.implode(' | ', $summaryParts).'
             </div>
 
             <table>
@@ -200,11 +176,11 @@ class ReporteMovimientosSoportes extends Page implements HasForms
                         <th>Realizado por</th>
                     </tr>
                 </thead>
-                <tbody>' . $rows . '</tbody>
+                <tbody>'.$rows.'</tbody>
             </table>
 
             <p class="footer">
-                Generado: ' . now()->format('d/m/Y H:i') . ' | ' . e(auth()->user()->name) . ' | SecuriForm — PSC000003
+                Generado: '.now()->format('d/m/Y H:i').' | '.e(auth()->user()->name).' | SecuriForm — PSC000003
             </p>');
     }
 

--- a/app/Filament/Pages/ReporteMovimientosSoportes.php
+++ b/app/Filament/Pages/ReporteMovimientosSoportes.php
@@ -27,6 +27,8 @@ class ReporteMovimientosSoportes extends Page implements HasForms
 
     protected static string|\UnitEnum|null $navigationGroup = 'Reportes';
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?string $navigationLabel = 'Movimientos Soportes (F08)';
 
     protected static ?string $title = 'Formato 8 — Ingreso y Salida de Soportes';

--- a/app/Filament/Resources/Politicas/Pages/ViewNdaFirmantes.php
+++ b/app/Filament/Resources/Politicas/Pages/ViewNdaFirmantes.php
@@ -4,8 +4,9 @@ namespace App\Filament\Resources\Politicas\Pages;
 
 use App\Filament\Resources\Politicas\PoliticaResource;
 use App\Models\AceptacionPolitica;
-use Filament\Resources\Pages\Page;
+use App\Models\Politica;
 use Filament\Actions\Action;
+use Filament\Resources\Pages\Page;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -27,17 +28,41 @@ class ViewNdaFirmantes extends Page implements HasTable
 
     public function mount(int|string $record): void
     {
-        $this->record = \App\Models\Politica::findOrFail($record);
+        $this->record = Politica::findOrFail($record);
     }
 
     public function getTitle(): string
     {
-        return 'Firmantes — ' . $this->record->titulo;
+        return 'Firmantes — '.$this->record->titulo;
     }
 
     public function getBreadcrumb(): string
     {
         return 'Firmantes';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        $hasFirmados = AceptacionPolitica::where('politica_id', $this->record->id)
+            ->whereNotNull('firma_imagen')
+            ->whereHas('user', fn ($q) => $q->firmantes())
+            ->exists();
+
+        return [
+            Action::make('descargar_resumen')
+                ->label('Resumen firmantes (PDF)')
+                ->icon('heroicon-o-document-text')
+                ->color('gray')
+                ->url(fn () => route('politicas.resumen-firmantes-pdf', ['politica' => $this->record]))
+                ->openUrlInNewTab(),
+
+            Action::make('descargar_firmados_zip')
+                ->label('Descargar todos los firmados (ZIP)')
+                ->icon('heroicon-o-archive-box-arrow-down')
+                ->color('primary')
+                ->url(fn () => route('politicas.firmados-zip', ['politica' => $this->record]))
+                ->visible(fn () => $hasFirmados),
+        ];
     }
 
     public function table(Table $table): Table

--- a/app/Http/Controllers/PoliticaPdfController.php
+++ b/app/Http/Controllers/PoliticaPdfController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Mpdf\Mpdf;
+use Mpdf\Output\Destination;
 
 class PoliticaPdfController extends Controller
 {
@@ -28,30 +29,30 @@ class PoliticaPdfController extends Controller
 
         $html .= '
         <div class="header">
-            <h1>' . e($empresa?->razon_social ?? 'SecuriForm') . '</h1>
+            <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
             <p>Documento de politica de seguridad de la informacion</p>
         </div>
 
         <div class="meta">
             <table>
-                <tr><td class="label">Titulo:</td><td class="value">' . e($politica->titulo) . '</td></tr>
-                <tr><td class="label">Version:</td><td class="value">' . e($politica->version) . '</td></tr>
-                <tr><td class="label">Estado:</td><td class="value">' . ($politica->activa ? 'Activa' : 'Inactiva') . '</td></tr>
-                <tr><td class="label">Obligatoria:</td><td class="value">' . ($politica->obligatoria ? 'Si' : 'No') . '</td></tr>
-                <tr><td class="label">Fecha:</td><td class="value">' . $politica->created_at->format('d/m/Y') . '</td></tr>'
-                . ($politica->es_nda ? '<tr><td class="label">Tipo:</td><td class="value">Acuerdo de Confidencialidad (NDA)</td></tr>' : '')
-                . ($politica->es_nda && $politica->vigencia_meses ? '<tr><td class="label">Vigencia:</td><td class="value">' . $politica->vigencia_meses . ' meses</td></tr>' : '')
-                . ($aceptacion?->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">' . $aceptacion->fecha_expiracion->format('d/m/Y') . '</td></tr>' : '') . '
+                <tr><td class="label">Titulo:</td><td class="value">'.e($politica->titulo).'</td></tr>
+                <tr><td class="label">Version:</td><td class="value">'.e($politica->version).'</td></tr>
+                <tr><td class="label">Estado:</td><td class="value">'.($politica->activa ? 'Activa' : 'Inactiva').'</td></tr>
+                <tr><td class="label">Obligatoria:</td><td class="value">'.($politica->obligatoria ? 'Si' : 'No').'</td></tr>
+                <tr><td class="label">Fecha:</td><td class="value">'.$politica->created_at->format('d/m/Y').'</td></tr>'
+                .($politica->es_nda ? '<tr><td class="label">Tipo:</td><td class="value">Acuerdo de Confidencialidad (NDA)</td></tr>' : '')
+                .($politica->es_nda && $politica->vigencia_meses ? '<tr><td class="label">Vigencia:</td><td class="value">'.$politica->vigencia_meses.' meses</td></tr>' : '')
+                .($aceptacion?->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">'.$aceptacion->fecha_expiracion->format('d/m/Y').'</td></tr>' : '').'
             </table>
         </div>
 
-        <div class="content">' . $this->renderContenido($politica, $user) . '</div>';
+        <div class="content">'.$this->renderContenido($politica, $user).'</div>';
 
         $html .= $this->buildSignatureBlock($admin, $aceptacion, $empresa);
 
         $html .= '
         <div class="footer">
-            ' . e($empresa?->razon_social ?? '') . ' &mdash; Generado el ' . now()->format('d/m/Y H:i') . '
+            '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
             <br>Este documento es confidencial y de uso interno.
         </div>';
 
@@ -63,22 +64,95 @@ class PoliticaPdfController extends Controller
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        $mpdf->SetTitle($politica->titulo . ' v' . $politica->version);
+        $mpdf->SetTitle($politica->titulo.' v'.$politica->version);
         $mpdf->WriteHTML($html);
 
-        $filename = 'politica_' . $politica->slug . '_v' . $politica->version . '.pdf';
-        $path = storage_path('app/temp/' . $filename);
+        $filename = 'politica_'.$politica->slug.'_v'.$politica->version.'.pdf';
+        $path = storage_path('app/temp/'.$filename);
 
         if (! is_dir(storage_path('app/temp'))) {
             mkdir(storage_path('app/temp'), 0755, true);
         }
 
-        $mpdf->Output($path, \Mpdf\Output\Destination::FILE);
+        $mpdf->Output($path, Destination::FILE);
 
         return response()->download($path, $filename)->deleteFileAfterSend();
     }
 
     public function downloadNdaFirmante(Request $request, Politica $politica, AceptacionPolitica $aceptacion)
+    {
+        $firmante = $aceptacion->user;
+        $bytes = $this->buildFirmantePdfBytes($politica, $aceptacion);
+
+        $filename = 'nda_'.Str::slug($firmante->name).'_v'.$aceptacion->version_aceptada.'.pdf';
+
+        if (! is_dir(storage_path('app/temp'))) {
+            mkdir(storage_path('app/temp'), 0755, true);
+        }
+
+        $path = storage_path('app/temp/'.$filename);
+        file_put_contents($path, $bytes);
+
+        return response()->download($path, $filename)->deleteFileAfterSend();
+    }
+
+    public function downloadAllFirmadosZip(Request $request, Politica $politica)
+    {
+        if (! auth()->user()?->hasRole(['super_admin', 'admin_empresa', 'agente_helpdesk'])) {
+            abort(403);
+        }
+
+        $aceptaciones = AceptacionPolitica::where('politica_id', $politica->id)
+            ->whereNotNull('firma_imagen')
+            ->whereHas('user', fn ($q) => $q->firmantes())
+            ->with('user')
+            ->orderBy('fecha_aceptacion', 'desc')
+            ->get();
+
+        if ($aceptaciones->isEmpty()) {
+            abort(404, 'No hay firmantes para esta politica.');
+        }
+
+        if (! is_dir(storage_path('app/temp'))) {
+            mkdir(storage_path('app/temp'), 0755, true);
+        }
+
+        $zipFilename = 'firmados_'.$politica->slug.'_v'.$politica->version.'_'.now()->format('Ymd_His').'.zip';
+        $zipPath = storage_path('app/temp/'.$zipFilename);
+
+        $zip = new \ZipArchive;
+        if ($zip->open($zipPath, \ZipArchive::CREATE | \ZipArchive::OVERWRITE) !== true) {
+            abort(500, 'No se pudo crear el archivo ZIP.');
+        }
+
+        $usedNames = [];
+        foreach ($aceptaciones as $aceptacion) {
+            $firmante = $aceptacion->user;
+            if (! $firmante) {
+                continue;
+            }
+
+            $bytes = $this->buildFirmantePdfBytes($politica, $aceptacion);
+
+            $base = 'nda_'.Str::slug($firmante->name).'_v'.$aceptacion->version_aceptada;
+            $entryName = $base.'.pdf';
+            $i = 1;
+            while (isset($usedNames[$entryName])) {
+                $entryName = $base.'_'.(++$i).'.pdf';
+            }
+            $usedNames[$entryName] = true;
+
+            $zip->addFromString($entryName, $bytes);
+        }
+
+        $zip->close();
+
+        return response()->download($zipPath, $zipFilename, [
+            'Content-Type' => 'application/zip',
+        ])->deleteFileAfterSend();
+    }
+
+    private function buildFirmantePdfBytes(Politica $politica, AceptacionPolitica $aceptacion): string
     {
         $empresa = $politica->empresa;
         $firmante = $aceptacion->user;
@@ -88,30 +162,30 @@ class PoliticaPdfController extends Controller
 
         $html .= '
         <div class="header">
-            <h1>' . e($empresa?->razon_social ?? 'SecuriForm') . '</h1>
+            <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
             <p>Acuerdo de Confidencialidad (NDA)</p>
         </div>
 
         <div class="meta">
             <table>
-                <tr><td class="label">Documento:</td><td class="value">' . e($politica->titulo) . '</td></tr>
-                <tr><td class="label">Version:</td><td class="value">' . e($aceptacion->version_aceptada) . '</td></tr>
-                <tr><td class="label">Firmante:</td><td class="value">' . e($firmante->name) . '</td></tr>
-                <tr><td class="label">DNI:</td><td class="value">' . e($firmante->dni ?? 'N/A') . '</td></tr>
-                <tr><td class="label">Puesto:</td><td class="value">' . e($firmante->puesto ?? 'N/A') . '</td></tr>
-                <tr><td class="label">Fecha firma:</td><td class="value">' . $aceptacion->fecha_aceptacion->format('d/m/Y H:i') . '</td></tr>'
-                . ($aceptacion->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">' . $aceptacion->fecha_expiracion->format('d/m/Y') . '</td></tr>' : '')
-                . '<tr><td class="label">Estado:</td><td class="value">' . ($aceptacion->estaVigente() ? 'Vigente' : 'Expirado') . '</td></tr>
+                <tr><td class="label">Documento:</td><td class="value">'.e($politica->titulo).'</td></tr>
+                <tr><td class="label">Version:</td><td class="value">'.e($aceptacion->version_aceptada).'</td></tr>
+                <tr><td class="label">Firmante:</td><td class="value">'.e($firmante?->name ?? '-').'</td></tr>
+                <tr><td class="label">DNI:</td><td class="value">'.e($firmante?->dni ?? 'N/A').'</td></tr>
+                <tr><td class="label">Puesto:</td><td class="value">'.e($firmante?->puesto ?? 'N/A').'</td></tr>
+                <tr><td class="label">Fecha firma:</td><td class="value">'.$aceptacion->fecha_aceptacion->format('d/m/Y H:i').'</td></tr>'
+                .($aceptacion->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">'.$aceptacion->fecha_expiracion->format('d/m/Y').'</td></tr>' : '')
+                .'<tr><td class="label">Estado:</td><td class="value">'.($aceptacion->estaVigente() ? 'Vigente' : 'Expirado').'</td></tr>
             </table>
         </div>
 
-        <div class="content">' . $this->renderContenido($politica, $firmante) . '</div>';
+        <div class="content">'.$this->renderContenido($politica, $firmante).'</div>';
 
         $html .= $this->buildSignatureBlock($admin, $aceptacion, $empresa);
 
         $html .= '
         <div class="footer">
-            ' . e($empresa?->razon_social ?? '') . ' &mdash; Generado el ' . now()->format('d/m/Y H:i') . '
+            '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
             <br>Este documento es confidencial y de uso interno.
         </div>';
 
@@ -123,19 +197,10 @@ class PoliticaPdfController extends Controller
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        $mpdf->SetTitle('NDA - ' . $firmante->name . ' - ' . $politica->titulo);
+        $mpdf->SetTitle('NDA - '.($firmante?->name ?? '-').' - '.$politica->titulo);
         $mpdf->WriteHTML($html);
 
-        $filename = 'nda_' . Str::slug($firmante->name) . '_v' . $aceptacion->version_aceptada . '.pdf';
-        $path = storage_path('app/temp/' . $filename);
-
-        if (! is_dir(storage_path('app/temp'))) {
-            mkdir(storage_path('app/temp'), 0755, true);
-        }
-
-        $mpdf->Output($path, \Mpdf\Output\Destination::FILE);
-
-        return response()->download($path, $filename)->deleteFileAfterSend();
+        return $mpdf->Output('', Destination::STRING_RETURN);
     }
 
     public function downloadResumenFirmantes(Request $request, Politica $politica)
@@ -189,17 +254,17 @@ class PoliticaPdfController extends Controller
 
         $html .= '
         <div class="header">
-            <h1>' . e($empresa?->razon_social ?? 'SecuriForm') . '</h1>
-            <p>Resumen de firmantes — ' . e($politica->titulo) . '</p>
+            <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
+            <p>Resumen de firmantes — '.e($politica->titulo).'</p>
         </div>
 
         <div class="meta">
             <table>
-                <tr><td class="label">Politica:</td><td class="value">' . e($politica->titulo) . '</td></tr>
-                <tr><td class="label">Version actual:</td><td class="value">' . e($politica->version) . '</td></tr>
-                <tr><td class="label">Tipo:</td><td class="value">' . ($politica->es_nda ? 'Acuerdo de Confidencialidad (NDA)' : 'Politica de seguridad') . '</td></tr>
-                <tr><td class="label">Total firmantes:</td><td class="value">' . $aceptaciones->count() . '</td></tr>
-                <tr><td class="label">Generado:</td><td class="value">' . now()->format('d/m/Y H:i') . '</td></tr>
+                <tr><td class="label">Politica:</td><td class="value">'.e($politica->titulo).'</td></tr>
+                <tr><td class="label">Version actual:</td><td class="value">'.e($politica->version).'</td></tr>
+                <tr><td class="label">Tipo:</td><td class="value">'.($politica->es_nda ? 'Acuerdo de Confidencialidad (NDA)' : 'Politica de seguridad').'</td></tr>
+                <tr><td class="label">Total firmantes:</td><td class="value">'.$aceptaciones->count().'</td></tr>
+                <tr><td class="label">Generado:</td><td class="value">'.now()->format('d/m/Y H:i').'</td></tr>
             </table>
         </div>';
 
@@ -207,9 +272,9 @@ class PoliticaPdfController extends Controller
         $html .= '<div class="admin-box">';
         if ($admin?->firma_guardada && str_starts_with($admin->firma_guardada, 'data:image')) {
             $html .= '<h4>Firma del Gerente General</h4>
-                <img src="' . $admin->firma_guardada . '" class="admin-img"><br>
-                <div class="admin-name">' . e($admin->name) . '</div>
-                <div class="admin-detail">Gerente General — ' . e($empresa?->razon_social ?? '') . '</div>';
+                <img src="'.$admin->firma_guardada.'" class="admin-img"><br>
+                <div class="admin-name">'.e($admin->name).'</div>
+                <div class="admin-detail">Gerente General — '.e($empresa?->razon_social ?? '').'</div>';
         } else {
             $html .= '<h4>Firma del Gerente General</h4>
                 <div style="height:40px;"></div>
@@ -220,7 +285,7 @@ class PoliticaPdfController extends Controller
 
         // Firmantes by version
         foreach ($porVersion as $version => $firmas) {
-            $html .= '<div class="version-title">Version ' . e($version) . ' — ' . $firmas->count() . ' firmante(s)</div>';
+            $html .= '<div class="version-title">Version '.e($version).' — '.$firmas->count().' firmante(s)</div>';
 
             foreach ($firmas as $a) {
                 $user = $a->user;
@@ -228,14 +293,14 @@ class PoliticaPdfController extends Controller
 
                 // Left: user info
                 $html .= '<td width="55%" valign="middle">
-                    <div class="firma-name">' . e($user?->name ?? '-') . '</div>
-                    <div class="firma-detail">' . e($user?->puesto ?? '-') . ' · DNI: ' . e($user?->dni ?? '-') . '</div>
-                    <div class="firma-detail">Firmado: ' . $a->fecha_aceptacion->format('d/m/Y H:i');
+                    <div class="firma-name">'.e($user?->name ?? '-').'</div>
+                    <div class="firma-detail">'.e($user?->puesto ?? '-').' · DNI: '.e($user?->dni ?? '-').'</div>
+                    <div class="firma-detail">Firmado: '.$a->fecha_aceptacion->format('d/m/Y H:i');
 
                 if ($politica->es_nda && $a->fecha_expiracion) {
                     $vigente = $a->estaVigente();
-                    $html .= ' · Expira: ' . $a->fecha_expiracion->format('d/m/Y')
-                        . ' <span style="color:' . ($vigente ? '#059669' : '#dc2626') . ';font-weight:bold;">(' . ($vigente ? 'Vigente' : 'Expirado') . ')</span>';
+                    $html .= ' · Expira: '.$a->fecha_expiracion->format('d/m/Y')
+                        .' <span style="color:'.($vigente ? '#059669' : '#dc2626').';font-weight:bold;">('.($vigente ? 'Vigente' : 'Expirado').')</span>';
                 }
 
                 $html .= '</div></td>';
@@ -243,9 +308,9 @@ class PoliticaPdfController extends Controller
                 // Right: signature
                 $html .= '<td width="45%" valign="middle" style="text-align:right;">';
                 if ($a->firma_imagen && str_starts_with($a->firma_imagen, 'data:image')) {
-                    $html .= '<img src="' . $a->firma_imagen . '" class="firma-img">';
+                    $html .= '<img src="'.$a->firma_imagen.'" class="firma-img">';
                     if ($a->firma_nombre) {
-                        $html .= '<div class="firma-detail">' . e($a->firma_nombre) . '</div>';
+                        $html .= '<div class="firma-detail">'.e($a->firma_nombre).'</div>';
                     }
                 } else {
                     $html .= '<span class="firma-detail" style="color:#dc2626;">Sin firma digital</span>';
@@ -255,21 +320,21 @@ class PoliticaPdfController extends Controller
         }
 
         $html .= '<div class="footer">'
-            . e($empresa?->razon_social ?? '') . ' — Resumen generado el ' . now()->format('d/m/Y H:i')
-            . ' por ' . e(auth()->user()->name)
-            . '<br>Este documento es confidencial y de uso interno.</div>';
+            .e($empresa?->razon_social ?? '').' — Resumen generado el '.now()->format('d/m/Y H:i')
+            .' por '.e(auth()->user()->name)
+            .'<br>Este documento es confidencial y de uso interno.</div>';
 
-        $mpdf->SetTitle('Firmantes - ' . $politica->titulo);
+        $mpdf->SetTitle('Firmantes - '.$politica->titulo);
         $mpdf->WriteHTML($html);
 
-        $filename = 'firmantes_' . $politica->slug . '_v' . $politica->version . '.pdf';
-        $path = storage_path('app/temp/' . $filename);
+        $filename = 'firmantes_'.$politica->slug.'_v'.$politica->version.'.pdf';
+        $path = storage_path('app/temp/'.$filename);
 
         if (! is_dir(storage_path('app/temp'))) {
             mkdir(storage_path('app/temp'), 0755, true);
         }
 
-        $mpdf->Output($path, \Mpdf\Output\Destination::FILE);
+        $mpdf->Output($path, Destination::FILE);
 
         return response()->download($path, $filename)->deleteFileAfterSend();
     }
@@ -320,10 +385,10 @@ class PoliticaPdfController extends Controller
         if ($admin?->firma_guardada && str_starts_with($admin->firma_guardada, 'data:image')) {
             $html .= '<div class="sig-box">
                 <h4>Firma del Gerente General</h4>
-                <img src="' . $admin->firma_guardada . '" class="sig-img">
-                <div class="sig-name">' . e($admin->name) . '</div>
+                <img src="'.$admin->firma_guardada.'" class="sig-img">
+                <div class="sig-name">'.e($admin->name).'</div>
                 <div class="sig-detail">Gerente General</div>
-                <div class="sig-detail">' . e($empresa?->razon_social ?? '') . '</div>
+                <div class="sig-detail">'.e($empresa?->razon_social ?? '').'</div>
             </div>';
         } else {
             $html .= '<div class="sig-missing">
@@ -338,11 +403,11 @@ class PoliticaPdfController extends Controller
         if ($aceptacion?->firma_imagen && str_starts_with($aceptacion->firma_imagen, 'data:image')) {
             $html .= '<div class="sig-box">
                 <h4>Firma del trabajador</h4>
-                <img src="' . $aceptacion->firma_imagen . '" class="sig-img">
-                <div class="sig-name">' . e($aceptacion->firma_nombre) . '</div>'
-                . ($aceptacion->firma_cargo ? '<div class="sig-detail">' . e($aceptacion->firma_cargo) . '</div>' : '') . '
-                <div class="sig-detail">Firmado: ' . $aceptacion->fecha_aceptacion->format('d/m/Y H:i') . '</div>
-                <div class="sig-detail">IP: ' . e($aceptacion->ip_address) . '</div>
+                <img src="'.$aceptacion->firma_imagen.'" class="sig-img">
+                <div class="sig-name">'.e($aceptacion->firma_nombre).'</div>'
+                .($aceptacion->firma_cargo ? '<div class="sig-detail">'.e($aceptacion->firma_cargo).'</div>' : '').'
+                <div class="sig-detail">Firmado: '.$aceptacion->fecha_aceptacion->format('d/m/Y H:i').'</div>
+                <div class="sig-detail">IP: '.e($aceptacion->ip_address).'</div>
             </div>';
         } else {
             $html .= '<div class="sig-box">

--- a/resources/views/filament/pages/auth/register-empresa.blade.php
+++ b/resources/views/filament/pages/auth/register-empresa.blade.php
@@ -114,11 +114,6 @@
                                     <canvas x-ref="canvas" width="460" height="160" style="width:100%; cursor:crosshair; touch-action:none; display:block;"
                                             @mousedown="start($event)" @mousemove="move($event)" @mouseup="end()" @mouseleave="end()"
                                             @touchstart="start($event)" @touchmove="move($event)" @touchend="end()"></canvas>
-                                    @if (!$firmaDataUrl)
-                                        <div style="position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); pointer-events:none;" class="text-xs text-gray-300 dark:text-gray-600">
-                                            Dibuja aqui tu firma
-                                        </div>
-                                    @endif
                                 </div>
                                 <div style="display:flex; justify-content:flex-end; margin-top:4px;">
                                     <button @click="clear()" type="button" class="text-xs text-danger-600 dark:text-danger-400 hover:underline">Limpiar</button>

--- a/resources/views/filament/pages/centro-reportes.blade.php
+++ b/resources/views/filament/pages/centro-reportes.blade.php
@@ -1,0 +1,35 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+            Selecciona un reporte para generarlo individualmente, o usa el boton <strong>Reporte completo (PDF)</strong>
+            del header para descargar un consolidado con todas las areas en un solo documento.
+        </p>
+    </x-filament::section>
+
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; margin-top: 16px;">
+        @foreach ($this->getReportesVisibles() as $rep)
+            <a href="{{ $rep['url'] }}"
+               style="text-decoration: none; color: inherit;
+                      background: rgba(255,255,255,0.04);
+                      border: 1px solid rgba(255,255,255,0.08);
+                      border-left: 4px solid {{ $rep['color'] }};
+                      border-radius: 12px;
+                      padding: 18px 20px;
+                      display: block;
+                      transition: transform 0.15s, box-shadow 0.15s;"
+               onmouseover="this.style.transform='translateY(-2px)';this.style.boxShadow='0 8px 24px rgba(0,0,0,0.2)';"
+               onmouseout="this.style.transform='';this.style.boxShadow='';">
+                <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 10px;">
+                    <div style="width: 40px; height: 40px; border-radius: 8px;
+                                background: {{ $rep['color'] }}20;
+                                display: flex; align-items: center; justify-content: center;">
+                        <x-filament::icon :icon="$rep['icon']"
+                                          style="width: 22px; height: 22px; color: {{ $rep['color'] }};" />
+                    </div>
+                    <div style="font-size: 15px; font-weight: 600;">{{ $rep['title'] }}</div>
+                </div>
+                <p style="font-size: 13px; color: #9ca3af; margin: 0; line-height: 1.5;">{{ $rep['desc'] }}</p>
+            </a>
+        @endforeach
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/mi-perfil.blade.php
+++ b/resources/views/filament/pages/mi-perfil.blade.php
@@ -253,9 +253,6 @@
                                         @mousedown="start($event)" @mousemove="move($event)" @mouseup="end()" @mouseleave="end()"
                                         @touchstart="start($event)" @touchmove="move($event)" @touchend="end()">
                                 </canvas>
-                                <div x-show="!ps.length && !d" style="position:absolute; bottom:8px; left:12px; pointer-events:none;" class="text-xs text-gray-300 dark:text-gray-600">
-                                    Dibuja aqui tu firma
-                                </div>
                             </div>
                             <div style="display:flex; justify-content:space-between; align-items:center; margin-top:6px;" :style="fs ? 'color:#fff;' : ''">
                                 <span class="text-xs" :class="fs ? '' : 'text-gray-400'">Usa el mouse o el dedo en pantalla tactil</span>

--- a/resources/views/filament/pages/reporte-capacitaciones.blade.php
+++ b/resources/views/filament/pages/reporte-capacitaciones.blade.php
@@ -1,15 +1,12 @@
 <x-filament-panels::page>
     <x-filament::section>
         <form wire:submit="generateReport">
-            <div style="display: grid; grid-template-columns: 1fr 1fr auto; gap: 16px; align-items: end;">
-                {{ $this->form }}
-
-                <div style="padding-bottom: 2px;">
-                    <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
-                        Generar PDF
-                    </x-filament::button>
-                </div>
-            </div>
+            <p class="text-sm text-gray-500 dark:text-gray-400" style="margin-bottom: 16px;">
+                Genera un PDF con todas las capacitaciones y la asistencia de los usuarios.
+            </p>
+            <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
+                Generar PDF
+            </x-filament::button>
         </form>
     </x-filament::section>
 
@@ -19,7 +16,7 @@
                 Reporte de Capacitaciones de Ciberseguridad
             </div>
             <p style="font-size: 14px; color: #d1d5db; margin: 0;">
-                Genera un PDF con todas las capacitaciones realizadas en el mes seleccionado, incluyendo metricas de asistencia y cumplimiento por usuario. Formato formal para presentar ante entes auditores (PSC000001).
+                Genera un PDF con todas las capacitaciones realizadas, incluyendo metricas de asistencia y cumplimiento por usuario. Formato formal para presentar ante entes auditores (PSC000001).
             </p>
         </div>
     </x-filament::section>

--- a/resources/views/filament/pages/reporte-checklists.blade.php
+++ b/resources/views/filament/pages/reporte-checklists.blade.php
@@ -1,0 +1,19 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <form wire:submit="generateReport">
+            <p class="text-sm text-gray-500 dark:text-gray-400" style="margin-bottom: 16px;">
+                Genera un PDF con todas las plantillas de checklist y todas las ejecuciones realizadas sobre los equipos de la empresa.
+            </p>
+            <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
+                Generar PDF
+            </x-filament::button>
+        </form>
+    </x-filament::section>
+
+    <x-filament::section heading="Informacion" icon="heroicon-o-information-circle">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+            Reporte completo del estado de checklists de cumplimiento por equipo. Incluye listado de plantillas activas,
+            historial de ejecuciones con score (% cumplido), y ficha detallada de cada ejecucion con sus items y observaciones.
+        </p>
+    </x-filament::section>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/reporte-destruccion-activos.blade.php
+++ b/resources/views/filament/pages/reporte-destruccion-activos.blade.php
@@ -1,7 +1,7 @@
 <x-filament-panels::page>
     <x-filament::section>
         <form wire:submit="generateReport">
-            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr auto; gap: 16px; align-items: end;">
+            <div style="display: grid; grid-template-columns: 1fr 1fr auto; gap: 16px; align-items: end;">
                 {{ $this->form }}
 
                 <div style="padding-bottom: 2px;">
@@ -17,8 +17,7 @@
         <p class="text-sm text-gray-500 dark:text-gray-400">
             Genera un reporte PDF completo de destruccion de activos (Formato 13) segun las politicas PSC000003 y PSC000004.
             Incluye estadisticas por metodo de destruccion y motivo de baja, tabla resumen de todos los registros F13,
-            y fichas detalladas individuales con la informacion del equipo vinculado (tipo, marca, modelo, serie, categoria,
-            clasificacion, sensibilidad, ubicacion, contenido de datos y notas de baja).
+            y fichas detalladas individuales con la informacion del equipo vinculado. Filtros opcionales por metodo o motivo.
         </p>
     </x-filament::section>
 </x-filament-panels::page>

--- a/resources/views/filament/pages/reporte-incidencias.blade.php
+++ b/resources/views/filament/pages/reporte-incidencias.blade.php
@@ -1,15 +1,12 @@
 <x-filament-panels::page>
     <x-filament::section>
         <form wire:submit="generateReport">
-            <div style="display: grid; grid-template-columns: 1fr 1fr auto; gap: 16px; align-items: end;">
-                {{ $this->form }}
-
-                <div style="padding-bottom: 2px;">
-                    <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
-                        Generar PDF
-                    </x-filament::button>
-                </div>
-            </div>
+            <p class="text-sm text-gray-500 dark:text-gray-400" style="margin-bottom: 16px;">
+                Genera un PDF con todas las incidencias y resoluciones registradas en la empresa.
+            </p>
+            <x-filament::button type="submit" icon="heroicon-o-document-arrow-down" size="lg">
+                Generar PDF
+            </x-filament::button>
         </form>
     </x-filament::section>
 
@@ -20,7 +17,7 @@
                     F09 — Incidencias
                 </div>
                 <p style="font-size: 14px; color: #d1d5db; margin: 0;">
-                    Reporte de notificaciones de incidencias de seguridad registradas en el mes seleccionado, según política PSC000001 / PSC000-25.
+                    Reporte completo de notificaciones de incidencias de seguridad registradas, según política PSC000001 / PSC000-25.
                 </p>
             </div>
             <div style="background: rgba(255,255,255,0.05); border-radius: 12px; padding: 20px;">
@@ -28,7 +25,7 @@
                     F10 — Resoluciones
                 </div>
                 <p style="font-size: 14px; color: #d1d5db; margin: 0;">
-                    Reporte de resoluciones de incidencias registradas en el mes seleccionado, según política PSC000-25.
+                    Reporte completo de resoluciones de incidencias registradas, según política PSC000-25.
                 </p>
             </div>
         </div>

--- a/resources/views/filament/pages/reporte-movimientos-soportes.blade.php
+++ b/resources/views/filament/pages/reporte-movimientos-soportes.blade.php
@@ -1,7 +1,7 @@
 <x-filament-panels::page>
     <x-filament::section>
         <form wire:submit="generateReport">
-            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr auto; gap: 16px; align-items: end;">
+            <div style="display: grid; grid-template-columns: 1fr auto; gap: 16px; align-items: end;">
                 {{ $this->form }}
 
                 <div style="padding-bottom: 2px;">
@@ -15,8 +15,9 @@
 
     <x-filament::section heading="Informacion" icon="heroicon-o-information-circle">
         <p class="text-sm text-gray-500 dark:text-gray-400">
-            Genera un reporte PDF de movimientos de soportes (Formato 8) segun la politica PSC000003.
+            Genera un reporte PDF de todos los movimientos de soportes (Formato 8) segun la politica PSC000003.
             Incluye ingresos, asignaciones, transferencias, devoluciones, salidas a mantenimiento, home office y terceros.
+            Filtro opcional por tipo de movimiento.
         </p>
     </x-filament::section>
 </x-filament-panels::page>

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,3 +57,7 @@ Route::get('/politicas/{politica}/nda/{aceptacion}/pdf', [\App\Http\Controllers\
 Route::get('/politicas/{politica}/firmantes/pdf', [\App\Http\Controllers\PoliticaPdfController::class, 'downloadResumenFirmantes'])
     ->middleware('auth')
     ->name('politicas.resumen-firmantes-pdf');
+
+Route::get('/politicas/{politica}/firmados/zip', [\App\Http\Controllers\PoliticaPdfController::class, 'downloadAllFirmadosZip'])
+    ->middleware('auth')
+    ->name('politicas.firmados-zip');


### PR DESCRIPTION
## Summary
- Quita filtros de fecha de los reportes (Incidencias, Capacitaciones, MovimientosSoportes, DestruccionActivos) — los clientes ya no eligen mes/anio, el PDF cubre todo el periodo
- Nuevo **Centro de Reportes** con tarjetas a cada reporte y boton "Reporte completo (PDF)" que entrega un consolidado ejecutivo con todas las areas
- Nuevo **ReporteChecklists** (plantillas + ejecuciones por equipo) y nueva descarga **ZIP de todos los NDAs firmados** por politica

## Detalles tecnicos
- `PoliticaPdfController::downloadAllFirmadosZip` itera firmantes vigentes y empaqueta 1 PDF por firmante en `ZipArchive`
- Helper `buildFirmantePdfBytes` reutilizado entre descarga individual y ZIP
- `CentroReportes::generateReporteCompleto` produce un PDF unico con cover, resumen ejecutivo (counts por area) y tablas resumidas por seccion
- Pages que conservan filtros opcionales no-fecha: `MovimientosSoportes` (tipo movimiento), `DestruccionActivos` (metodo + motivo), `InventarioSoportes` (sin cambios)
- Boton "Descargar todos los firmados (ZIP)" + "Resumen firmantes (PDF)" en header de `ViewNdaFirmantes`

## Linear
SEN-120 — https://linear.app/genniality-nerve/issue/SEN-120

## Test plan
- [ ] Login como admin_empresa, ir a "Reportes > Centro de Reportes" y verificar 6 tarjetas visibles
- [ ] Click cada tarjeta y generar el PDF — debe descargar sin errores
- [ ] Boton "Reporte completo (PDF)" en header del Centro de Reportes debe entregar 1 PDF con cover, resumen y secciones de las 6 areas
- [ ] En una politica con NDA firmado, ver Firmantes y probar boton "Descargar todos los firmados (ZIP)" — el ZIP debe contener 1 PDF por firmante
- [ ] El boton ZIP no debe aparecer en politicas sin firmantes
- [ ] Verificar permisos: super_admin, admin_empresa, agente_helpdesk

🤖 Generated with [Claude Code](https://claude.com/claude-code)