### PR TITLE
[SEN-126] feat: migraciones, modelos y enums de Activos Digitales

### DIFF
--- a/app/Enums/EstadoActivoDigital.php
+++ b/app/Enums/EstadoActivoDigital.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+enum EstadoActivoDigital: string
+{
+    case Activo = 'activo';
+    case Suspendido = 'suspendido';
+    case Vencido = 'vencido';
+    case Cancelado = 'cancelado';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Activo => 'Activo',
+            self::Suspendido => 'Suspendido',
+            self::Vencido => 'Vencido',
+            self::Cancelado => 'Cancelado',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::Activo => 'success',
+            self::Suspendido => 'warning',
+            self::Vencido => 'danger',
+            self::Cancelado => 'gray',
+        };
+    }
+
+    /** @return array<string, string> */
+    public static function options(): array
+    {
+        return collect(self::cases())
+            ->mapWithKeys(fn (self $e) => [$e->value => $e->label()])
+            ->all();
+    }
+}

--- a/app/Enums/ModalidadPago.php
+++ b/app/Enums/ModalidadPago.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Enums;
+
+enum ModalidadPago: string
+{
+    case Mensual = 'mensual';
+    case Anual = 'anual';
+    case PagoUnico = 'pago_unico';
+    case Gratuito = 'gratuito';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Mensual => 'Pago mensual',
+            self::Anual => 'Pago anual',
+            self::PagoUnico => 'Pago único',
+            self::Gratuito => 'Gratuito',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::Mensual => 'warning',
+            self::Anual => 'info',
+            self::PagoUnico => 'success',
+            self::Gratuito => 'gray',
+        };
+    }
+
+    /** ¿La modalidad implica una renovación con fecha de vencimiento? */
+    public function esRecurrente(): bool
+    {
+        return in_array($this, [self::Mensual, self::Anual], true);
+    }
+
+    /** @return array<string, string> */
+    public static function options(): array
+    {
+        return collect(self::cases())
+            ->mapWithKeys(fn (self $m) => [$m->value => $m->label()])
+            ->all();
+    }
+}

--- a/app/Enums/TipoActivoDigital.php
+++ b/app/Enums/TipoActivoDigital.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Enums;
+
+enum TipoActivoDigital: string
+{
+    case Whatsapp = 'whatsapp';
+    case Meta = 'meta';
+    case SuscripcionSaas = 'suscripcion_saas';
+    case Dominio = 'dominio';
+    case LicenciaUnica = 'licencia_unica';
+    case Correo = 'correo';
+    case RedesSociales = 'redes_sociales';
+    case Otro = 'otro';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Whatsapp => 'Cuenta WhatsApp',
+            self::Meta => 'Cuenta Meta / Business Manager',
+            self::SuscripcionSaas => 'Suscripción SaaS',
+            self::Dominio => 'Dominio web',
+            self::LicenciaUnica => 'Licencia de pago único',
+            self::Correo => 'Cuenta de correo',
+            self::RedesSociales => 'Redes sociales',
+            self::Otro => 'Otro',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::Whatsapp => 'heroicon-o-chat-bubble-left-right',
+            self::Meta => 'heroicon-o-building-storefront',
+            self::SuscripcionSaas => 'heroicon-o-cloud',
+            self::Dominio => 'heroicon-o-globe-alt',
+            self::LicenciaUnica => 'heroicon-o-key',
+            self::Correo => 'heroicon-o-envelope',
+            self::RedesSociales => 'heroicon-o-hashtag',
+            self::Otro => 'heroicon-o-square-3-stack-3d',
+        };
+    }
+
+    /** @return array<string, string> */
+    public static function options(): array
+    {
+        return collect(self::cases())
+            ->mapWithKeys(fn (self $t) => [$t->value => $t->label()])
+            ->all();
+    }
+}

