### PR TITLE
feat(empresas,reportes): branding PDF + Documentos Firmados en Centro de Reportes (SEN-122)

### DIFF
--- a/app/Filament/Pages/CentroReportes.php
+++ b/app/Filament/Pages/CentroReportes.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Http\Controllers\PoliticaPdfController;
 use App\Models\AceptacionPolitica;
 use App\Models\Capacitacion;
 use App\Models\ChecklistEjecucion;
@@ -12,10 +13,13 @@ use App\Models\Politica;
 use App\Models\Registro;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Str;
 use Mpdf\Mpdf;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipArchive;
 
 class CentroReportes extends Page
 {
@@ -87,6 +91,14 @@ class CentroReportes extends Page
                 'url' => ReporteChecklists::getUrl(),
                 'roles' => ['super_admin', 'admin_empresa'],
             ],
+            [
+                'title' => 'Documentos Firmados',
+                'desc' => 'Un PDF por documento (NDA o politica) con la firma mas reciente de cada colaborador.',
+                'icon' => 'heroicon-o-document-duplicate',
+                'color' => '#9333ea',
+                'action' => 'descargarDocumentosFirmados',
+                'roles' => ['super_admin', 'admin_empresa'],
+            ],
         ];
     }
 
@@ -109,6 +121,99 @@ class CentroReportes extends Page
         ];
     }
 
