### PR TITLE
feat(reportes): firma asistentes + anti-orfandad firmas PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env
 .env.backup
 .env.production
+docker-compose.override.yml
 .phpactor.json
 .phpunit.result.cache
 /.fleet

--- a/app/Filament/Pages/ReporteCapacitaciones.php
+++ b/app/Filament/Pages/ReporteCapacitaciones.php
@@ -179,6 +179,16 @@ class ReporteCapacitaciones extends Page implements HasForms
                 $confirmador = $a->confirmador?->name ?? '—';
                 $fechaConf = $a->fecha_confirmacion?->format('d/m/Y H:i') ?? '—';
 
+                $firmaCell = '<span style="color:#9ca3af;">—</span>';
+                if ($a->asistio) {
+                    $firma = $a->user?->firma_guardada;
+                    if ($firma && str_starts_with($firma, 'data:image')) {
+                        $firmaCell = '<img src="'.$firma.'" style="max-height:38px;max-width:120px;" />';
+                    } else {
+                        $firmaCell = '<span style="color:#dc2626;font-size:9px;">Sin firma</span>';
+                    }
+                }
+
                 $asistenciaRows .= '<tr>
                     <td>'.e($a->user?->name ?? '—').'</td>
                     <td>'.e($a->user?->dni ?? '—').'</td>
@@ -186,6 +196,7 @@ class ReporteCapacitaciones extends Page implements HasForms
                     <td style="color:'.$estadoColor.'; font-weight:bold;">'.$estado.'</td>
                     <td>'.e($confirmador).'</td>
                     <td>'.$fechaConf.'</td>
+                    <td style="text-align:center;">'.$firmaCell.'</td>
                 </tr>';
             }
 
@@ -212,7 +223,7 @@ class ReporteCapacitaciones extends Page implements HasForms
 
                 <h3>Lista de asistencia</h3>
                 <table>
-                    <tr><th>Nombre</th><th>DNI</th><th>Puesto</th><th>Asistio</th><th>Confirmado por</th><th>Fecha confirmacion</th></tr>
+                    <tr><th>Nombre</th><th>DNI</th><th>Puesto</th><th>Asistio</th><th>Confirmado por</th><th>Fecha confirmacion</th><th style="width:130px;">Firma</th></tr>
                     {$asistenciaRows}
                 </table>
 

--- a/app/Filament/Pages/ReporteChecklists.php
+++ b/app/Filament/Pages/ReporteChecklists.php
@@ -143,6 +143,57 @@ class ReporteChecklists extends Page implements HasForms
             </tr>';
         }
 
