### PR TITLE
[SEN-127] feat: ActivoDigitalResource CRUD en Filament

### DIFF
--- a/app/Filament/Resources/ActivosDigitales/ActivoDigitalResource.php
+++ b/app/Filament/Resources/ActivosDigitales/ActivoDigitalResource.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales;
+
+use App\Filament\Resources\ActivosDigitales\Pages\CreateActivoDigital;
+use App\Filament\Resources\ActivosDigitales\Pages\EditActivoDigital;
+use App\Filament\Resources\ActivosDigitales\Pages\ListActivosDigitales;
+use App\Filament\Resources\ActivosDigitales\Schemas\ActivoDigitalForm;
+use App\Filament\Resources\ActivosDigitales\Tables\ActivosDigitalesTable;
+use App\Models\ActivoDigital;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class ActivoDigitalResource extends Resource
+{
+    protected static ?string $model = ActivoDigital::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedGlobeAlt;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Activos Digitales';
+
+    protected static ?string $modelLabel = 'Activo digital';
+
+    protected static ?string $pluralModelLabel = 'Activos digitales';
+
+    protected static ?string $slug = 'cuentas-digitales';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return ActivoDigitalForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ActivosDigitalesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListActivosDigitales::route('/'),
+            'create' => CreateActivoDigital::route('/create'),
+            'edit' => EditActivoDigital::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getRecordRouteBindingEloquentQuery(): Builder
+    {
+        return parent::getRecordRouteBindingEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/ActivosDigitales/Pages/CreateActivoDigital.php
+++ b/app/Filament/Resources/ActivosDigitales/Pages/CreateActivoDigital.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\Pages;
+
+use App\Filament\Resources\ActivosDigitales\ActivoDigitalResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateActivoDigital extends CreateRecord
+{
+    protected static string $resource = ActivoDigitalResource::class;
+}

--- a/app/Filament/Resources/ActivosDigitales/Pages/EditActivoDigital.php
+++ b/app/Filament/Resources/ActivosDigitales/Pages/EditActivoDigital.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\Pages;
+
+use App\Filament\Resources\ActivosDigitales\ActivoDigitalResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditActivoDigital extends EditRecord
+{
+    protected static string $resource = ActivoDigitalResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+            ForceDeleteAction::make(),
+            RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ActivosDigitales/Pages/ListActivosDigitales.php
+++ b/app/Filament/Resources/ActivosDigitales/Pages/ListActivosDigitales.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\Pages;
+
+use App\Filament\Resources\ActivosDigitales\ActivoDigitalResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListActivosDigitales extends ListRecords
+{
+    protected static string $resource = ActivoDigitalResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/ActivosDigitales/Schemas/ActivoDigitalForm.php
+++ b/app/Filament/Resources/ActivosDigitales/Schemas/ActivoDigitalForm.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\Schemas;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\ModalidadPago;
+use App\Enums\TipoActivoDigital;
+use App\Models\User;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+class ActivoDigitalForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(1)
+            ->components([
+                Section::make('Identificacion de la cuenta')
+                    ->icon('heroicon-o-identification')
+                    ->description('Datos basicos del activo digital. El codigo interno se genera automaticamente.')
+                    ->columns(2)
+                    ->schema([
+                        TextInput::make('nombre')
+                            ->label('Nombre')
+                            ->placeholder('WhatsApp Ventas, Meta Business Studio...')
+                            ->required()
+                            ->maxLength(255)
+                            ->columnSpanFull(),
+                        Select::make('tipo')
+                            ->label('Tipo de activo')
+                            ->options(TipoActivoDigital::options())
+                            ->required()
+                            ->native(false),
+                        TextInput::make('proveedor')
+                            ->label('Proveedor')
+                            ->placeholder('Meta, Google, OpenAI, GoDaddy...')
+                            ->maxLength(255),
+                        TextInput::make('url')
+                            ->label('URL de acceso')
+                            ->placeholder('https://business.facebook.com')
+                            ->url()
+                            ->maxLength(255),
+                        TextInput::make('identificador')
+                            ->label('Identificador')
+                            ->placeholder('Nro de telefono, email, business ID...')
+                            ->helperText('Como se identifica la cuenta en el proveedor')
+                            ->maxLength(255),
+                        TextInput::make('codigo_interno')
+                            ->label('Codigo interno')
+                            ->placeholder('AD-001 (automatico)')
+                            ->helperText('Se genera solo si lo dejas vacio')
+                            ->maxLength(255),
+                    ]),
+
+                Section::make('Cobro y vigencia')
+                    ->icon('heroicon-o-credit-card')
+                    ->description('Modalidad de pago y control de renovacion.')
+                    ->columns(3)
+                    ->schema([
+                        Select::make('modalidad_pago')
+                            ->label('Modalidad de pago')
+                            ->options(ModalidadPago::options())
+                            ->default(ModalidadPago::Mensual->value)
+                            ->required()
+                            ->live()
+                            ->native(false),
+                        TextInput::make('costo')
+                            ->label('Costo del periodo')
+                            ->numeric()
+                            ->minValue(0)
+                            ->step('0.01')
+                            ->prefix(fn (Get $get): string => $get('moneda') ?: 'PEN')
+                            ->visible(fn (Get $get): bool => $get('modalidad_pago') !== ModalidadPago::Gratuito->value),
+                        Select::make('moneda')
+                            ->label('Moneda')
+                            ->options([
+                                'PEN' => 'PEN — Soles',
+                                'USD' => 'USD — Dolares',
+                                'EUR' => 'EUR — Euros',
+                            ])
+                            ->default('PEN')
+                            ->required()
+                            ->native(false)
+                            ->visible(fn (Get $get): bool => $get('modalidad_pago') !== ModalidadPago::Gratuito->value),
+                        TextInput::make('metodo_pago')
+                            ->label('Metodo de pago')
+                            ->placeholder('Visa ***1234, transferencia, PayPal...')
+                            ->maxLength(255)
+                            ->visible(fn (Get $get): bool => $get('modalidad_pago') !== ModalidadPago::Gratuito->value),
+                        DatePicker::make('fecha_adquisicion')
+                            ->label('Fecha de adquisicion'),
+                        DatePicker::make('fecha_vencimiento')
+                            ->label('Proximo vencimiento')
+                            ->helperText('Cuando vence/renueva la suscripcion')
+                            ->visible(fn (Get $get): bool => in_array($get('modalidad_pago'), [
+                                ModalidadPago::Mensual->value,
+                                ModalidadPago::Anual->value,
+                            ], true)),
+                        Toggle::make('renovacion_automatica')
+                            ->label('Renovacion automatica')
+                            ->inline(false)
+                            ->visible(fn (Get $get): bool => in_array($get('modalidad_pago'), [
+                                ModalidadPago::Mensual->value,
+                                ModalidadPago::Anual->value,
+                            ], true)),
+                    ]),
+
+                Section::make('Gestion y clasificacion')
+                    ->icon('heroicon-o-shield-check')
+                    ->description('Responsable, estado y sensibilidad de la informacion.')
+                    ->columns(3)
+                    ->schema([
+                        Select::make('responsable_id')
+                            ->label('Responsable')
+                            ->options(fn (): array => User::query()->orderBy('name')->pluck('name', 'id')->all())
+                            ->searchable()
+                            ->placeholder('Quien gestiona esta cuenta'),
+                        Select::make('estado')
+                            ->label('Estado')
+                            ->options(EstadoActivoDigital::options())
+                            ->default(EstadoActivoDigital::Activo->value)
+                            ->required()
+                            ->native(false),
+                        Select::make('nivel_sensibilidad')
+                            ->label('Nivel de sensibilidad')
+                            ->options([
+                                'publico' => 'Publico',
+                                'interno' => 'Interno',
+                                'confidencial' => 'Confidencial',
+                                'sensible' => 'Sensible',
+                            ])
+                            ->default('interno')
+                            ->required()
+                            ->native(false),
+                    ]),
+
+                Section::make('Observaciones')
+                    ->schema([
+                        Textarea::make('observaciones')
+                            ->label('Notas adicionales')
+                            ->rows(3)
+                            ->placeholder('Detalles del activo, alcance, accesos relacionados, etc.')
+                            ->columnSpanFull(),
+                    ])
+                    ->collapsible()
+                    ->collapsed(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ActivosDigitales/Tables/ActivosDigitalesTable.php
+++ b/app/Filament/Resources/ActivosDigitales/Tables/ActivosDigitalesTable.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\Tables;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\ModalidadPago;
+use App\Enums\TipoActivoDigital;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\RestoreBulkAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TrashedFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ActivosDigitalesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('codigo_interno')
+                    ->label('Codigo')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('nombre')
+                    ->label('Nombre')
+                    ->searchable()
+                    ->sortable()
+                    ->weight('medium'),
+                TextColumn::make('tipo')
+                    ->label('Tipo')
+                    ->badge()
+                    ->formatStateUsing(fn (TipoActivoDigital $state): string => $state->label())
+                    ->icon(fn (TipoActivoDigital $state): string => $state->icon()),
+                TextColumn::make('proveedor')
+                    ->label('Proveedor')
+                    ->placeholder('—')
+                    ->toggleable(),
+                TextColumn::make('modalidad_pago')
+                    ->label('Pago')
+                    ->badge()
+                    ->color(fn (ModalidadPago $state): string => $state->color())
+                    ->formatStateUsing(fn (ModalidadPago $state): string => $state->label()),
+                TextColumn::make('costo')
+                    ->label('Costo')
+                    ->formatStateUsing(fn ($state, $record): string => $state ? $record->moneda . ' ' . number_format((float) $state, 2) : '—')
+                    ->toggleable(),
+                TextColumn::make('fecha_vencimiento')
+                    ->label('Vence')
+                    ->date('d/m/Y')
+                    ->placeholder('—')
+                    ->sortable()
+                    ->badge()
+                    ->color(fn ($record): string => $record->estaVencido() ? 'danger' : ($record->porVencer(30) ? 'warning' : 'gray')),
+                TextColumn::make('responsable.name')
+                    ->label('Responsable')
+                    ->placeholder('Sin asignar')
+                    ->toggleable(),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (EstadoActivoDigital $state): string => $state->color())
+                    ->formatStateUsing(fn (EstadoActivoDigital $state): string => $state->label()),
+                TextColumn::make('created_at')
+                    ->label('Registrado')
+                    ->dateTime('d/m/Y')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                SelectFilter::make('tipo')
+                    ->label('Tipo')
+                    ->options(TipoActivoDigital::options()),
+                SelectFilter::make('modalidad_pago')
+                    ->label('Modalidad de pago')
+                    ->options(ModalidadPago::options()),
+                SelectFilter::make('estado')
+                    ->label('Estado')
+                    ->options(EstadoActivoDigital::options()),
+                Filter::make('por_vencer')
+                    ->label('Por vencer (30 dias)')
+                    ->toggle()
+                    ->query(fn (Builder $query): Builder => $query
+                        ->whereIn('modalidad_pago', [ModalidadPago::Mensual->value, ModalidadPago::Anual->value])
+                        ->whereNotNull('fecha_vencimiento')
+                        ->whereDate('fecha_vencimiento', '<=', now()->addDays(30))),
+                TrashedFilter::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- `ActivoDigitalResource` con grupo de navegacion **Activos Digitales** (slug `cuentas-digitales`)
- **Form**: identificacion (nombre, tipo, proveedor, url, identificador, codigo auto), cobro/vigencia con visibilidad condicional segun modalidad de pago, gestion (responsable, estado, sensibilidad), observaciones
- **Table**: badges por tipo/modalidad/estado, costo formateado, columna de vencimiento con color (vencido/por vencer), filtros por tipo/modalidad/estado + filtro rapido "por vencer 30d" + papelera
- **Pages**: List/Create/Edit con soft-delete (delete/forceDelete/restore)
- `canAccess` restringido a `super_admin` / `admin_empresa`
- Reusa los enums de SEN-126

Segunda story de **EP-19: Control de Activos Digitales**.

closes SEN-127

## Security checklist
- [x] SQL: Eloquent only (Resource + queries de filtro con Builder)
- [x] CSRF: Filament lo maneja
- [x] XSS: sin `{!! !!}` con datos de usuario; salida via componentes Filament
- [x] Auth: `canAccess` por rol
- [x] Tenant: Global Scope activo via `BelongsToEmpresa` (modelo)
- [x] Uploads: N/A

## Functional checklist
- [x] Funcionalidad segun la user story (CRUD)
- [x] Sin errores PHP (lint OK en todos los archivos)
- [x] Rutas registradas (`route:list`)
- [x] Tests pasan (11 passed)
- [ ] Probado en navegador (pendiente smoke test manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)