--- a/app/Models/ActivoDigital.php
+++ b/app/Models/ActivoDigital.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\ModalidadPago;
+use App\Enums\TipoActivoDigital;
+use App\Models\Concerns\BelongsToEmpresa;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ActivoDigital extends Model
+{
+    use BelongsToEmpresa, SoftDeletes;
+
+    protected $table = 'activos_digitales';
+
+    protected $fillable = [
+        'empresa_id',
+        'codigo_interno',
+        'nombre',
+        'tipo',
+        'proveedor',
+        'url',
+        'identificador',
+        'estado',
+        'nivel_sensibilidad',
+        'responsable_id',
+        'modalidad_pago',
+        'costo',
+        'moneda',
+        'metodo_pago',
+        'renovacion_automatica',
+        'fecha_adquisicion',
+        'fecha_vencimiento',
+        'equipo_id',
+        'registro_id',
+        'observaciones',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'tipo' => TipoActivoDigital::class,
+            'estado' => EstadoActivoDigital::class,
+            'modalidad_pago' => ModalidadPago::class,
+            'costo' => 'decimal:2',
+            'renovacion_automatica' => 'boolean',
+            'fecha_adquisicion' => 'date',
+            'fecha_vencimiento' => 'date',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (ActivoDigital $activo) {
+            if (empty($activo->codigo_interno)) {
+                $activo->codigo_interno = static::generarCodigoInterno($activo->empresa_id);
+            }
+        });
+    }
+
+    /** Genera el siguiente codigo correlativo AD-XXX por empresa. */
+    public static function generarCodigoInterno(?int $empresaId): string
+    {
+        $ultimo = static::withTrashed()
+            ->withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('codigo_interno', 'like', 'AD-%')
+            ->orderByDesc('id')
+            ->value('codigo_interno');
+
+        $secuencia = $ultimo ? ((int) substr($ultimo, 3)) + 1 : 1;
+
+        return 'AD-'.str_pad((string) $secuencia, 3, '0', STR_PAD_LEFT);
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'empresa_id');
+    }
+
+    public function responsable(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'responsable_id');
+    }
+
+    public function equipo(): BelongsTo
+    {
+        return $this->belongsTo(Equipo::class, 'equipo_id');
+    }
+
+    public function registro(): BelongsTo
+    {
+        return $this->belongsTo(Registro::class, 'registro_id');
+    }
+
+    public function credenciales(): HasMany
+    {
+        return $this->hasMany(ActivoDigitalCredencial::class, 'activo_digital_id');
+    }
+
+    public function pagos(): HasMany
+    {
+        return $this->hasMany(ActivoDigitalPago::class, 'activo_digital_id')->latest('fecha_pago');
+    }
+
+    /** ¿Está por vencer dentro de los próximos $dias días? */
+    public function porVencer(int $dias = 30): bool
+    {
+        if (! $this->fecha_vencimiento || ! $this->modalidad_pago?->esRecurrente()) {
+            return false;
+        }
+
+        return $this->fecha_vencimiento->isFuture()
+            && $this->fecha_vencimiento->lessThanOrEqualTo(now()->addDays($dias));
+    }
+
+    public function estaVencido(): bool
+    {
+        return $this->fecha_vencimiento
+            && $this->modalidad_pago?->esRecurrente()
+            && $this->fecha_vencimiento->isPast();
+    }
+}

--- a/app/Models/ActivoDigitalCredencial.php
+++ b/app/Models/ActivoDigitalCredencial.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ActivoDigitalCredencial extends Model
+{
+    protected $table = 'activo_digital_credenciales';
+
+    protected $fillable = [
+        'activo_digital_id',
+        'etiqueta',
+        'usuario',
+        'password',
+        'dato_2fa',
+        'recovery',
+        'notas',
+    ];
+
+    /**
+     * Los campos sensibles se cifran en reposo con la APP_KEY (cast 'encrypted').
+     * Nunca exponer en listados, logs ni reportes.
+     */
+    protected function casts(): array
+    {
+        return [
+            'usuario' => 'encrypted',
+            'password' => 'encrypted',
+            'dato_2fa' => 'encrypted',
+            'recovery' => 'encrypted',
+            'notas' => 'encrypted',
+        ];
+    }
+
+    protected $hidden = [
+        'usuario',
+        'password',
+        'dato_2fa',
+        'recovery',
+        'notas',
+    ];
+
+    public function activoDigital(): BelongsTo
+    {
+        return $this->belongsTo(ActivoDigital::class, 'activo_digital_id');
+    }
+}

--- a/app/Models/ActivoDigitalPago.php
+++ b/app/Models/ActivoDigitalPago.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ActivoDigitalPago extends Model
+{
+    protected $table = 'activo_digital_pagos';
+
+    protected $fillable = [
+        'activo_digital_id',
+        'fecha_pago',
+        'monto',
+        'moneda',
+        'metodo',
+        'periodo_desde',
+        'periodo_hasta',
+        'comprobante',
+        'registrado_por',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'fecha_pago' => 'date',
+            'periodo_desde' => 'date',
+            'periodo_hasta' => 'date',
+            'monto' => 'decimal:2',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (ActivoDigitalPago $pago) {
+            if (! $pago->registrado_por && auth()->check()) {
+                $pago->registrado_por = auth()->id();
+            }
+        });
+    }
+
+    public function activoDigital(): BelongsTo
+    {
+        return $this->belongsTo(ActivoDigital::class, 'activo_digital_id');
+    }
+
+    public function registradoPor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'registrado_por');
+    }
+}