+        // Detalle por ejecucion — flujo continuo, sin AddPage
+        $detalleHtml = '';
+        if ($ejecuciones->isNotEmpty()) {
+            $detalleHtml .= '<h2 style="margin-top:24px;">Detalle de ejecuciones</h2>';
+        }
+        foreach ($ejecuciones as $e) {
+            $cumple = $e->itemsCumplen();
+            $total = $e->totalItems();
+            $pct = $total > 0 ? round($cumple / $total * 100) : 0;
+            $estClass = $pct >= 80 ? 'badge-ok' : ($pct >= 50 ? 'badge-warn' : 'badge-bad');
+
+            $itemsRows = '';
+            foreach (($e->resultados ?? []) as $idx => $r) {
+                $cumpleVal = ! empty($r['cumple']);
+                $itemsRows .= '<tr>
+                    <td style="text-align:center;width:30px;">'.($idx + 1).'</td>
+                    <td>'.e($r['item'] ?? $r['nombre'] ?? '-').'</td>
+                    <td style="text-align:center;width:60px;">'.($cumpleVal ? '<span class="badge badge-ok">Si</span>' : '<span class="badge badge-bad">No</span>').'</td>
+                    <td>'.e($r['observacion'] ?? $r['observaciones'] ?? '').'</td>
+                </tr>';
+            }
+
+            $detalleHtml .= '
+                <div class="ficha" style="margin-top:14px;page-break-inside:avoid;">
+                    <div class="ficha-header">
+                        <h3 style="margin:0;">'.e($e->plantilla?->nombre ?? '-').' — '.$e->fecha_ejecucion->format('d/m/Y H:i').'</h3>
+                    </div>
+                    <div class="ficha-body">
+                        <table style="border:none;">
+                            <tr style="border:none;">
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Equipo:</strong> '.e($e->equipo?->codigo_interno ?? '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Marca/Modelo:</strong> '.e(trim(($e->equipo?->marca ?? '').' '.($e->equipo?->modelo ?? '')) ?: '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>S/N:</strong> '.e($e->equipo?->numero_serie ?? '-').'</td>
+                            </tr>
+                            <tr style="border:none;">
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Ejecutor:</strong> '.e($e->ejecutor?->name ?? '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Estado:</strong> '.e($e->estado ?? '-').'</td>
+                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Score:</strong> <span class="badge '.$estClass.'">'.$cumple.'/'.$total.' ('.$pct.'%)</span></td>
+                            </tr>
+                        </table>
+
+                        <table style="margin-top:8px;">
+                            <tr><th style="width:30px;">#</th><th>Item</th><th style="width:60px;">Cumple</th><th>Observaciones</th></tr>
+                            '.($itemsRows ?: '<tr><td colspan="4" style="text-align:center;color:#999;">Sin items</td></tr>').'
+                        </table>
+                        '.(! empty($e->observaciones_generales) ? '
+                        <p style="margin-top:8px;padding:6px 8px;background:#fafafa;border:1px solid #eee;"><strong>Observaciones:</strong> '.nl2br(e($e->observaciones_generales)).'</p>' : '').'
+                    </div>
+                </div>';
+        }
+
         $mpdf->WriteHTML($style.'
             '.$logoHtml.'
             <h1>'.e($tenant->razon_social).'</h1>
@@ -176,68 +227,10 @@ class ReporteChecklists extends Page implements HasForms
                 '.($ejecRows ?: '<tr><td colspan="7" style="text-align:center;color:#999;">Sin ejecuciones</td></tr>').'
             </table>
 
+            '.$detalleHtml.'
+
             <p class="footer">
                 Generado: '.now()->format('d/m/Y H:i').' | '.e(auth()->user()->name).' | SecuriForm
             </p>');
-
-        // Detalle por ejecucion
-        foreach ($ejecuciones as $e) {
-            $mpdf->AddPage();
-
-            $cumple = $e->itemsCumplen();
-            $total = $e->totalItems();
-            $pct = $total > 0 ? round($cumple / $total * 100) : 0;
-            $estClass = $pct >= 80 ? 'badge-ok' : ($pct >= 50 ? 'badge-warn' : 'badge-bad');
-
-            $itemsRows = '';
-            foreach (($e->resultados ?? []) as $idx => $r) {
-                $cumpleVal = ! empty($r['cumple']);
-                $itemsRows .= '<tr>
-                    <td style="text-align:center;width:30px;">'.($idx + 1).'</td>
-                    <td>'.e($r['item'] ?? $r['nombre'] ?? '-').'</td>
-                    <td style="text-align:center;width:60px;">'.($cumpleVal ? '<span class="badge badge-ok">Si</span>' : '<span class="badge badge-bad">No</span>').'</td>
-                    <td>'.e($r['observacion'] ?? $r['observaciones'] ?? '').'</td>
-                </tr>';
-            }
-
-            $mpdf->WriteHTML($style.'
-                '.$logoHtml.'
-                <h1>'.e($tenant->razon_social).'</h1>
-                <p style="color:#666;">RUC: '.e($tenant->ruc).'</p>
-
-                <div class="ficha">
-                    <div class="ficha-header">
-                        <h2 style="margin:0;">Ejecucion de Checklist</h2>
-                        <p style="margin:4px 0 0; color:#666;">'.e($e->plantilla?->nombre ?? '-').' — '.$e->fecha_ejecucion->format('d/m/Y H:i').'</p>
-                    </div>
-                    <div class="ficha-body">
-                        <table style="border:none;">
-                            <tr style="border:none;">
-                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Equipo:</strong> '.e($e->equipo?->codigo_interno ?? '-').'</td>
-                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Marca/Modelo:</strong> '.e(trim(($e->equipo?->marca ?? '').' '.($e->equipo?->modelo ?? '')) ?: '-').'</td>
-                                <td style="border:none;padding:2px 16px 2px 0;"><strong>S/N:</strong> '.e($e->equipo?->numero_serie ?? '-').'</td>
-                            </tr>
-                            <tr style="border:none;">
-                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Ejecutor:</strong> '.e($e->ejecutor?->name ?? '-').'</td>
-                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Estado:</strong> '.e($e->estado ?? '-').'</td>
-                                <td style="border:none;padding:2px 16px 2px 0;"><strong>Score:</strong> <span class="badge '.$estClass.'">'.$cumple.'/'.$total.' ('.$pct.'%)</span></td>
-                            </tr>
-                        </table>
-
-                        <h3>Items verificados</h3>
-                        <table>
-                            <tr><th style="width:30px;">#</th><th>Item</th><th style="width:60px;">Cumple</th><th>Observaciones</th></tr>
-                            '.($itemsRows ?: '<tr><td colspan="4" style="text-align:center;color:#999;">Sin items</td></tr>').'
-                        </table>
-                        '.(! empty($e->observaciones_generales) ? '
-                        <h3>Observaciones generales</h3>
-                        <p style="padding:6px 8px;background:#fafafa;border:1px solid #eee;">'.nl2br(e($e->observaciones_generales)).'</p>' : '').'
-                    </div>
-                </div>
-
-                <p class="footer">
-                    Generado: '.now()->format('d/m/Y H:i').' | SecuriForm
-                </p>');
-        }
     }
 }

