### PR TITLE
fix(registros): tipo_formato undefined al crear registro (SEN-124)

### DIFF
--- a/app/Filament/Resources/Registros/Pages/CreateRegistro.php
+++ b/app/Filament/Resources/Registros/Pages/CreateRegistro.php
@@ -29,7 +29,16 @@ class CreateRegistro extends CreateRecord
 
     protected function mutateFormDataBeforeCreate(array $data): array
     {
-        $tipo = TipoFormato::from($data['tipo_formato']);
+        if (empty($data['tipo_formato']) || ! ($tipo = TipoFormato::tryFrom($data['tipo_formato']))) {
+            \Filament\Notifications\Notification::make()
+                ->title('Selecciona un formato')
+                ->body('Debes elegir un tipo de formato antes de guardar el registro.')
+                ->warning()
+                ->send();
+
+            $this->halt();
+        }
+
         $tenant = Filament::getTenant();
 
         $data['empresa_id'] = $tenant->id;

--- a/app/Filament/Resources/Registros/Schemas/RegistroForm.php
+++ b/app/Filament/Resources/Registros/Schemas/RegistroForm.php
@@ -42,6 +42,7 @@ class RegistroForm
                     ->live()
                     ->searchable()
                     ->disabled(fn (string $operation): bool => $operation === 'edit')
+                    ->dehydrated()
                     ->hidden(fn (string $operation): bool => $operation === 'create')
                     ->columnSpanFull(),
 


### PR DESCRIPTION
## Summary

Fix `ErrorException: Undefined array key \"tipo_formato\"` al crear un Registro.

## Causa

`Select::make('tipo_formato')` esta `hidden()` durante create (se usa un catalogo visual con `wire:click=\"\$set('data.tipo_formato', ...)\"`). Filament no dehidrata los campos hidden por defecto, asi que el valor no llegaba a `\$data` en `mutateFormDataBeforeCreate`.

## Fix

- `RegistroForm`: agrega `->dehydrated()` al Select `tipo_formato`.
- `CreateRegistro`: guard defensivo. Si falta o es invalido, notifica al usuario y `halt()` en vez de lanzar excepcion.

## Test plan

- [ ] Entrar a /admin/{empresa}/registros/create y seleccionar un formato del catalogo → el registro se crea correctamente con tipo_formato + numero_registro auto
- [ ] Intentar crear sin seleccionar formato → notificacion warning, no excepcion
- [ ] Editar un registro existente → tipo_formato visible, deshabilitado y persiste

Closes SEN-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)