### PR TITLE
feat(pdfs): branding empresa + layout compacto en todos los reportes (SEN-123)

### DIFF
--- a/app/Filament/Pages/CentroReportes.php
+++ b/app/Filament/Pages/CentroReportes.php
@@ -11,6 +11,7 @@ use App\Models\Equipo;
 use App\Models\EquipoAsignacion;
 use App\Models\Politica;
 use App\Models\Registro;
+use App\Support\PdfBranding;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
@@ -220,18 +221,14 @@ class CentroReportes extends Page
 
         $mpdf = new Mpdf([
             'format' => 'A4',
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 14,
+            'margin_right' => 14,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        $logoPath = $tenant->getPdfLogoPath();
-        $hasLogo = false;
-        if ($logoPath) {
-            $disk = \Illuminate\Support\Facades\Storage::disk('logos');
-            if ($disk->exists($logoPath)) {
-                $mpdf->imageVars['logo'] = $disk->get($logoPath);
-                $hasLogo = true;
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
         $this->buildCompleto($mpdf, $tenant, $hasLogo);
 
@@ -244,30 +241,19 @@ class CentroReportes extends Page
 
     private function buildCompleto(Mpdf $mpdf, $tenant, bool $hasLogo = false): void
     {
-        $logoHtml = $hasLogo ? '<img src="var:logo" style="height:60px;margin-bottom:8px;" /><br>' : '';
+        $logoHtml = PdfBranding::logoHtml($hasLogo, 50);
+        $colors = PdfBranding::colors($tenant);
 
-        $primario = $tenant->getPdfColorPrimario();
-        $secundario = $tenant->getPdfColorSecundario();
-
-        $style = '
+        $style = PdfBranding::reportStyle($tenant).'
         <style>
-            body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
-            h1 { color: '.$primario.'; font-size: 18px; margin-bottom: 2px; }
-            h2 { font-size: 14px; margin-top: 18px; color: '.$secundario.'; border-bottom: 2px solid '.$primario.'; padding-bottom: 4px; }
-            h3 { font-size: 12px; margin-top: 12px; color: #555; }
-            table { width: 100%; border-collapse: collapse; margin-top: 6px; }
-            th, td { border: 1px solid #ddd; padding: 4px 6px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; font-size: 9px; }
-            .cover { text-align: center; padding: 80px 20px 20px; }
-            .cover h1 { font-size: 26px; }
-            .cover .subtitle { font-size: 14px; color: #6b7280; margin-top: 16px; }
-            .cover .meta { margin-top: 60px; font-size: 11px; color: #4b5563; }
-            .stat-grid table { margin-top: 8px; }
-            .stat-grid td { text-align: center; padding: 8px 6px; background: #f9fafb; border: 1px solid #e5e7eb; }
-            .stat-number { font-size: 20px; font-weight: bold; color: '.$primario.'; }
-            .stat-label { font-size: 9px; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
-            .section { margin-top: 20px; }
-            .footer { margin-top: 30px; font-size: 9px; color: #888; }
+            .cover { text-align: center; padding: 60px 16px 16px; }
+            .cover h1 { font-size: 22px; }
+            .cover .subtitle { font-size: 12px; color: #6b7280; margin-top: 10px; }
+            .cover .meta { margin-top: 40px; font-size: 10px; color: #4b5563; }
+            .stat-grid table { margin-top: 4px; }
+            .stat-grid td { text-align: center; padding: 6px; background: #f9fafb; border: 1px solid #e5e7eb; }
+            .stat-number { font-size: 16px; font-weight: bold; color: '.$colors['primario'].'; }
+            .stat-label { font-size: 7.5px; color: #666; text-transform: uppercase; letter-spacing: 0.4px; }
         </style>';
 
         // ═══ COVER PAGE ═══

--- a/app/Filament/Pages/ReporteCapacitaciones.php
+++ b/app/Filament/Pages/ReporteCapacitaciones.php
@@ -5,6 +5,7 @@ namespace App\Filament\Pages;
 use App\Models\Capacitacion;
 use App\Models\CapacitacionAsistencia;
 use App\Models\User;
+use App\Support\PdfBranding;
 use Filament\Facades\Filament;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
@@ -66,17 +67,16 @@ class ReporteCapacitaciones extends Page implements HasForms
 
         $mpdf = new Mpdf([
             'format' => 'A4',
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 14,
+            'margin_right' => 14,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/'.$tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
-        $this->buildReportPages($mpdf, $tenant, $capacitaciones, $users);
+        $this->buildReportPages($mpdf, $tenant, $capacitaciones, $users, $hasLogo);
 
         $filename = 'reporte_capacitaciones_'.now()->format('Ymd').'.pdf';
 
@@ -85,25 +85,12 @@ class ReporteCapacitaciones extends Page implements HasForms
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReportPages(Mpdf $mpdf, $tenant, $capacitaciones, $users): void
+    private function buildReportPages(Mpdf $mpdf, $tenant, $capacitaciones, $users, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
-        }
-
-        $style = '
+        $logoHtml = PdfBranding::logoHtml($hasLogo);
+        $style = PdfBranding::reportStyle($tenant).'
         <style>
-            body { font-family: Arial, sans-serif; font-size: 10px; }
-            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
-            h2 { font-size: 13px; margin-top: 20px; color: #333; }
-            h3 { font-size: 12px; margin-top: 10px; color: #555; }
-            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
-            th, td { border: 1px solid #ddd; padding: 5px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; }
-            .summary { margin-top: 15px; padding: 10px; background: #f9fafb; border: 1px solid #e5e7eb; }
-            .cap-header { background: #f0f0ff; padding: 10px; border: 1px solid #ddd; margin-bottom: 10px; }
-            .footer { margin-top: 30px; font-size: 9px; color: #888; }
+            .cap-header { background: #f0f0ff; padding: 6px 8px; border: 1px solid #e5e7eb; margin-bottom: 6px; border-radius: 3px; }
         </style>';
 
         // ═══ PAGE 1: Resumen general ═══

--- a/app/Filament/Pages/ReporteChecklists.php
+++ b/app/Filament/Pages/ReporteChecklists.php
@@ -5,6 +5,7 @@ namespace App\Filament\Pages;
 use App\Models\ChecklistEjecucion;
 use App\Models\ChecklistPlantilla;
 use App\Models\Equipo;
+use App\Support\PdfBranding;
 use Filament\Facades\Filament;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
@@ -81,17 +82,16 @@ class ReporteChecklists extends Page implements HasForms
 
         $mpdf = new Mpdf([
             'format' => 'A4',
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 14,
+            'margin_right' => 14,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/'.$tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
-        $this->buildReport($mpdf, $tenant, $plantillas, $ejecuciones);
+        $this->buildReport($mpdf, $tenant, $plantillas, $ejecuciones, $hasLogo);
 
         $filename = 'reporte_checklists_'.now()->format('Ymd').'.pdf';
 
@@ -100,31 +100,14 @@ class ReporteChecklists extends Page implements HasForms
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReport(Mpdf $mpdf, $tenant, $plantillas, $ejecuciones): void
+    private function buildReport(Mpdf $mpdf, $tenant, $plantillas, $ejecuciones, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
-        }
-
-        $style = '
+        $logoHtml = PdfBranding::logoHtml($hasLogo);
+        $style = PdfBranding::reportStyle($tenant).'
         <style>
-            body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
-            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
-            h2 { font-size: 13px; margin-top: 20px; color: #333; }
-            h3 { font-size: 11px; margin-top: 12px; color: #555; }
-            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
-            th, td { border: 1px solid #ddd; padding: 5px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; }
-            .summary { margin-top: 12px; padding: 10px; background: #f9fafb; border: 1px solid #e5e7eb; }
-            .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 9px; font-weight: bold; }
-            .badge-ok { background: #d1fae5; color: #059669; }
-            .badge-warn { background: #fef3c7; color: #d97706; }
-            .badge-bad { background: #fee2e2; color: #dc2626; }
-            .ficha { border: 1px solid #ddd; border-radius: 4px; margin-top: 12px; }
-            .ficha-header { background: #f0f0ff; padding: 8px 10px; border-bottom: 1px solid #ddd; }
-            .ficha-body { padding: 10px; }
-            .footer { margin-top: 30px; font-size: 9px; color: #888; }
+            .badge-ok { background: #d1fae5; color: #047857; }
+            .badge-warn { background: #fef3c7; color: #b45309; }
+            .badge-bad { background: #fee2e2; color: #b91c1c; }
         </style>';
 
         $totalEjec = $ejecuciones->count();

--- a/app/Filament/Pages/ReporteDestruccionActivos.php
+++ b/app/Filament/Pages/ReporteDestruccionActivos.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages;
 
 use App\Models\Equipo;
 use App\Models\Registro;
+use App\Support\PdfBranding;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -122,17 +123,16 @@ class ReporteDestruccionActivos extends Page implements HasForms
 
         $mpdf = new Mpdf([
             'format' => 'A4-L',
+            'margin_top' => 10,
+            'margin_bottom' => 10,
+            'margin_left' => 10,
+            'margin_right' => 10,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/'.$tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
-        $this->buildReport($mpdf, $tenant, $registros, $equipos);
+        $this->buildReport($mpdf, $tenant, $registros, $equipos, $hasLogo);
 
         $filename = 'destruccion_activos_F13_'.now()->format('Ymd').'.pdf';
 
@@ -141,48 +141,32 @@ class ReporteDestruccionActivos extends Page implements HasForms
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReport(Mpdf $mpdf, $tenant, $registros, $equipos): void
+    private function buildReport(Mpdf $mpdf, $tenant, $registros, $equipos, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:36px;margin-bottom:4px;" /><br>';
-        }
-
-        $style = '
+        $logoHtml = PdfBranding::logoHtml($hasLogo, 32);
+        $colors = PdfBranding::colors($tenant);
+        $style = PdfBranding::reportStyle($tenant).'
         <style>
-            body { font-family: Arial, sans-serif; font-size: 8px; color: #333; }
-            h1 { color: #4338ca; font-size: 14px; margin-bottom: 0; }
-            h2 { font-size: 11px; margin-top: 8px; margin-bottom: 2px; color: #333; }
-            h3 { font-size: 9px; margin-top: 6px; margin-bottom: 2px; color: #555; }
-            table { width: 100%; border-collapse: collapse; margin-top: 4px; }
-            th, td { border: 1px solid #ddd; padding: 2px 4px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; font-size: 7px; }
-            .summary { margin-top: 6px; padding: 4px 8px; background: #f9fafb; border: 1px solid #e5e7eb; font-size: 8px; }
-            .stat-grid { margin-top: 6px; }
+            body { font-size: 8px; }
+            h1 { font-size: 12px; }
+            h2 { font-size: 10px; margin-top: 7px; }
+            h3 { font-size: 9px; margin-top: 5px; }
+            th, td { padding: 2px 4px; }
+            th { font-size: 7.5px; }
+            .stat-grid { margin-top: 5px; }
             .stat-grid table { margin-top: 2px; }
             .stat-grid td { text-align: center; padding: 4px 6px; }
-            .stat-number { font-size: 16px; font-weight: bold; color: #4338ca; }
+            .stat-number { font-size: 14px; font-weight: bold; color: '.$colors['primario'].'; }
             .stat-label { font-size: 7px; color: #666; text-transform: uppercase; letter-spacing: 0.3px; }
-            .badge { display: inline-block; padding: 1px 4px; border-radius: 6px; font-size: 7px; font-weight: bold; }
-            .badge-danger { background: #fee2e2; color: #dc2626; }
-            .badge-warning { background: #fef3c7; color: #d97706; }
+            .badge-danger { background: #fee2e2; color: #b91c1c; }
+            .badge-warning { background: #fef3c7; color: #b45309; }
             .badge-info { background: #dbeafe; color: #1d4ed8; }
-            .badge-success { background: #d1fae5; color: #059669; }
+            .badge-success { background: #d1fae5; color: #047857; }
             .badge-purple { background: #ede9fe; color: #7c3aed; }
-            .ficha { border: 1px solid #ddd; border-radius: 4px; margin-top: 8px; }
-            .ficha-header { background: #fef2f2; padding: 6px 10px; border-bottom: 1px solid #ddd; }
-            .ficha-body { padding: 8px 10px; }
-            .field { margin-bottom: 6px; }
-            .field-label { font-size: 7px; font-weight: bold; color: #666; text-transform: uppercase; letter-spacing: 0.3px; margin-bottom: 1px; }
-            .field-value { font-size: 9px; color: #222; }
-            .field-value-long { font-size: 9px; color: #222; padding: 4px 6px; background: #fafafa; border: 1px solid #eee; border-radius: 3px; }
-            .grid-2 { display: flex; gap: 0; }
-            .grid-2 > div { width: 50%; }
-            .grid-3 { display: flex; gap: 0; }
-            .grid-3 > div { width: 33.33%; }
-            .equipo-box { background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 4px; padding: 6px 8px; margin-top: 6px; font-size: 8px; }
+            .ficha-header { background: #fef2f2; padding: 5px 8px; }
+            .field-value-long { font-size: 8px; padding: 3px 5px; }
+            .equipo-box { background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 3px; padding: 5px 7px; margin-top: 5px; font-size: 7.5px; }
             .equipo-box strong { color: #0369a1; }
-            .footer { margin-top: 10px; font-size: 7px; color: #888; }
         </style>';
 
         // ═══ Statistics ═══

--- a/app/Filament/Pages/ReporteIncidencias.php
+++ b/app/Filament/Pages/ReporteIncidencias.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Models\Registro;
+use App\Support\PdfBranding;
 use Filament\Facades\Filament;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
@@ -67,17 +68,16 @@ class ReporteIncidencias extends Page implements HasForms
 
         $mpdf = new Mpdf([
             'format' => 'A4',
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 14,
+            'margin_right' => 14,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/'.$tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
-        $this->buildReportPages($mpdf, $tenant, $incidencias, $resoluciones);
+        $this->buildReportPages($mpdf, $tenant, $incidencias, $resoluciones, $hasLogo);
 
         $filename = 'reporte_incidencias_'.now()->format('Ymd').'.pdf';
 
@@ -86,40 +86,10 @@ class ReporteIncidencias extends Page implements HasForms
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReportPages(Mpdf $mpdf, $tenant, $incidencias, $resoluciones): void
+    private function buildReportPages(Mpdf $mpdf, $tenant, $incidencias, $resoluciones, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
-        }
-
-        $style = '
-        <style>
-            body { font-family: Arial, sans-serif; font-size: 10px; color: #333; }
-            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
-            h2 { font-size: 13px; margin-top: 20px; color: #333; }
-            h3 { font-size: 12px; margin-top: 10px; color: #555; }
-            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
-            th, td { border: 1px solid #ddd; padding: 5px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; }
-            .summary { margin-top: 15px; padding: 10px; background: #f9fafb; border: 1px solid #e5e7eb; }
-            .ficha { border: 1px solid #ddd; border-radius: 4px; margin-top: 12px; }
-            .ficha-header { background: #f0f0ff; padding: 10px 12px; border-bottom: 1px solid #ddd; }
-            .ficha-body { padding: 12px; }
-            .field { margin-bottom: 10px; }
-            .field-label { font-size: 9px; font-weight: bold; color: #666; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 2px; }
-            .field-value { font-size: 11px; color: #222; }
-            .field-value-long { font-size: 10px; color: #222; padding: 6px 8px; background: #fafafa; border: 1px solid #eee; border-radius: 3px; }
-            .grid-2 { display: flex; gap: 0; }
-            .grid-2 > div { width: 50%; }
-            .grid-3 { display: flex; gap: 0; }
-            .grid-3 > div { width: 33.33%; }
-            .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 9px; font-weight: bold; }
-            .badge-alta { background: #fee2e2; color: #dc2626; }
-            .badge-media { background: #fef3c7; color: #d97706; }
-            .badge-baja { background: #d1fae5; color: #059669; }
-            .footer { margin-top: 30px; font-size: 9px; color: #888; }
-        </style>';
+        $logoHtml = PdfBranding::logoHtml($hasLogo);
+        $style = PdfBranding::reportStyle($tenant);
 
         // ═══ PAGE 1: Resumen general ═══
         $incTable = '';

--- a/app/Filament/Pages/ReporteInventarioSoportes.php
+++ b/app/Filament/Pages/ReporteInventarioSoportes.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Models\Equipo;
+use App\Support\PdfBranding;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -148,74 +149,55 @@ class ReporteInventarioSoportes extends Page implements HasForms
 
         $mpdf = new Mpdf([
             'format' => 'A4-L',
+            'margin_top' => 10,
+            'margin_bottom' => 10,
+            'margin_left' => 10,
+            'margin_right' => 10,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/' . $tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
-        $this->buildReport($mpdf, $tenant, $equipos);
+        $this->buildReport($mpdf, $tenant, $equipos, $hasLogo);
 
         return response()->streamDownload(function () use ($mpdf) {
             echo $mpdf->Output('', 'S');
         }, 'inventario_soportes_F07_' . now()->format('Ymd') . '.pdf', ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReport(Mpdf $mpdf, $tenant, $equipos): void
+    private function buildReport(Mpdf $mpdf, $tenant, $equipos, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/' . $tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:36px;margin-bottom:4px;" /><br>';
-        }
-
-        $style = '
+        $logoHtml = PdfBranding::logoHtml($hasLogo, 32);
+        $colors = PdfBranding::colors($tenant);
+        $style = PdfBranding::reportStyle($tenant).'
         <style>
-            body { font-family: Arial, sans-serif; font-size: 8px; color: #333; }
-            h1 { color: #4338ca; font-size: 14px; margin-bottom: 0; }
-            h2 { font-size: 11px; margin-top: 8px; margin-bottom: 2px; color: #333; }
-            h3 { font-size: 9px; margin-top: 6px; margin-bottom: 2px; color: #555; }
-            table { width: 100%; border-collapse: collapse; margin-top: 4px; }
-            th, td { border: 1px solid #ddd; padding: 2px 4px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; font-size: 7px; }
-            .stat-grid { margin-top: 6px; }
+            body { font-size: 8px; }
+            h1 { font-size: 12px; }
+            h2 { font-size: 10px; margin-top: 7px; }
+            h3 { font-size: 9px; margin-top: 5px; }
+            th, td { padding: 2px 4px; }
+            th { font-size: 7.5px; }
+            .stat-grid { margin-top: 5px; }
             .stat-grid table { margin-top: 2px; }
             .stat-grid td { text-align: center; padding: 4px 6px; }
-            .stat-number { font-size: 16px; font-weight: bold; color: #4338ca; }
+            .stat-number { font-size: 14px; font-weight: bold; color: '.$colors['primario'].'; }
             .stat-label { font-size: 7px; color: #666; text-transform: uppercase; letter-spacing: 0.3px; }
-            .summary { margin-top: 6px; padding: 4px 8px; background: #f9fafb; border: 1px solid #e5e7eb; font-size: 8px; }
-            .badge { display: inline-block; padding: 1px 4px; border-radius: 6px; font-size: 7px; font-weight: bold; }
             .badge-tec { background: #dbeafe; color: #1d4ed8; }
-            .badge-notec { background: #fef3c7; color: #d97706; }
-            .badge-activo { background: #d1fae5; color: #059669; }
-            .badge-mant { background: #fef3c7; color: #d97706; }
+            .badge-notec { background: #fef3c7; color: #b45309; }
+            .badge-activo { background: #d1fae5; color: #047857; }
+            .badge-mant { background: #fef3c7; color: #b45309; }
             .badge-obs { background: #fed7aa; color: #c2410c; }
-            .badge-baja { background: #fee2e2; color: #dc2626; }
-            .badge-publico { background: #e0e7ff; color: #4338ca; }
+            .badge-baja { background: #fee2e2; color: #b91c1c; }
+            .badge-publico { background: '.$colors['primario'].'22; color: '.$colors['primario'].'; }
             .badge-interno { background: #dbeafe; color: #1d4ed8; }
-            .badge-confidencial { background: #fef3c7; color: #d97706; }
-            .badge-sensible { background: #fee2e2; color: #dc2626; }
-            .ficha { border: 1px solid #ddd; border-radius: 4px; margin-top: 8px; }
-            .ficha-header { background: #eef2ff; padding: 6px 10px; border-bottom: 1px solid #ddd; }
-            .ficha-body { padding: 8px 10px; }
-            .field { margin-bottom: 6px; }
-            .field-label { font-size: 7px; font-weight: bold; color: #666; text-transform: uppercase; letter-spacing: 0.3px; margin-bottom: 1px; }
-            .field-value { font-size: 9px; color: #222; }
-            .field-value-long { font-size: 9px; color: #222; padding: 4px 6px; background: #fafafa; border: 1px solid #eee; border-radius: 3px; }
-            .grid-2 { display: flex; gap: 0; }
-            .grid-2 > div { width: 50%; }
-            .grid-3 { display: flex; gap: 0; }
-            .grid-3 > div { width: 33.33%; }
+            .badge-confidencial { background: #fef3c7; color: #b45309; }
+            .badge-sensible { background: #fee2e2; color: #b91c1c; }
             .grid-4 { display: flex; gap: 0; }
             .grid-4 > div { width: 25%; }
-            .spec-box { background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 4px; padding: 6px 8px; margin-top: 6px; font-size: 8px; }
+            .spec-box { background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 3px; padding: 5px 7px; margin-top: 5px; font-size: 7.5px; }
             .spec-box strong { color: #0369a1; }
-            .asign-box { background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 4px; padding: 6px 8px; margin-top: 6px; font-size: 8px; }
+            .asign-box { background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 3px; padding: 5px 7px; margin-top: 5px; font-size: 7.5px; }
             .asign-box strong { color: #15803d; }
-            .footer { margin-top: 10px; font-size: 7px; color: #888; }
         </style>';
 
         $total = $equipos->count();

--- a/app/Filament/Pages/ReporteMovimientosSoportes.php
+++ b/app/Filament/Pages/ReporteMovimientosSoportes.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Models\EquipoAsignacion;
+use App\Support\PdfBranding;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -91,17 +92,16 @@ class ReporteMovimientosSoportes extends Page implements HasForms
 
         $mpdf = new Mpdf([
             'format' => 'A4-L',
+            'margin_top' => 10,
+            'margin_bottom' => 10,
+            'margin_left' => 10,
+            'margin_right' => 10,
             'tempDir' => storage_path('app/temp'),
         ]);
 
-        if ($tenant->logo_path) {
-            $logoPath = storage_path('app/'.$tenant->logo_path);
-            if (file_exists($logoPath)) {
-                $mpdf->imageVars['logo'] = file_get_contents($logoPath);
-            }
-        }
+        $hasLogo = PdfBranding::attachLogo($mpdf, $tenant);
 
-        $this->buildReport($mpdf, $tenant, $movimientos);
+        $this->buildReport($mpdf, $tenant, $movimientos, $hasLogo);
 
         $filename = 'movimientos_soportes_F08_'.now()->format('Ymd').'.pdf';
 
@@ -110,24 +110,10 @@ class ReporteMovimientosSoportes extends Page implements HasForms
         }, $filename, ['Content-Type' => 'application/pdf']);
     }
 
-    private function buildReport(Mpdf $mpdf, $tenant, $movimientos): void
+    private function buildReport(Mpdf $mpdf, $tenant, $movimientos, bool $hasLogo = false): void
     {
-        $logoHtml = '';
-        if ($tenant->logo_path && file_exists(storage_path('app/'.$tenant->logo_path))) {
-            $logoHtml = '<img src="var:logo" style="height:50px;margin-bottom:8px;" /><br>';
-        }
-
-        $style = '
-        <style>
-            body { font-family: Arial, sans-serif; font-size: 9px; color: #333; }
-            h1 { color: #4338ca; font-size: 16px; margin-bottom: 2px; }
-            h2 { font-size: 13px; margin-top: 15px; color: #333; }
-            table { width: 100%; border-collapse: collapse; margin-top: 8px; }
-            th, td { border: 1px solid #ddd; padding: 4px 6px; text-align: left; }
-            th { background: #f3f4f6; font-weight: bold; font-size: 8px; }
-            .summary { margin-top: 12px; padding: 8px 12px; background: #f9fafb; border: 1px solid #e5e7eb; font-size: 10px; }
-            .footer { margin-top: 20px; font-size: 8px; color: #888; }
-        </style>';
+        $logoHtml = PdfBranding::logoHtml($hasLogo, 36);
+        $style = PdfBranding::reportStyle($tenant);
 
         $tipoCount = $movimientos->groupBy('tipo')->map->count();
 

--- a/app/Http/Controllers/PoliticaPdfController.php
+++ b/app/Http/Controllers/PoliticaPdfController.php
@@ -6,6 +6,7 @@ use App\Models\AceptacionPolitica;
 use App\Models\Empresa;
 use App\Models\Politica;
 use App\Models\User;
+use App\Support\PdfBranding;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Mpdf\Mpdf;
@@ -27,10 +28,10 @@ class PoliticaPdfController extends Controller
         $admin = $this->getAdminConFirma($politica->empresa_id);
 
         $mpdf = new Mpdf([
-            'margin_top' => 20,
-            'margin_bottom' => 20,
-            'margin_left' => 20,
-            'margin_right' => 20,
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 16,
+            'margin_right' => 16,
             'tempDir' => storage_path('app/temp'),
         ]);
 
@@ -168,10 +169,10 @@ class PoliticaPdfController extends Controller
         }
 
         $mpdf = new Mpdf([
-            'margin_top' => 20,
-            'margin_bottom' => 20,
-            'margin_left' => 20,
-            'margin_right' => 20,
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 16,
+            'margin_right' => 16,
             'tempDir' => storage_path('app/temp'),
         ]);
 
@@ -245,10 +246,10 @@ class PoliticaPdfController extends Controller
         }
 
         $mpdf = new Mpdf([
-            'margin_top' => 20,
-            'margin_bottom' => 20,
-            'margin_left' => 20,
-            'margin_right' => 20,
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 16,
+            'margin_right' => 16,
             'tempDir' => storage_path('app/temp'),
         ]);
 
@@ -325,41 +326,40 @@ class PoliticaPdfController extends Controller
         $porVersion = $aceptaciones->groupBy('version_aceptada');
 
         $mpdf = new Mpdf([
-            'margin_top' => 20,
-            'margin_bottom' => 20,
-            'margin_left' => 20,
-            'margin_right' => 20,
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 16,
+            'margin_right' => 16,
             'tempDir' => storage_path('app/temp'),
         ]);
 
         $hasLogo = $this->attachLogoToMpdf($mpdf, $empresa);
-        $primario = $empresa?->getPdfColorPrimario() ?? '#4f46e5';
-        $secundario = $empresa?->getPdfColorSecundario() ?? '#1e1b4b';
+        $c = PdfBranding::colors($empresa);
 
         $style = '
         <style>
-            body { font-family: Arial, sans-serif; font-size: 11px; color: #1a1a1a; line-height: 1.5; }
-            .header { text-align: center; border-bottom: 2px solid '.$primario.'; padding-bottom: 12px; margin-bottom: 18px; }
-            .header img.brand-logo { max-height: 50px; max-width: 180px; margin-bottom: 6px; }
-            .header h1 { font-size: 18px; margin: 0; color: '.$secundario.'; }
-            .header p { font-size: 11px; color: #6b7280; margin: 4px 0 0; }
-            .meta { background: #f3f4f6; padding: 10px 15px; border-radius: 6px; margin-bottom: 18px; font-size: 10px; }
-            .meta td { padding: 2px 0; }
-            .meta .label { color: #6b7280; width: 130px; }
+            body { font-family: Arial, sans-serif; font-size: 9.5px; color: #1f2937; line-height: 1.35; }
+            .header { text-align: center; border-bottom: 1.5px solid '.$c['primario'].'; padding-bottom: 8px; margin-bottom: 12px; }
+            .header img.brand-logo { max-height: 40px; max-width: 160px; margin-bottom: 4px; }
+            .header h1 { font-size: 14px; margin: 0; color: '.$c['secundario'].'; }
+            .header p { font-size: 9.5px; color: #6b7280; margin: 2px 0 0; }
+            .meta { background: #f3f4f6; padding: 6px 10px; border-radius: 4px; margin-bottom: 10px; font-size: 9px; }
+            .meta td { padding: 1px 0; }
+            .meta .label { color: #6b7280; width: 120px; }
             .meta .value { font-weight: bold; }
-            .version-title { font-size: 13px; font-weight: bold; color: '.$secundario.'; margin: 18px 0 8px; padding: 6px 10px; background: #eef2ff; border-radius: 4px; }
-            .firma-row { border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px 14px; margin-bottom: 8px; }
+            .version-title { font-size: 11px; font-weight: bold; color: '.$c['secundario'].'; margin: 10px 0 4px; padding: 4px 8px; background: '.$c['primario'].'14; border-radius: 3px; }
+            .firma-row { border: 1px solid #e5e7eb; border-radius: 4px; padding: 6px 10px; margin-bottom: 5px; }
             .firma-row table { width: 100%; }
-            .firma-img { max-height: 45px; max-width: 150px; }
-            .firma-name { font-weight: bold; font-size: 11px; }
-            .firma-detail { font-size: 9px; color: #6b7280; }
-            .summary { font-size: 10px; color: #6b7280; margin-bottom: 12px; }
-            .admin-box { border: 1px solid #d1d5db; border-radius: 8px; padding: 12px; margin-bottom: 18px; text-align: center; }
-            .admin-box h4 { font-size: 10px; color: #6b7280; text-transform: uppercase; margin: 0 0 8px; }
-            .admin-img { max-height: 60px; max-width: 200px; margin-bottom: 6px; }
-            .admin-name { font-weight: bold; font-size: 12px; border-top: 1px solid #1a1a1a; padding-top: 5px; margin-top: 5px; display: inline-block; min-width: 160px; }
-            .admin-detail { font-size: 9px; color: #6b7280; }
-            .footer { margin-top: 20px; border-top: 1px solid #d1d5db; padding-top: 8px; font-size: 8px; color: #9ca3af; text-align: center; }
+            .firma-img { max-height: 38px; max-width: 130px; }
+            .firma-name { font-weight: bold; font-size: 10px; }
+            .firma-detail { font-size: 8px; color: #6b7280; }
+            .summary { font-size: 9px; color: #6b7280; margin-bottom: 8px; }
+            .admin-box { border: 1px solid #d1d5db; border-radius: 5px; padding: 8px; margin-bottom: 12px; text-align: center; }
+            .admin-box h4 { font-size: 8.5px; color: #6b7280; text-transform: uppercase; margin: 0 0 5px; letter-spacing: 0.3px; }
+            .admin-img { max-height: 50px; max-width: 170px; margin-bottom: 4px; }
+            .admin-name { font-weight: bold; font-size: 10.5px; border-top: 1px solid #1f2937; padding-top: 3px; margin-top: 3px; display: inline-block; min-width: 140px; }
+            .admin-detail { font-size: 8px; color: #6b7280; }
+            .footer { margin-top: 12px; border-top: 1px solid #e5e7eb; padding-top: 4px; font-size: 7px; color: #9ca3af; text-align: center; }
         </style>';
 
         // ═══ PAGE 1: Header + Admin signature + Summary table ═══
@@ -463,52 +463,39 @@ class PoliticaPdfController extends Controller
 
     private function buildStyle(?Empresa $empresa = null): string
     {
-        $primario = $empresa?->getPdfColorPrimario() ?? '#4f46e5';
-        $secundario = $empresa?->getPdfColorSecundario() ?? '#1e1b4b';
+        $c = PdfBranding::colors($empresa);
 
         return '
         <style>
-            body { font-family: Arial, sans-serif; font-size: 12px; color: #1a1a1a; line-height: 1.6; }
-            .header { text-align: center; border-bottom: 2px solid '.$primario.'; padding-bottom: 15px; margin-bottom: 20px; }
-            .header img.brand-logo { max-height: 60px; max-width: 200px; margin-bottom: 8px; }
-            .header h1 { font-size: 18px; margin: 0; color: '.$secundario.'; }
-            .header p { font-size: 11px; color: #6b7280; margin: 4px 0 0; }
-            .meta { background: #f3f4f6; padding: 10px 15px; border-radius: 6px; margin-bottom: 20px; font-size: 11px; }
+            body { font-family: Arial, sans-serif; font-size: 10.5px; color: #1f2937; line-height: 1.4; }
+            .header { text-align: center; border-bottom: 1.5px solid '.$c['primario'].'; padding-bottom: 8px; margin-bottom: 12px; }
+            .header img.brand-logo { max-height: 45px; max-width: 160px; margin-bottom: 4px; }
+            .header h1 { font-size: 15px; margin: 0; color: '.$c['secundario'].'; }
+            .header p { font-size: 9.5px; color: #6b7280; margin: 2px 0 0; }
+            .meta { background: #f3f4f6; padding: 6px 10px; border-radius: 4px; margin-bottom: 12px; font-size: 9.5px; }
             .meta table { width: 100%; }
-            .meta td { padding: 3px 0; }
-            .meta .label { color: #6b7280; width: 140px; }
+            .meta td { padding: 1px 0; }
+            .meta .label { color: #6b7280; width: 130px; }
             .meta .value { font-weight: bold; }
-            .content { margin-top: 20px; }
-            .content h2 { font-size: 16px; color: '.$secundario.'; }
-            .content h3 { font-size: 14px; color: #374151; }
-            .content ul { padding-left: 20px; }
-            .content li { margin-bottom: 4px; }
-            .signatures { margin-top: 40px; }
-            .sig-box { border: 1px solid #d1d5db; border-radius: 8px; padding: 20px; margin-bottom: 15px; text-align: center; }
-            .sig-box h4 { font-size: 12px; color: #6b7280; text-transform: uppercase; margin: 0 0 15px; }
-            .sig-img { max-width: 280px; max-height: 120px; margin: 0 auto 10px; display: block; }
-            .sig-name { font-weight: bold; font-size: 13px; border-top: 1px solid #1a1a1a; padding-top: 8px; margin-top: 8px; display: inline-block; min-width: 200px; }
-            .sig-detail { font-size: 10px; color: #6b7280; }
-            .sig-missing { background: #fef2f2; border: 1px dashed #fca5a5; border-radius: 8px; padding: 20px; text-align: center; color: #dc2626; font-size: 11px; }
-            .footer { margin-top: 30px; border-top: 1px solid #d1d5db; padding-top: 10px; font-size: 9px; color: #9ca3af; text-align: center; }
+            .content { margin-top: 12px; }
+            .content h2 { font-size: 13px; color: '.$c['secundario'].'; margin: 10px 0 4px; }
+            .content h3 { font-size: 11.5px; color: #374151; margin: 8px 0 3px; }
+            .content ul { padding-left: 16px; }
+            .content li { margin-bottom: 2px; }
+            .signatures { margin-top: 20px; }
+            .sig-box { border: 1px solid #d1d5db; border-radius: 5px; padding: 10px; margin-bottom: 8px; text-align: center; }
+            .sig-box h4 { font-size: 9.5px; color: #6b7280; text-transform: uppercase; margin: 0 0 8px; letter-spacing: 0.3px; }
+            .sig-img { max-width: 200px; max-height: 80px; margin: 0 auto 4px; display: block; }
+            .sig-name { font-weight: bold; font-size: 10.5px; border-top: 1px solid #1f2937; padding-top: 4px; margin-top: 4px; display: inline-block; min-width: 160px; }
+            .sig-detail { font-size: 8.5px; color: #6b7280; }
+            .sig-missing { background: #fef2f2; border: 1px dashed #fca5a5; border-radius: 5px; padding: 10px; text-align: center; color: #b91c1c; font-size: 9.5px; }
+            .footer { margin-top: 16px; border-top: 1px solid #e5e7eb; padding-top: 5px; font-size: 7.5px; color: #9ca3af; text-align: center; }
         </style>';
     }
 
     private function attachLogoToMpdf(Mpdf $mpdf, ?Empresa $empresa): bool
     {
-        $logoPath = $empresa?->getPdfLogoPath();
-        if (! $logoPath) {
-            return false;
-        }
-
-        $disk = \Illuminate\Support\Facades\Storage::disk('logos');
-        if (! $disk->exists($logoPath)) {
-            return false;
-        }
-
-        $mpdf->imageVars['logo'] = $disk->get($logoPath);
-
-        return true;
+        return PdfBranding::attachLogo($mpdf, $empresa);
     }
 
     private function buildLogoHtml(bool $hasLogo): string

--- a/app/Services/PdfExportService.php
+++ b/app/Services/PdfExportService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\TipoFormato;
 use App\Models\Registro;
+use App\Support\PdfBranding;
 use Mpdf\Mpdf;
 
 class PdfExportService
@@ -14,14 +15,18 @@ class PdfExportService
         $empresa = $registro->empresa;
         $creador = $registro->creador;
 
-        $html = self::buildRegistroHtml($registro, $tipo, $empresa, $creador);
-
         $mpdf = new Mpdf([
             'format' => 'A4',
-            'margin_top' => 20,
-            'margin_bottom' => 20,
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 14,
+            'margin_right' => 14,
             'tempDir' => storage_path('app/temp'),
         ]);
+
+        $hasLogo = PdfBranding::attachLogo($mpdf, $empresa);
+
+        $html = self::buildRegistroHtml($registro, $tipo, $empresa, $creador, $hasLogo);
 
         $mpdf->SetTitle("{$tipo->prefix()}-{$registro->numero_registro}");
         $mpdf->WriteHTML($html);
@@ -33,7 +38,7 @@ class PdfExportService
         return $path;
     }
 
-    private static function buildRegistroHtml(Registro $registro, TipoFormato $tipo, $empresa, $creador): string
+    private static function buildRegistroHtml(Registro $registro, TipoFormato $tipo, $empresa, $creador, bool $hasLogo = false): string
     {
         $datos = $registro->datos ?? [];
         $fieldsHtml = '';
@@ -41,29 +46,20 @@ class PdfExportService
         foreach ($datos as $key => $value) {
             $label = ucfirst(str_replace('_', ' ', $key));
             $displayValue = is_array($value) ? implode(', ', $value) : ($value === true ? 'Sí' : ($value === false ? 'No' : ($value ?? '-')));
-            $fieldsHtml .= "<tr><td style='font-weight:bold;padding:6px;border:1px solid #ddd;width:35%;'>{$label}</td><td style='padding:6px;border:1px solid #ddd;'>{$displayValue}</td></tr>";
+            $fieldsHtml .= "<tr><td style='font-weight:bold;'>{$label}</td><td>{$displayValue}</td></tr>";
         }
 
-        return "
-        <style>
-            body { font-family: Arial, sans-serif; font-size: 11px; color: #333; }
-            h1 { color: #4338ca; font-size: 18px; margin-bottom: 5px; }
-            h2 { color: #555; font-size: 14px; margin-top: 20px; }
-            .header { border-bottom: 2px solid #4338ca; padding-bottom: 10px; margin-bottom: 20px; }
-            .meta { color: #666; font-size: 10px; }
-            table { width: 100%; border-collapse: collapse; margin-top: 10px; }
-            .footer { margin-top: 30px; border-top: 1px solid #ddd; padding-top: 10px; font-size: 9px; color: #888; }
-        </style>
-        <div class='header'>
-            <h1>{$empresa->razon_social}</h1>
-            <p class='meta'>RUC: {$empresa->ruc} | {$empresa->direccion}</p>
-        </div>
+        $style = PdfBranding::reportStyle($empresa);
+        $logoHtml = PdfBranding::logoHtml($hasLogo, 42);
+
+        return $style."
+        {$logoHtml}
+        <h1>{$empresa->razon_social}</h1>
+        <p class='meta'>RUC: {$empresa->ruc} | {$empresa->direccion}</p>
         <h2>{$tipo->label()}</h2>
         <p><strong>N° Registro:</strong> {$registro->numero_registro} &nbsp;&nbsp; <strong>Política:</strong> {$tipo->psc()}</p>
         <table>{$fieldsHtml}</table>
-        <div class='footer'>
-            <p>Creado por: " . ($creador?->name ?? 'N/A') . " | Fecha: {$registro->created_at->format('d/m/Y H:i')} | Exportado: " . now()->format('d/m/Y H:i') . "</p>
-        </div>";
+        <p class='footer'>Creado por: ".($creador?->name ?? 'N/A')." | Fecha: {$registro->created_at->format('d/m/Y H:i')} | Exportado: ".now()->format('d/m/Y H:i').'</p>';
     }
 
     public static function exportTicket($ticket): string
@@ -79,20 +75,28 @@ class PdfExportService
             }
             $tipoLabel = $msg->tipo === 'interno' ? ' <em>(nota interna)</em>' : '';
             $mensajesHtml .= "
-            <div style='margin-bottom:10px;padding:8px;border:1px solid #ddd;border-radius:4px;'>
-                <p style='font-weight:bold;margin:0;'>{$msg->autor->name}{$tipoLabel}</p>
-                <p style='font-size:9px;color:#888;margin:2px 0;'>{$msg->created_at->format('d/m/Y H:i')}</p>
-                <p style='margin:5px 0 0;'>{$msg->contenido}</p>
+            <div style='margin-bottom:6px;padding:5px 8px;border:1px solid #e5e7eb;border-radius:3px;'>
+                <p style='font-weight:bold;margin:0;font-size:9.5px;'>{$msg->autor->name}{$tipoLabel}</p>
+                <p style='font-size:8px;color:#9ca3af;margin:1px 0;'>{$msg->created_at->format('d/m/Y H:i')}</p>
+                <p style='margin:3px 0 0;font-size:9px;'>{$msg->contenido}</p>
             </div>";
         }
 
-        $html = "
-        <style>
-            body { font-family: Arial, sans-serif; font-size: 11px; color: #333; }
-            h1 { color: #4338ca; font-size: 16px; }
-            h2 { font-size: 13px; margin-top: 20px; }
-            .meta { color: #666; font-size: 10px; }
-        </style>
+        $mpdf = new Mpdf([
+            'format' => 'A4',
+            'margin_top' => 14,
+            'margin_bottom' => 14,
+            'margin_left' => 14,
+            'margin_right' => 14,
+            'tempDir' => storage_path('app/temp'),
+        ]);
+
+        $hasLogo = PdfBranding::attachLogo($mpdf, $empresa);
+        $style = PdfBranding::reportStyle($empresa);
+        $logoHtml = PdfBranding::logoHtml($hasLogo, 38);
+
+        $html = $style."
+        {$logoHtml}
         <h1>Ticket: {$ticket->numero_ticket}</h1>
         <p class='meta'>{$empresa->razon_social} | RUC: {$empresa->ruc}</p>
         <p><strong>Asunto:</strong> {$ticket->asunto}</p>
@@ -102,10 +106,6 @@ class PdfExportService
         <h2>Conversación</h2>
         {$mensajesHtml}";
 
-        $mpdf = new Mpdf([
-            'format' => 'A4',
-            'tempDir' => storage_path('app/temp'),
-        ]);
         $mpdf->WriteHTML($html);
 
         $path = storage_path("app/temp/ticket_{$ticket->numero_ticket}.pdf");

--- a/app/Support/PdfBranding.php
+++ b/app/Support/PdfBranding.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Empresa;
+use Illuminate\Support\Facades\Storage;
+use Mpdf\Mpdf;
+
+class PdfBranding
+{
+    public const DEFAULT_PRIMARIO = '#4f46e5';
+
+    public const DEFAULT_SECUNDARIO = '#1e1b4b';
+
+    public static function colors(?Empresa $empresa): array
+    {
+        return [
+            'primario' => $empresa?->getPdfColorPrimario() ?? self::DEFAULT_PRIMARIO,
+            'secundario' => $empresa?->getPdfColorSecundario() ?? self::DEFAULT_SECUNDARIO,
+        ];
+    }
+
+    public static function attachLogo(Mpdf $mpdf, ?Empresa $empresa): bool
+    {
+        $logoPath = $empresa?->getPdfLogoPath();
+        if (! $logoPath) {
+            return false;
+        }
+
+        $disk = Storage::disk('logos');
+        if (! $disk->exists($logoPath)) {
+            return false;
+        }
+
+        $mpdf->imageVars['logo'] = $disk->get($logoPath);
+
+        return true;
+    }
+
+    public static function logoHtml(bool $hasLogo, int $height = 42): string
+    {
+        return $hasLogo
+            ? '<img src="var:logo" style="height:'.$height.'px;margin-bottom:4px;" /><br>'
+            : '';
+    }
+
+    /**
+     * Compact base style for tabular PDF reports.
+     */
+    public static function reportStyle(?Empresa $empresa): string
+    {
+        $c = self::colors($empresa);
+
+        return '
+        <style>
+            body { font-family: Arial, sans-serif; font-size: 9px; color: #1f2937; line-height: 1.35; }
+            h1 { color: '.$c['primario'].'; font-size: 14px; margin: 0 0 2px; }
+            h2 { color: '.$c['secundario'].'; font-size: 11px; margin: 12px 0 4px; border-bottom: 1px solid '.$c['primario'].'; padding-bottom: 2px; }
+            h3 { font-size: 10px; margin: 8px 0 3px; color: #374151; }
+            p { margin: 2px 0; }
+            table { width: 100%; border-collapse: collapse; margin-top: 4px; }
+            th, td { border: 1px solid #e5e7eb; padding: 3px 5px; text-align: left; vertical-align: top; }
+            th { background: #f3f4f6; font-weight: bold; font-size: 8.5px; color: '.$c['secundario'].'; }
+            .meta { color: #6b7280; font-size: 8.5px; margin: 0 0 6px; }
+            .summary { padding: 6px 8px; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 3px; margin: 6px 0; font-size: 9px; }
+            .footer { margin-top: 14px; font-size: 7.5px; color: #9ca3af; border-top: 1px solid #e5e7eb; padding-top: 4px; }
+            .badge { display: inline-block; padding: 1px 6px; border-radius: 8px; font-size: 8px; font-weight: bold; }
+            .badge-alta { background: #fee2e2; color: #b91c1c; }
+            .badge-media { background: #fef3c7; color: #b45309; }
+            .badge-baja { background: #d1fae5; color: #047857; }
+            .ficha { border: 1px solid #e5e7eb; border-radius: 4px; margin-top: 8px; }
+            .ficha-header { background: '.$c['primario'].'14; padding: 6px 10px; border-bottom: 1px solid #e5e7eb; }
+            .ficha-header h2 { border: none; margin: 0; padding: 0; color: '.$c['secundario'].'; }
+            .ficha-body { padding: 8px 10px; }
+            .field { margin-bottom: 5px; }
+            .field-label { font-size: 7.5px; font-weight: bold; color: #6b7280; text-transform: uppercase; letter-spacing: 0.3px; margin-bottom: 1px; }
+            .field-value { font-size: 9px; color: #111827; }
+            .field-value-long { font-size: 8.5px; color: #111827; padding: 4px 6px; background: #fafafa; border: 1px solid #f3f4f6; border-radius: 2px; }
+            .grid-2, .grid-3 { display: flex; }
+            .grid-2 > div { width: 50%; }
+            .grid-3 > div { width: 33.33%; }
+        </style>';
+    }
+}


### PR DESCRIPTION
## Summary

- Nuevo helper `App\Support\PdfBranding` centraliza logo + colores + estilo base de PDFs.
- Todos los generadores de PDF (7 reportes + politicas/NDA + exports puntuales) ahora aplican el logo y los colores configurados por la empresa.
- Layout compactado (~30% mas denso): font-size 9-10px, margenes 14mm, paddings reducidos.

## Cambios

- `app/Support/PdfBranding.php` (nuevo)
- `CentroReportes` y los 6 `Reporte*` pages usan el helper
- `PoliticaPdfController.buildStyle()` delega colores y compacta tipografia
- `PdfExportService` (registro + ticket) usa branding
- Logo cargado correctamente desde el disco `logos` (antes leia mal `storage/app/<path>`)

## Test plan

- [ ] Empresa con logo + colores custom: todos los PDFs muestran logo y colores aplicados
- [ ] Empresa sin colores: PDFs usan defaults `#4f46e5` / `#1e1b4b`
- [ ] Empresa solo con logo de sistema (no logo documentos): aparece logo de sistema en PDFs
- [ ] Reporte Incidencias / Capacitaciones / Checklists / Destruccion / Inventario / Movimientos: descargar y comparar densidad
- [ ] Reporte completo del Centro de Reportes: cover, h1, h2 y stats con color primario
- [ ] Documentos Firmados (NDA / Politica) consolidado y resumen firmantes: tipografia compacta y branding
- [ ] Export individual de registro y de ticket: aplica branding

Closes SEN-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)