+    public function descargarDocumentosFirmados()
+    {
+        $tenant = Filament::getTenant();
+
+        $politicas = Politica::withoutGlobalScopes()
+            ->where('empresa_id', $tenant->id)
+            ->whereHas('aceptaciones', fn ($q) => $q->whereNotNull('firma_imagen')
+                ->whereHas('user', fn ($u) => $u->firmantes()))
+            ->orderBy('es_nda', 'desc')
+            ->orderBy('titulo')
+            ->get();
+
+        if ($politicas->isEmpty()) {
+            Notification::make()
+                ->title('Sin firmantes')
+                ->body('No hay documentos firmados por colaboradores en esta empresa.')
+                ->warning()
+                ->send();
+
+            return null;
+        }
+
+        $pdfController = app(PoliticaPdfController::class);
+
+        if ($politicas->count() === 1) {
+            $politica = $politicas->first();
+            $bytes = $pdfController->buildConsolidatedFirmadosPdfBytes($politica);
+
+            if ($bytes === null) {
+                Notification::make()
+                    ->title('Sin firmantes')
+                    ->body('No hay firmantes para este documento.')
+                    ->warning()
+                    ->send();
+
+                return null;
+            }
+
+            $prefix = $politica->es_nda ? 'nda' : 'politica';
+            $filename = $prefix.'_firmantes_'.$politica->slug.'_v'.$politica->version.'_'.now()->format('Ymd_His').'.pdf';
+
+            return response()->streamDownload(function () use ($bytes) {
+                echo $bytes;
+            }, $filename, ['Content-Type' => 'application/pdf']);
+        }
+
+        $tempDir = storage_path('app/temp');
+        if (! is_dir($tempDir)) {
+            mkdir($tempDir, 0755, true);
+        }
+
+        $zipName = 'documentos_firmados_'.Str::slug($tenant->razon_social ?? 'empresa').'_'.now()->format('Ymd_His').'.zip';
+        $zipPath = $tempDir.'/'.$zipName;
+
+        $zip = new ZipArchive;
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            Notification::make()
+                ->title('Error')
+                ->body('No se pudo crear el archivo ZIP.')
+                ->danger()
+                ->send();
+
+            return null;
+        }
+
+        $usados = [];
+
+        foreach ($politicas as $politica) {
+            $bytes = $pdfController->buildConsolidatedFirmadosPdfBytes($politica);
+            if ($bytes === null) {
+                continue;
+            }
+
+            $prefix = $politica->es_nda ? 'nda' : 'politica';
+            $folder = $politica->es_nda ? 'NDA' : 'Politicas';
+            $base = $prefix.'_firmantes_'.$politica->slug.'_v'.$politica->version.'.pdf';
+
+            $finalName = $base;
+            $i = 1;
+            while (isset($usados[$folder.'/'.$finalName])) {
+                $finalName = preg_replace('/\.pdf$/', '_'.$i.'.pdf', $base);
+                $i++;
+            }
+            $usados[$folder.'/'.$finalName] = true;
+
+            $zip->addFromString($folder.'/'.$finalName, $bytes);
+        }
+
+        $zip->close();
+
+        return response()->download($zipPath, $zipName)->deleteFileAfterSend();
+    }
+
     public function generateReporteCompleto(): StreamedResponse
     {
         $tenant = Filament::getTenant();
@@ -118,14 +223,17 @@ class CentroReportes extends Page
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/'.$tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
+        $logoPath = $tenant->getPdfLogoPath();
+        $hasLogo = false;
+        if ($logoPath) {
+            $disk = \Illuminate\Support\Facades\Storage::disk('logos');
+            if ($disk->exists($logoPath)) {
+                $mpdf->imageVars['logo'] = $disk->get($logoPath);
+                $hasLogo = true;
             }
         }
 
-        $this->buildCompleto($mpdf, $tenant);
+        $this->buildCompleto($mpdf, $tenant, $hasLogo);
 
         $filename = 'reporte_completo_'.now()->format('Ymd_His').'.pdf';
 
@@ -134,18 +242,18 @@ class CentroReportes extends Page
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildCompleto(Mpdf $mpdf, $tenant): void
+    private function buildCompleto(Mpdf $mpdf, $tenant, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:60px;margin-bottom:8px;" /><br>';
-        }
+        $logoHtml = $hasLogo ? '<img src="var:logo" style="height:60px;margin-bottom:8px;" /><br>' : '';
+
+        $primario = $tenant->getPdfColorPrimario();
+        $secundario = $tenant->getPdfColorSecundario();
 
         $style = '
         <style>
             body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
-            h1 { color: #4338ca; font-size: 18px; margin-bottom: 2px; }
-            h2 { font-size: 14px; margin-top: 18px; color: #1e1b4b; border-bottom: 2px solid #4338ca; padding-bottom: 4px; }
+            h1 { color: '.$primario.'; font-size: 18px; margin-bottom: 2px; }
+            h2 { font-size: 14px; margin-top: 18px; color: '.$secundario.'; border-bottom: 2px solid '.$primario.'; padding-bottom: 4px; }
             h3 { font-size: 12px; margin-top: 12px; color: #555; }
             table { width: 100%; border-collapse: collapse; margin-top: 6px; }
             th, td { border: 1px solid #ddd; padding: 4px 6px; text-align: left; }
@@ -156,7 +264,7 @@ class CentroReportes extends Page
             .cover .meta { margin-top: 60px; font-size: 11px; color: #4b5563; }
             .stat-grid table { margin-top: 8px; }
             .stat-grid td { text-align: center; padding: 8px 6px; background: #f9fafb; border: 1px solid #e5e7eb; }
-            .stat-number { font-size: 20px; font-weight: bold; color: #4338ca; }
+            .stat-number { font-size: 20px; font-weight: bold; color: '.$primario.'; }
             .stat-label { font-size: 9px; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
             .section { margin-top: 20px; }
             .footer { margin-top: 30px; font-size: 9px; color: #888; }

--- a/app/Filament/Resources/Empresas/Pages/ViewEmpresa.php
+++ b/app/Filament/Resources/Empresas/Pages/ViewEmpresa.php
@@ -81,10 +81,15 @@ class ViewEmpresa extends ViewRecord
                     ->columnSpanFull()
                     ->schema([
                         ImageEntry::make('logo_path')
-                            ->label('Logo')
+                            ->label('Logo sistema')
                             ->disk('logos')
                             ->height(60)
                             ->defaultImageUrl(url('/images/placeholder.png')),
+                        ImageEntry::make('logo_documentos_path')
+                            ->label('Logo documentos')
+                            ->disk('logos')
+                            ->height(60)
+                            ->placeholder('—'),
                         TextEntry::make('ruc')
                             ->label('RUC'),
                         TextEntry::make('razon_social')

--- a/app/Filament/Resources/Empresas/Schemas/EmpresaForm.php
+++ b/app/Filament/Resources/Empresas/Schemas/EmpresaForm.php
@@ -51,7 +51,8 @@ class EmpresaForm
                     ->collapsible()
                     ->schema([
                         FileUpload::make('logo_path')
-                            ->label('Logo de la empresa')
+                            ->label('Logo del sistema')
+                            ->helperText('Se muestra en el sidebar, login y selector de empresa.')
                             ->image()
                             ->disk('logos')
                             ->directory('/')
@@ -67,6 +68,29 @@ class EmpresaForm
                             ->label('Color secundario (acentos)'),
                         ColorPicker::make('color_sidebar')
                             ->label('Color del sidebar'),
+                    ]),
+                Section::make('Personalización de documentos PDF')
+                    ->description('Logo y colores aplicados a los reportes y politicas/NDA en PDF.')
+                    ->columns(2)
+                    ->collapsible()
+                    ->schema([
+                        FileUpload::make('logo_documentos_path')
+                            ->label('Logo para documentos')
+                            ->helperText('Aparece en la cabecera de PDFs (politicas, NDA, reportes). Si no se carga, se usa el logo del sistema.')
+                            ->image()
+                            ->disk('logos')
+                            ->directory('/')
+                            ->maxSize(2048)
+                            ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/svg+xml'])
+                            ->columnSpanFull(),
+                        ColorPicker::make('pdf_color_primario')
+                            ->label('Color primario PDF')
+                            ->helperText('Bordes de cabecera y titulos principales (h1).')
+                            ->placeholder('#4f46e5'),
+                        ColorPicker::make('pdf_color_secundario')
+                            ->label('Color secundario PDF')
+                            ->helperText('Subtitulos (h2) y acentos.')
+                            ->placeholder('#1e1b4b'),
                     ]),
                 Section::make('Configuración')
                     ->schema([

--- a/app/Http/Controllers/PoliticaPdfController.php
+++ b/app/Http/Controllers/PoliticaPdfController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\AceptacionPolitica;
+use App\Models\Empresa;
 use App\Models\Politica;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -25,10 +26,21 @@ class PoliticaPdfController extends Controller
 
         $admin = $this->getAdminConFirma($politica->empresa_id);
 
-        $html = $this->buildStyle();
+        $mpdf = new Mpdf([
+            'margin_top' => 20,
+            'margin_bottom' => 20,
+            'margin_left' => 20,
+            'margin_right' => 20,
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        $hasLogo = $this->attachLogoToMpdf($mpdf, $empresa);
+
+        $html = $this->buildStyle($empresa);
 
         $html .= '
         <div class="header">
+            '.$this->buildLogoHtml($hasLogo).'
             <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
             <p>Documento de politica de seguridad de la informacion</p>
         </div>
@@ -56,14 +68,6 @@ class PoliticaPdfController extends Controller
             <br>Este documento es confidencial y de uso interno.
         </div>';
 
-        $mpdf = new Mpdf([
-            'margin_top' => 20,
-            'margin_bottom' => 20,
-            'margin_left' => 20,
-            'margin_right' => 20,
-            'tempDir' => storage_path('app/temp'),
-        ]);
-
         $mpdf->SetTitle($politica->titulo.' v'.$politica->version);
         $mpdf->WriteHTML($html);
 
@@ -81,10 +85,8 @@ class PoliticaPdfController extends Controller
 
     public function downloadNdaFirmante(Request $request, Politica $politica, AceptacionPolitica $aceptacion)
     {
-        $firmante = $aceptacion->user;
         $bytes = $this->buildFirmantePdfBytes($politica, $aceptacion);
-
-        $filename = 'nda_'.Str::slug($firmante->name).'_v'.$aceptacion->version_aceptada.'.pdf';
+        $filename = $this->aceptacionFilename($politica, $aceptacion);
 
         if (! is_dir(storage_path('app/temp'))) {
             mkdir(storage_path('app/temp'), 0755, true);
@@ -127,18 +129,16 @@ class PoliticaPdfController extends Controller
 
         $usedNames = [];
         foreach ($aceptaciones as $aceptacion) {
-            $firmante = $aceptacion->user;
-            if (! $firmante) {
+            if (! $aceptacion->user) {
                 continue;
             }
 
             $bytes = $this->buildFirmantePdfBytes($politica, $aceptacion);
 
-            $base = 'nda_'.Str::slug($firmante->name).'_v'.$aceptacion->version_aceptada;
-            $entryName = $base.'.pdf';
+            $entryName = $this->aceptacionFilename($politica, $aceptacion);
             $i = 1;
             while (isset($usedNames[$entryName])) {
-                $entryName = $base.'_'.(++$i).'.pdf';
+                $entryName = preg_replace('/\.pdf$/', '_'.(++$i).'.pdf', $this->aceptacionFilename($politica, $aceptacion));
             }
             $usedNames[$entryName] = true;
 
@@ -152,18 +152,38 @@ class PoliticaPdfController extends Controller
         ])->deleteFileAfterSend();
     }
 
-    private function buildFirmantePdfBytes(Politica $politica, AceptacionPolitica $aceptacion): string
+    /**
+     * Build PDF bytes for a signed acceptance (política o NDA).
+     * Used by single-download, per-política ZIP, and centro de reportes.
+     */
+    public function buildFirmantePdfBytes(Politica $politica, AceptacionPolitica $aceptacion): string
     {
         $empresa = $politica->empresa;
         $firmante = $aceptacion->user;
         $admin = $this->getAdminConFirma($politica->empresa_id);
+        $tipoLabel = $politica->es_nda ? 'Acuerdo de Confidencialidad (NDA)' : 'Politica de seguridad de la informacion';
 
-        $html = $this->buildStyle();
+        if (! is_dir(storage_path('app/temp'))) {
+            mkdir(storage_path('app/temp'), 0755, true);
+        }
+
+        $mpdf = new Mpdf([
+            'margin_top' => 20,
+            'margin_bottom' => 20,
+            'margin_left' => 20,
+            'margin_right' => 20,
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        $hasLogo = $this->attachLogoToMpdf($mpdf, $empresa);
+
+        $html = $this->buildStyle($empresa);
 
         $html .= '
         <div class="header">
+            '.$this->buildLogoHtml($hasLogo).'
             <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
-            <p>Acuerdo de Confidencialidad (NDA)</p>
+            <p>'.$tipoLabel.'</p>
         </div>
 
         <div class="meta">
@@ -189,6 +209,41 @@ class PoliticaPdfController extends Controller
             <br>Este documento es confidencial y de uso interno.
         </div>';
 
+        $titlePrefix = $politica->es_nda ? 'NDA' : 'Politica';
+        $mpdf->SetTitle($titlePrefix.' - '.($firmante?->name ?? '-').' - '.$politica->titulo);
+        $mpdf->WriteHTML($html);
+
+        return $mpdf->Output('', Destination::STRING_RETURN);
+    }
+
+    /**
+     * Build one consolidated PDF for a policy: one section per firmante,
+     * using only the most recent acceptance per user with a signature.
+     */
+    public function buildConsolidatedFirmadosPdfBytes(Politica $politica): ?string
+    {
+        $aceptaciones = AceptacionPolitica::where('politica_id', $politica->id)
+            ->whereNotNull('firma_imagen')
+            ->whereHas('user', fn ($q) => $q->firmantes())
+            ->with('user')
+            ->orderBy('fecha_aceptacion', 'desc')
+            ->get()
+            ->groupBy('user_id')
+            ->map(fn ($group) => $group->first())
+            ->values();
+
+        if ($aceptaciones->isEmpty()) {
+            return null;
+        }
+
+        $empresa = $politica->empresa;
+        $admin = $this->getAdminConFirma($politica->empresa_id);
+        $tipoLabel = $politica->es_nda ? 'Acuerdo de Confidencialidad (NDA)' : 'Politica de seguridad de la informacion';
+
+        if (! is_dir(storage_path('app/temp'))) {
+            mkdir(storage_path('app/temp'), 0755, true);
+        }
+
         $mpdf = new Mpdf([
             'margin_top' => 20,
             'margin_bottom' => 20,
@@ -197,10 +252,63 @@ class PoliticaPdfController extends Controller
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        $mpdf->SetTitle('NDA - '.($firmante?->name ?? '-').' - '.$politica->titulo);
-        $mpdf->WriteHTML($html);
+        $mpdf->SetTitle(($politica->es_nda ? 'NDA' : 'Politica').' - '.$politica->titulo.' - Firmantes');
+
+        $hasLogo = $this->attachLogoToMpdf($mpdf, $empresa);
+        $logoHtml = $this->buildLogoHtml($hasLogo);
+        $style = $this->buildStyle($empresa);
+        $first = true;
+
+        foreach ($aceptaciones as $aceptacion) {
+            $firmante = $aceptacion->user;
+
+            if (! $first) {
+                $mpdf->AddPage();
+            }
+            $first = false;
+
+            $html = $style.'
+            <div class="header">
+                '.$logoHtml.'
+                <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
+                <p>'.$tipoLabel.'</p>
+            </div>
+
+            <div class="meta">
+                <table>
+                    <tr><td class="label">Documento:</td><td class="value">'.e($politica->titulo).'</td></tr>
+                    <tr><td class="label">Version:</td><td class="value">'.e($aceptacion->version_aceptada).'</td></tr>
+                    <tr><td class="label">Firmante:</td><td class="value">'.e($firmante?->name ?? '-').'</td></tr>
+                    <tr><td class="label">DNI:</td><td class="value">'.e($firmante?->dni ?? 'N/A').'</td></tr>
+                    <tr><td class="label">Puesto:</td><td class="value">'.e($firmante?->puesto ?? 'N/A').'</td></tr>
+                    <tr><td class="label">Fecha firma:</td><td class="value">'.$aceptacion->fecha_aceptacion->format('d/m/Y H:i').'</td></tr>'
+                    .($aceptacion->fecha_expiracion ? '<tr><td class="label">Expira:</td><td class="value">'.$aceptacion->fecha_expiracion->format('d/m/Y').'</td></tr>' : '')
+                    .'<tr><td class="label">Estado:</td><td class="value">'.($aceptacion->estaVigente() ? 'Vigente' : 'Expirado').'</td></tr>
+                </table>
+            </div>
+
+            <div class="content">'.$this->renderContenido($politica, $firmante).'</div>';
+
+            $html .= $this->buildSignatureBlock($admin, $aceptacion, $empresa);
+
+            $html .= '
+            <div class="footer">
+                '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
+                <br>Este documento es confidencial y de uso interno.
+            </div>';
+
+            $mpdf->WriteHTML($html);
+        }
 
         return $mpdf->Output('', Destination::STRING_RETURN);
+    }
+
+    public function aceptacionFilename(Politica $politica, AceptacionPolitica $aceptacion): string
+    {
+        $prefix = $politica->es_nda ? 'nda' : 'politica';
+        $nombre = $aceptacion->user?->name ?? 'sin-usuario';
+
+        return $prefix.'_'.Str::slug($nombre).'_'.$politica->slug.'_v'.$aceptacion->version_aceptada.'.pdf';
     }
 
     public function downloadResumenFirmantes(Request $request, Politica $politica)
@@ -224,17 +332,22 @@ class PoliticaPdfController extends Controller
             'tempDir' => storage_path('app/temp'),
         ]);
 
+        $hasLogo = $this->attachLogoToMpdf($mpdf, $empresa);
+        $primario = $empresa?->getPdfColorPrimario() ?? '#4f46e5';
+        $secundario = $empresa?->getPdfColorSecundario() ?? '#1e1b4b';
+
         $style = '
         <style>
             body { font-family: Arial, sans-serif; font-size: 11px; color: #1a1a1a; line-height: 1.5; }
-            .header { text-align: center; border-bottom: 2px solid #4f46e5; padding-bottom: 12px; margin-bottom: 18px; }
-            .header h1 { font-size: 18px; margin: 0; color: #1e1b4b; }
+            .header { text-align: center; border-bottom: 2px solid '.$primario.'; padding-bottom: 12px; margin-bottom: 18px; }
+            .header img.brand-logo { max-height: 50px; max-width: 180px; margin-bottom: 6px; }
+            .header h1 { font-size: 18px; margin: 0; color: '.$secundario.'; }
             .header p { font-size: 11px; color: #6b7280; margin: 4px 0 0; }
             .meta { background: #f3f4f6; padding: 10px 15px; border-radius: 6px; margin-bottom: 18px; font-size: 10px; }
             .meta td { padding: 2px 0; }
             .meta .label { color: #6b7280; width: 130px; }
             .meta .value { font-weight: bold; }
-            .version-title { font-size: 13px; font-weight: bold; color: #1e1b4b; margin: 18px 0 8px; padding: 6px 10px; background: #eef2ff; border-radius: 4px; }
+            .version-title { font-size: 13px; font-weight: bold; color: '.$secundario.'; margin: 18px 0 8px; padding: 6px 10px; background: #eef2ff; border-radius: 4px; }
             .firma-row { border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px 14px; margin-bottom: 8px; }
             .firma-row table { width: 100%; }
             .firma-img { max-height: 45px; max-width: 150px; }
@@ -254,6 +367,7 @@ class PoliticaPdfController extends Controller
 
         $html .= '
         <div class="header">
+            '.$this->buildLogoHtml($hasLogo).'
             <h1>'.e($empresa?->razon_social ?? 'SecuriForm').'</h1>
             <p>Resumen de firmantes — '.e($politica->titulo).'</p>
         </div>
@@ -347,13 +461,17 @@ class PoliticaPdfController extends Controller
             ->first();
     }
 
-    private function buildStyle(): string
+    private function buildStyle(?Empresa $empresa = null): string
     {
+        $primario = $empresa?->getPdfColorPrimario() ?? '#4f46e5';
+        $secundario = $empresa?->getPdfColorSecundario() ?? '#1e1b4b';
+
         return '
         <style>
             body { font-family: Arial, sans-serif; font-size: 12px; color: #1a1a1a; line-height: 1.6; }
-            .header { text-align: center; border-bottom: 2px solid #4f46e5; padding-bottom: 15px; margin-bottom: 20px; }
-            .header h1 { font-size: 18px; margin: 0; color: #1e1b4b; }
+            .header { text-align: center; border-bottom: 2px solid '.$primario.'; padding-bottom: 15px; margin-bottom: 20px; }
+            .header img.brand-logo { max-height: 60px; max-width: 200px; margin-bottom: 8px; }
+            .header h1 { font-size: 18px; margin: 0; color: '.$secundario.'; }
             .header p { font-size: 11px; color: #6b7280; margin: 4px 0 0; }
             .meta { background: #f3f4f6; padding: 10px 15px; border-radius: 6px; margin-bottom: 20px; font-size: 11px; }
             .meta table { width: 100%; }
@@ -361,7 +479,7 @@ class PoliticaPdfController extends Controller
             .meta .label { color: #6b7280; width: 140px; }
             .meta .value { font-weight: bold; }
             .content { margin-top: 20px; }
-            .content h2 { font-size: 16px; color: #1e1b4b; }
+            .content h2 { font-size: 16px; color: '.$secundario.'; }
             .content h3 { font-size: 14px; color: #374151; }
             .content ul { padding-left: 20px; }
             .content li { margin-bottom: 4px; }
@@ -374,6 +492,28 @@ class PoliticaPdfController extends Controller
             .sig-missing { background: #fef2f2; border: 1px dashed #fca5a5; border-radius: 8px; padding: 20px; text-align: center; color: #dc2626; font-size: 11px; }
             .footer { margin-top: 30px; border-top: 1px solid #d1d5db; padding-top: 10px; font-size: 9px; color: #9ca3af; text-align: center; }
         </style>';
+    }
+
+    private function attachLogoToMpdf(Mpdf $mpdf, ?Empresa $empresa): bool
+    {
+        $logoPath = $empresa?->getPdfLogoPath();
+        if (! $logoPath) {
+            return false;
+        }
+
+        $disk = \Illuminate\Support\Facades\Storage::disk('logos');
+        if (! $disk->exists($logoPath)) {
+            return false;
+        }
+
+        $mpdf->imageVars['logo'] = $disk->get($logoPath);
+
+        return true;
+    }
+
+    private function buildLogoHtml(bool $hasLogo): string
+    {
+        return $hasLogo ? '<img src="var:logo" class="brand-logo"><br>' : '';
     }
 
     private function buildSignatureBlock(?User $admin, ?AceptacionPolitica $aceptacion, $empresa): string
@@ -426,7 +566,7 @@ class PoliticaPdfController extends Controller
     {
         $contenido = $politica->contenido;
 
-        if ($politica->es_nda) {
+        if ($politica->es_nda && $user) {
             $contenido = str_replace(
                 ['{nombre_completo}', '{dni}', '{direccion}', '{telefono}', '{puesto}'],
                 [
@@ -440,6 +580,22 @@ class PoliticaPdfController extends Controller
             );
         }
 
-        return $contenido;
+        return $this->markdownToHtml($contenido);
+    }
+
+    private function markdownToHtml(?string $contenido): string
+    {
+        if (blank($contenido)) {
+            return '';
+        }
+
+        if (preg_match('/<\s*(p|div|h[1-6]|ul|ol|table|section|article|br)\b/i', $contenido)) {
+            return $contenido;
+        }
+
+        return Str::markdown($contenido, [
+            'html_input' => 'allow',
+            'allow_unsafe_links' => false,
+        ]);
     }
 }

--- a/app/Models/Empresa.php
+++ b/app/Models/Empresa.php
@@ -13,15 +13,33 @@ class Empresa extends Model implements HasName, HasAvatar
         'ruc',
         'razon_social',
         'logo_path',
+        'logo_documentos_path',
         'color_primario',
         'color_secundario',
         'color_sidebar',
+        'pdf_color_primario',
+        'pdf_color_secundario',
         'nombre_portal',
         'direccion',
         'email',
         'telefono',
         'estado',
     ];
+
+    public function getPdfColorPrimario(): string
+    {
+        return $this->pdf_color_primario ?: '#4f46e5';
+    }
+
+    public function getPdfColorSecundario(): string
+    {
+        return $this->pdf_color_secundario ?: '#1e1b4b';
+    }
+
+    public function getPdfLogoPath(): ?string
+    {
+        return $this->logo_documentos_path ?: $this->logo_path;
+    }
 
     public function users(): HasMany
     {

--- a/database/migrations/2026_05_12_000001_add_pdf_branding_to_empresas_table.php
+++ b/database/migrations/2026_05_12_000001_add_pdf_branding_to_empresas_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('empresas', function (Blueprint $table) {
+            $table->string('logo_documentos_path')->nullable()->after('logo_path');
+            $table->string('pdf_color_primario', 7)->nullable()->after('color_sidebar');
+            $table->string('pdf_color_secundario', 7)->nullable()->after('pdf_color_primario');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('empresas', function (Blueprint $table) {
+            $table->dropColumn(['logo_documentos_path', 'pdf_color_primario', 'pdf_color_secundario']);
+        });
+    }
+};

--- a/resources/views/filament/pages/centro-reportes.blade.php
+++ b/resources/views/filament/pages/centro-reportes.blade.php
@@ -8,28 +8,57 @@
 
     <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; margin-top: 16px;">
         @foreach ($this->getReportesVisibles() as $rep)
-            <a href="{{ $rep['url'] }}"
-               style="text-decoration: none; color: inherit;
+            @php
+                $cardStyle = "text-decoration: none; color: inherit;
                       background: rgba(255,255,255,0.04);
                       border: 1px solid rgba(255,255,255,0.08);
-                      border-left: 4px solid {{ $rep['color'] }};
+                      border-left: 4px solid {$rep['color']};
                       border-radius: 12px;
                       padding: 18px 20px;
                       display: block;
-                      transition: transform 0.15s, box-shadow 0.15s;"
-               onmouseover="this.style.transform='translateY(-2px)';this.style.boxShadow='0 8px 24px rgba(0,0,0,0.2)';"
-               onmouseout="this.style.transform='';this.style.boxShadow='';">
-                <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 10px;">
-                    <div style="width: 40px; height: 40px; border-radius: 8px;
-                                background: {{ $rep['color'] }}20;
-                                display: flex; align-items: center; justify-content: center;">
-                        <x-filament::icon :icon="$rep['icon']"
-                                          style="width: 22px; height: 22px; color: {{ $rep['color'] }};" />
+                      width: 100%;
+                      text-align: left;
+                      cursor: pointer;
+                      font: inherit;
+                      transition: transform 0.15s, box-shadow 0.15s;";
+                $hoverIn = "this.style.transform='translateY(-2px)';this.style.boxShadow='0 8px 24px rgba(0,0,0,0.2)';";
+                $hoverOut = "this.style.transform='';this.style.boxShadow='';";
+            @endphp
+
+            @if (! empty($rep['action']))
+                <button type="button"
+                        wire:click="{{ $rep['action'] }}"
+                        style="{{ $cardStyle }}"
+                        onmouseover="{{ $hoverIn }}"
+                        onmouseout="{{ $hoverOut }}">
+                    <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 10px;">
+                        <div style="width: 40px; height: 40px; border-radius: 8px;
+                                    background: {{ $rep['color'] }}20;
+                                    display: flex; align-items: center; justify-content: center;">
+                            <x-filament::icon :icon="$rep['icon']"
+                                              style="width: 22px; height: 22px; color: {{ $rep['color'] }};" />
+                        </div>
+                        <div style="font-size: 15px; font-weight: 600;">{{ $rep['title'] }}</div>
                     </div>
-                    <div style="font-size: 15px; font-weight: 600;">{{ $rep['title'] }}</div>
-                </div>
-                <p style="font-size: 13px; color: #9ca3af; margin: 0; line-height: 1.5;">{{ $rep['desc'] }}</p>
-            </a>
+                    <p style="font-size: 13px; color: #9ca3af; margin: 0; line-height: 1.5;">{{ $rep['desc'] }}</p>
+                </button>
+            @else
+                <a href="{{ $rep['url'] }}"
+                   style="{{ $cardStyle }}"
+                   onmouseover="{{ $hoverIn }}"
+                   onmouseout="{{ $hoverOut }}">
+                    <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 10px;">
+                        <div style="width: 40px; height: 40px; border-radius: 8px;
+                                    background: {{ $rep['color'] }}20;
+                                    display: flex; align-items: center; justify-content: center;">
+                            <x-filament::icon :icon="$rep['icon']"
+                                              style="width: 22px; height: 22px; color: {{ $rep['color'] }};" />
+                        </div>
+                        <div style="font-size: 15px; font-weight: 600;">{{ $rep['title'] }}</div>
+                    </div>
+                    <p style="font-size: 13px; color: #9ca3af; margin: 0; line-height: 1.5;">{{ $rep['desc'] }}</p>
+                </a>
+            @endif
         @endforeach
     </div>
 </x-filament-panels::page>


### PR DESCRIPTION
## Summary

- **Empresas**: nuevos campos `logo_documentos_path`, `pdf_color_primario`, `pdf_color_secundario`. Logo del sistema y logo para documentos separados, con fallback al primero. Dos ColorPickers para personalizar PDFs.
- **PDFs**: `PoliticaPdfController` y `CentroReportes` ahora aplican logo + colores del tenant en headers, h1, h2, bordes y badges.
- **Documentos Firmados**: modulo independiente eliminado. Consolidado dentro de Centro de Reportes como accion. Salida: 1 PDF por documento con una pagina por firmante (solo la firma mas reciente por usuario). 1 politica = PDF directo; N politicas = ZIP (`NDA/` + `Politicas/`).

## Cambios

- Migracion `2026_05_12_000001_add_pdf_branding_to_empresas_table`
- `Empresa::getPdfColorPrimario/Secundario/LogoPath()` con defaults
- Nueva seccion "Personalizacion de documentos PDF" en `EmpresaForm`
- `EmpresaResource\Pages\ViewEmpresa` muestra ambos logos
- `PoliticaPdfController::buildStyle(?Empresa)` parametrizado + helpers `attachLogoToMpdf`/`buildLogoHtml`
- Nuevo `buildConsolidatedFirmadosPdfBytes(Politica)`
- `CentroReportes::descargarDocumentosFirmados()` (accion via wire:click)
- Blade `centro-reportes` soporta tarjetas con `action`
- Eliminados: `ReporteDocumentosFirmados.php` + su blade

## Test plan

- [ ] Migrar BD limpia, verificar columnas nuevas en `empresas`
- [ ] Empresa con logo de documentos custom: PDFs (politica, NDA firmante, consolidado, reporte completo) usan ese logo
- [ ] Empresa solo con logo de sistema: PDFs caen al logo del sistema
- [ ] Configurar colores primario y secundario: verificar header/h1/h2/bordes en PDFs
- [ ] Sin colores configurados: PDFs usan defaults (#4f46e5, #1e1b4b)
- [ ] Centro de Reportes: tarjeta "Documentos Firmados" dispara descarga (sin navegar)
- [ ] Empresa con 1 politica firmada: descarga 1 PDF directo
- [ ] Empresa con varias politicas firmadas: descarga ZIP con carpetas
- [ ] Usuario firmo 3 veces el mismo documento: solo aparece la firma mas reciente
- [ ] Verificar que la pagina `ReporteDocumentosFirmados` ya no aparece en navegacion ni es accesible por URL

Closes SEN-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)