--- a/database/migrations/2026_06_02_000001_create_activos_digitales_table.php
+++ b/database/migrations/2026_06_02_000001_create_activos_digitales_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activos_digitales', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('empresa_id');
+            $table->foreign('empresa_id')->references('id')->on('empresas')->cascadeOnDelete();
+            $table->string('codigo_interno')->nullable(); // AD-001
+            $table->string('nombre'); // "WhatsApp Ventas", "Meta Business Studio"
+            $table->string('tipo'); // whatsapp, meta, suscripcion_saas, dominio, licencia_unica, correo, redes_sociales, otro
+            $table->string('proveedor')->nullable(); // Meta, Google, OpenAI...
+            $table->string('url')->nullable(); // panel de acceso
+            $table->string('identificador')->nullable(); // nro telefono, email, business ID
+            $table->string('estado')->default('activo'); // activo, suspendido, vencido, cancelado
+            $table->string('nivel_sensibilidad')->default('interno'); // publico, interno, confidencial, sensible
+            $table->unsignedBigInteger('responsable_id')->nullable();
+            $table->foreign('responsable_id')->references('id')->on('users')->nullOnDelete();
+            $table->string('modalidad_pago')->default('mensual'); // mensual, anual, pago_unico, gratuito
+            $table->decimal('costo', 12, 2)->nullable();
+            $table->string('moneda', 3)->default('PEN');
+            $table->string('metodo_pago')->nullable(); // "Visa ***1234", "transferencia"
+            $table->boolean('renovacion_automatica')->default(false);
+            $table->date('fecha_adquisicion')->nullable();
+            $table->date('fecha_vencimiento')->nullable(); // null si pago unico / gratuito
+            // Vinculos opcionales con el resto del sistema (PSC / equipos) — US-1905
+            $table->unsignedBigInteger('equipo_id')->nullable();
+            $table->foreign('equipo_id')->references('id')->on('equipos')->nullOnDelete();
+            $table->unsignedBigInteger('registro_id')->nullable();
+            $table->foreign('registro_id')->references('id')->on('registros')->nullOnDelete();
+            $table->text('observaciones')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['empresa_id', 'estado']);
+            $table->index(['empresa_id', 'tipo']);
+            $table->index(['empresa_id', 'fecha_vencimiento']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activos_digitales');
+    }
+};

--- a/database/migrations/2026_06_02_000002_create_activo_digital_credenciales_table.php
+++ b/database/migrations/2026_06_02_000002_create_activo_digital_credenciales_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activo_digital_credenciales', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('activo_digital_id');
+            $table->foreign('activo_digital_id')->references('id')->on('activos_digitales')->cascadeOnDelete();
+            $table->string('etiqueta'); // "admin principal", "API key"
+            // Campos sensibles: se almacenan cifrados via casts 'encrypted' en el modelo (TEXT para el ciphertext)
+            $table->text('usuario')->nullable();
+            $table->text('password')->nullable();
+            $table->text('dato_2fa')->nullable(); // seed TOTP
+            $table->text('recovery')->nullable(); // codigos de recuperacion
+            $table->text('notas')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activo_digital_credenciales');
+    }
+};

--- a/database/migrations/2026_06_02_000003_create_activo_digital_pagos_table.php
+++ b/database/migrations/2026_06_02_000003_create_activo_digital_pagos_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activo_digital_pagos', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('activo_digital_id');
+            $table->foreign('activo_digital_id')->references('id')->on('activos_digitales')->cascadeOnDelete();
+            $table->date('fecha_pago');
+            $table->decimal('monto', 12, 2);
+            $table->string('moneda', 3)->default('PEN');
+            $table->string('metodo')->nullable(); // tarjeta, transferencia, paypal...
+            $table->date('periodo_desde')->nullable();
+            $table->date('periodo_hasta')->nullable();
+            $table->string('comprobante')->nullable(); // path del archivo (FileUpload)
+            $table->unsignedBigInteger('registrado_por')->nullable();
+            $table->foreign('registrado_por')->references('id')->on('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['activo_digital_id', 'fecha_pago']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activo_digital_pagos');
+    }
+};


### PR DESCRIPTION
## Summary
- Tablas: `activos_digitales`, `activo_digital_credenciales`, `activo_digital_pagos`
- Enums: `TipoActivoDigital`, `ModalidadPago`, `EstadoActivoDigital`
- Multi-tenancy (trait `BelongsToEmpresa`) + softDeletes
- Credenciales cifradas en reposo (cast `encrypted`) y ocultas (`$hidden`)
- Auto-código correlativo `AD-XXX` por empresa
- FK opcionales a equipos y registros (para US-1905)

Primera story de la épica **EP-19: Control de Activos Digitales** (cuentas WhatsApp/Meta, suscripciones SaaS, licencias de pago único, etc.).

closes SEN-126

## Security checklist
- [x] SQL: Eloquent only
- [x] CSRF: Filament/Laravel lo maneja
- [x] XSS: N/A (sin vistas en esta story)
- [x] Auth: Policies/permisos vienen en SEN-128
- [x] Tenant: Global Scope activo via `BelongsToEmpresa`
- [x] Uploads: N/A

## Functional checklist
- [x] Funcionalidad segun la user story
- [x] Sin errores PHP
- [x] Tests pasan (11 passed)
- [ ] Probado en navegador (no aplica: sin UI aún)

🤖 Generated with [Claude Code](https://claude.com/claude-code)