--- a/app/Http/Controllers/PoliticaPdfController.php
+++ b/app/Http/Controllers/PoliticaPdfController.php
@@ -61,16 +61,9 @@ class PoliticaPdfController extends Controller
 
         <div class="content">'.$this->renderContenido($politica, $user).'</div>';
 
-        $html .= $this->buildSignatureBlock($admin, $aceptacion, $empresa);
-
-        $html .= '
-        <div class="footer">
-            '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
-            <br>Este documento es confidencial y de uso interno.
-        </div>';
-
         $mpdf->SetTitle($politica->titulo.' v'.$politica->version);
         $mpdf->WriteHTML($html);
+        $this->writeSignaturesAndFooter($mpdf, $admin, $aceptacion, $empresa, $politica);
 
         $filename = 'politica_'.$politica->slug.'_v'.$politica->version.'.pdf';
         $path = storage_path('app/temp/'.$filename);
@@ -202,17 +195,10 @@ class PoliticaPdfController extends Controller
 
         <div class="content">'.$this->renderContenido($politica, $firmante).'</div>';
 
-        $html .= $this->buildSignatureBlock($admin, $aceptacion, $empresa);
-
-        $html .= '
-        <div class="footer">
-            '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
-            <br>Este documento es confidencial y de uso interno.
-        </div>';
-
         $titlePrefix = $politica->es_nda ? 'NDA' : 'Politica';
         $mpdf->SetTitle($titlePrefix.' - '.($firmante?->name ?? '-').' - '.$politica->titulo);
         $mpdf->WriteHTML($html);
+        $this->writeSignaturesAndFooter($mpdf, $admin, $aceptacion, $empresa, $politica);
 
         return $mpdf->Output('', Destination::STRING_RETURN);
     }
@@ -290,15 +276,8 @@ class PoliticaPdfController extends Controller
 
             <div class="content">'.$this->renderContenido($politica, $firmante).'</div>';
 
-            $html .= $this->buildSignatureBlock($admin, $aceptacion, $empresa);
-
-            $html .= '
-            <div class="footer">
-                '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
-                <br>Este documento es confidencial y de uso interno.
-            </div>';
-
             $mpdf->WriteHTML($html);
+            $this->writeSignaturesAndFooter($mpdf, $admin, $aceptacion, $empresa, $politica);
         }
 
         return $mpdf->Output('', Destination::STRING_RETURN);
@@ -503,9 +482,46 @@ class PoliticaPdfController extends Controller
         return $hasLogo ? '<img src="var:logo" class="brand-logo"><br>' : '';
     }
 
-    private function buildSignatureBlock(?User $admin, ?AceptacionPolitica $aceptacion, $empresa): string
+    /**
+     * Write signature block + footer ensuring signatures never appear alone
+     * on a page. Forces AddPage if remaining vertical space is insufficient.
+     */
+    private function writeSignaturesAndFooter(Mpdf $mpdf, ?User $admin, ?AceptacionPolitica $aceptacion, $empresa, ?Politica $politica): void
     {
-        $html = '<div class="signatures"><table width="100%" cellpadding="0" cellspacing="0"><tr>';
+        $signaturesHtml = $this->buildSignatureBlock($admin, $aceptacion, $empresa, $politica);
+
+        $footerHtml = '
+        <div class="footer">
+            '.e($empresa?->razon_social ?? '').' &mdash; Generado el '.now()->format('d/m/Y H:i').'
+            <br>Este documento es confidencial y de uso interno.
+        </div>';
+
+        // Reserve ~130mm: anchor (~14) + signatures box (~95) + footer (~12) + margin (~9)
+        $minSpaceMm = 130;
+        $pageHeight = $mpdf->h ?? 297;
+        $bottomMargin = $mpdf->bMargin ?? 14;
+        $usableBottom = $pageHeight - $bottomMargin;
+        $remaining = $usableBottom - $mpdf->y;
+
+        if ($remaining < $minSpaceMm) {
+            $mpdf->AddPage();
+        }
+
+        $mpdf->WriteHTML($signaturesHtml.$footerHtml);
+    }
+
+    private function buildSignatureBlock(?User $admin, ?AceptacionPolitica $aceptacion, $empresa, ?Politica $politica = null): string
+    {
+        $anchor = '';
+        if ($politica) {
+            $tipo = $politica->es_nda ? 'NDA' : 'Politica';
+            $firmanteNombre = $aceptacion?->user?->name ?? ($aceptacion?->firma_nombre ?? '-');
+            $anchor = '<div style="margin-top:18px;padding:6px 10px;background:#f3f4f6;border-left:3px solid #6b7280;font-size:9px;color:#374151;">
+                <strong>Firmas del documento:</strong> '.$tipo.' &laquo; '.e($politica->titulo).' &raquo; v'.e($politica->version).' &mdash; Firmante: '.e($firmanteNombre).'
+            </div>';
+        }
+
+        $html = $anchor.'<div class="signatures" style="page-break-inside:avoid;"><table width="100%" cellpadding="0" cellspacing="0"><tr>';
 
         // Admin / Gerente General — left 50%
         $html .= '<td width="48%" valign="top">';

--- a/docs/INVENTARIO_APP.md
+++ b/docs/INVENTARIO_APP.md
@@ -1,0 +1,245 @@
+# Inventario funcional — SecuriForm
+
+> Estado actual de la aplicación: módulos, funcionalidades, gestiones y artefactos técnicos.
+> Generado: 2026-05-11. Rama: `feature/sen-120-reportes-quitar-filtro-fecha-descarga-zip-de-ndas-firmados`.
+
+---
+
+## 1. Visión general
+
+SecuriForm es una aplicación web **Laravel 11 + Filament 3 multiempresa (multi-tenant)** que cubre:
+
+- **Gestión de formatos de seguridad de la información** (13 formatos PSC).
+- **Helpdesk centralizado** de tickets transversal a todas las empresas.
+- **Gestión de activos** (equipos, asignaciones, movimientos, backups).
+- **Cumplimiento normativo** (políticas, NDAs firmados, capacitaciones obligatorias).
+- **Reportería operativa** con exportación a Excel/PDF y descarga ZIP de NDAs firmados.
+
+El panel admin de Filament expone navegación agrupada en: **General · Soporte · Reportes · Activos · Seguridad · Capacitaciones · Administración**.
+
+---
+
+## 2. Módulos funcionales
+
+### 2.1. Administración (multi-tenant)
+
+| Funcionalidad | Recurso/Página | Notas |
+|---|---|---|
+| Gestión de empresas (tenants) | `EmpresaResource` | CRUD + branding (logo, colores) por empresa. Relation managers: usuarios y registros. |
+| Gestión de usuarios | `UserResource` | Asignación a empresa, roles (spatie/permission), datos personales. |
+| Plantillas de email | `EmailTemplateResource` | Edición de plantillas transaccionales. |
+| Registro público de empresa | `Auth/RegisterEmpresa` | Self-onboarding de nueva empresa. |
+| Perfil de usuario | `Auth/EditProfile`, `MiPerfil` | Datos personales + firma manuscrita. |
+| Selección de empresa (super admin) | `select-empresa` (ruta) + middleware `RedirectSuperAdminToSelectEmpresa` | Acceso cross-tenant para super admin. |
+| Branding por tenant | Middleware `ApplyTenantBranding` | Aplica logo/colores de la empresa activa. |
+
+**Roles definidos** (vía `RolePermissionSeeder`): `super_admin`, `admin_empresa`, `usuario`, `agente_helpdesk`, `solo_lectura`.
+
+---
+
+### 2.2. Seguridad — formatos PSC y políticas
+
+| Funcionalidad | Recurso/Página | Notas |
+|---|---|---|
+| Registros de los 13 formatos | `RegistroResource` | F01–F13 (AUD, BD, PRES, DS, PA, AS, INV, IS, INC, RES, REC, BAK, DEST). Campos dinámicos vía `FormatoFieldsService`. Numeración auto por empresa/formato/año (`RegistroNumberService`). |
+| Catálogo de políticas/NDAs | `PoliticaResource` | Versionado (`PoliticaVersion`), archivo PDF, firma admin, marcador de obligatoriedad, vigencia de aceptación. |
+| Aceptación de políticas (usuario final) | `AceptarPoliticas` | Flujo obligatorio gateado por middleware `EnsurePoliciesAccepted`. |
+| Wiki de políticas | `WikiPoliticas` | Vista de consulta para todo el personal. |
+| Completar datos NDA | `CompletarDatosNda` | Captura de datos faltantes previo a firma. |
+| Firmantes NDA | `ViewNdaFirmantes` (página dentro de PoliticaResource) | Listado y descarga ZIP de NDAs firmados. |
+| Generación PDF de política | `PoliticaPdfController` (ruta `/politicas/{politica}/pdf`) | Render PDF con mPDF. |
+| Enums | `TipoFormato` | Define los 13 tipos de formato. |
+
+---
+
+### 2.3. Activos
+
+| Funcionalidad | Recurso/Página | Notas |
+|---|---|---|
+| Inventario de equipos | `EquipoResource` | CRUD con campos extendidos de activos. |
+| Asignaciones y movimientos | Modelos `EquipoAsignacion` (+ tabla `ticket_equipo`) | Tracking de movimientos por equipo. Relación a tickets. |
+| Plantillas de checklist | `ChecklistPlantillaResource` | Definición de checklists reutilizables. |
+| Ejecución de checklists | `EjecutarChecklist` (página) + modelo `ChecklistEjecucion` | Llenado operativo por usuario. |
+| Programación de backups | `BackupProgramacionResource` | Calendario de respaldos por activo/sistema. |
+| Ejecuciones de backup | Modelo `BackupEjecucion` | Bitácora de corridas. |
+| Alarmas de backup | Comando `CheckBackupAlarms` | Job programable para alertar incumplimientos. |
+
+---
+
+### 2.4. Soporte (helpdesk)
+
+| Funcionalidad | Recurso/Página | Notas |
+|---|---|---|
+| Tickets | `TicketResource` | CRUD con numeración auto (`TicketNumberService`). |
+| Mensajes del ticket | Modelo `TicketMensaje` | Hilo de conversación. |
+| Adjuntos | Modelo `TicketAdjunto` + ruta `/tickets/adjuntos/{adjunto}` | Descarga segura de archivos. |
+| Relación con equipos | Tabla `ticket_equipo` | Vincula ticket a uno o más activos. |
+| Panel del agente | `PanelAgente` (página) | Vista operativa cross-tenant para agentes de helpdesk. |
+
+---
+
+### 2.5. Capacitaciones
+
+| Funcionalidad | Recurso/Página | Notas |
+|---|---|---|
+| Catálogo de capacitaciones | `CapacitacionResource` | Modalidades vía enum `ModalidadCapacitacion`. |
+| Asistencia | Modelo `CapacitacionAsistencia` | Registro de participantes. |
+| Vista de usuario | `MisCapacitaciones` (página) | Capacitaciones asignadas al usuario logueado. |
+
+---
+
+### 2.6. Reportes
+
+Centro de reportes y reportes individuales (los individuales ya no aparecen en sidebar, según commits recientes; quedan accesibles desde el centro).
+
+| Página | Contenido |
+|---|---|
+| `CentroReportes` | Hub central. Descarga ZIP de NDAs firmados. |
+| `ReporteIncidencias` | Formatos F09/F10 (incidencias y resolución). |
+| `ReporteCapacitaciones` | Cumplimiento de capacitaciones. |
+| `ReporteMovimientosSoportes` | Formato F08 (ingreso y salida de soportes). |
+| `ReporteDestruccionActivos` | Formato F13 (destrucción de activos). |
+| `ReporteInventarioSoportes` | Formato F07 (inventario de soportes). |
+| `ReporteChecklists` | Ejecuciones de checklists. |
+| `PanelCumplimiento` | Vista agregada de cumplimiento normativo. |
+
+Exportación: `ExcelExportService` (PhpSpreadsheet) y `PdfExportService` (mPDF).
+
+---
+
+### 2.7. Dashboards y widgets
+
+| Widget | Función |
+|---|---|
+| `Dashboard` (página) | Página principal del panel. |
+| `DashboardStats` | KPIs generales. |
+| `LatestRegistros` | Últimos registros creados. |
+| `QuickAccessFormatos` | Accesos rápidos a los 13 formatos. |
+| `RegistrosPorTipoChart` | Gráfico distribución por tipo. |
+| `TicketsTendenciaChart` | Tendencia de tickets. |
+| `ChecklistsVencidos` | Alerta de checklists pendientes. |
+| `MiEstado` | Estado del usuario actual. |
+| `UsuarioDashboard` | Dashboard contextual para rol usuario. |
+| `PoliticasCumplimiento` | Estado de aceptación de políticas. |
+| `PersonalOverview` | Vista resumen de personal. |
+
+---
+
+## 3. Servicios transversales (`app/Services/`)
+
+| Servicio | Responsabilidad |
+|---|---|
+| `AuditService` | Escritura inmutable a `audit_logs`. |
+| `RegistroNumberService` | Genera correlativo `[PREFIJO]-[AÑO]-[SEC]` por empresa/formato/año. |
+| `TicketNumberService` | Genera correlativo de ticket por empresa. |
+| `FormatoFieldsService` | Define campos dinámicos por tipo de formato (F01–F13). |
+| `ExcelExportService` | Exportación XLSX (PhpSpreadsheet). |
+| `PdfExportService` | Exportación PDF (mPDF). |
+
+---
+
+## 4. Infraestructura de aplicación
+
+### 4.1. Middleware custom
+
+| Middleware | Función |
+|---|---|
+| `ApplyTenantBranding` | Inyecta branding (logo/colores) del tenant activo. |
+| `EnsurePoliciesAccepted` | Bloquea acceso hasta que el usuario acepte políticas obligatorias vigentes. |
+| `RedirectSuperAdminToSelectEmpresa` | Fuerza al super admin a elegir tenant antes de operar. |
+| `SecurityHeaders` | Headers HTTP de seguridad (CSP, etc.). |
+| `BlockStoragePhpExecution` | Impide ejecución de PHP servido desde `storage/`. |
+
+### 4.2. Email
+
+- Mailable único `SecuriformMail` parametrizado por `EmailTemplate`.
+- Job `SendEmailJob` para envío asíncrono.
+- Modelo `NotificacionEmail` como bitácora.
+- MailHog en desarrollo (`http://localhost:8025`).
+
+### 4.3. Auditoría
+
+- Modelo `AuditLog` + `AuditService` para registro inmutable de acciones.
+
+### 4.4. Comandos Artisan
+
+| Comando | Uso |
+|---|---|
+| `CheckBackupAlarms` | Verifica programaciones vencidas y dispara alertas. |
+| `EmpresaSetupCommand` | Setup inicial de una empresa (datos base, plantillas, etc.). |
+
+### 4.5. Seeders relevantes
+
+`EmpresaSeeder`, `UserSeeder`, `RolePermissionSeeder`, `EmailTemplateSeeder`, `BackupEmailTemplatesSeeder`, `ChecklistPlantillaSeeder`, `PoliticaSeeder`, `EmpresaSetupSeeder`, `DemoDataSeeder`, `ProductionSeeder`.
+
+---
+
+## 5. Esquema de base de datos (tablas principales)
+
+| Dominio | Tablas |
+|---|---|
+| Tenants y usuarios | `empresas`, `users`, `model_has_roles`, `model_has_permissions`, `roles`, `permissions` |
+| Formatos PSC | `registros`, `secuencias_registro` |
+| Helpdesk | `tickets`, `ticket_mensajes`, `ticket_adjuntos`, `ticket_equipo`, `secuencias_ticket` |
+| Activos | `equipos`, `equipo_asignaciones` |
+| Backups | `backup_programaciones`, `backup_ejecuciones` |
+| Políticas / NDAs | `politicas`, `politica_versiones`, `aceptaciones_politica` |
+| Checklists | `checklist_plantillas`, `checklist_ejecuciones` |
+| Capacitaciones | `capacitaciones`, `capacitacion_asistencias` |
+| Email / auditoría | `email_templates`, `notificaciones_email`, `audit_logs` |
+| Laravel core | `cache`, `jobs`, `migrations` |
+
+---
+
+## 6. Rutas web públicas/operativas
+
+```
+GET  /                            Landing
+GET  /docs                        Índice de docs
+GET  /docs/{role}                 Docs por rol (super-admin, admin-empresa, usuario, agente-helpdesk, solo-lectura)
+GET  /select-empresa              Selector de empresa (super admin)
+GET  /tickets/adjuntos/{adjunto}  Descarga adjunto de ticket
+GET  /logos/{path}                Logo de tenant
+GET  /politicas/{politica}/pdf    PDF de política / NDA
+/admin/*                          Panel Filament (multi-tenant)
+```
+
+> No existe `routes/api.php` activo — toda la operación es Livewire/Filament server-side.
+
+---
+
+## 7. Stack y entorno
+
+| Capa | Tecnología |
+|---|---|
+| Backend | Laravel 11 + PHP 8.2 |
+| Admin UI | Filament 3 (Livewire 3, Alpine.js, Tailwind) |
+| BD | MariaDB 10.11 |
+| Cache/Sesiones/Cola | Redis 7 |
+| PDF | mPDF 8 |
+| Excel | PhpSpreadsheet 1.x |
+| Permisos | spatie/laravel-permission |
+| Multi-tenancy | Filament tenancy nativo (tenant = `Empresa`) |
+| Dev | Docker (PHP/Apache, MariaDB, Redis, MailHog, phpMyAdmin) |
+| CI | (pendiente) |
+| Tests | Pest/PHPUnit |
+
+---
+
+## 8. Brechas / lo que NO existe aún
+
+- `app/Policies/` vacío — autorización depende de roles spatie + gates Filament; no hay policies por modelo.
+- `app/Notifications/` vacío — notificaciones solo vía `SecuriformMail`.
+- `routes/api.php` ausente — no hay API REST pública.
+- Sin `app/Actions/`.
+- Solo 2 enums (`TipoFormato`, `ModalidadCapacitacion`); estados de ticket/registro siguen como strings en BD.
+- Solo 2 comandos artisan custom; sin scheduler explícito documentado.
+
+---
+
+## 9. Referencias rápidas
+
+- Stack y reglas: [CLAUDE.md](../CLAUDE.md)
+- Workflow: [WORKFLOW.md](../WORKFLOW.md)
+- Changelog: [CHANGELOG.md](../CHANGELOG.md)
+- Brand guidelines: [docs/brand-guidelines.md](brand-guidelines.md)


### PR DESCRIPTION
## Summary

- **Capacitaciones**: lista de asistencia ahora muestra firma del usuario (`users.firma_guardada`) por cada asistente. "Sin firma" si no cargada en perfil.
- **Checklists**: detalle de ejecuciones renderizado de corrido (sin `AddPage` por ejecucion). `page-break-inside:avoid` por ficha.
- **PDFs firmados (politicas/NDAs)**: helper `writeSignaturesAndFooter` mide `$mpdf->y` y fuerza `AddPage` si quedan <130mm. Evita que el bloque de firmas quede solo en una pagina (suspicaz). Anchor visual con `Tipo « Titulo » vX — Firmante: NOMBRE` antes de las firmas para tied-context si aun asi se separan.
- Aplicado a `download()`, `buildFirmantePdfBytes()` (centro reportes ZIP), y `buildConsolidatedFirmadosPdfBytes()`.
- `docker-compose.override.yml` gitignored.
- `docs/INVENTARIO_APP.md` agregado.

## Test plan

- [ ] Generar reporte capacitaciones → verificar columna Firma con imagen para asistentes con firma cargada y "Sin firma" para resto.
- [ ] Generar reporte checklists → verificar PDF de corrido, sin saltos por cada ejecucion.
- [ ] Descargar PDF politica/NDA individual → verificar que firmas siempre acompanan contenido (no solas en pagina).
- [ ] Descargar ZIP "Documentos Firmados" del centro de reportes → mismo comportamiento.
- [ ] Generar PDF politica con contenido largo → confirmar AddPage forzado antes de firmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)