### PR TITLE
[SEN-128] feat: credenciales cifradas + Policy de acceso

### DIFF
--- a/app/Filament/Resources/ActivosDigitales/ActivoDigitalResource.php
+++ b/app/Filament/Resources/ActivosDigitales/ActivoDigitalResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ActivosDigitales;
 use App\Filament\Resources\ActivosDigitales\Pages\CreateActivoDigital;
 use App\Filament\Resources\ActivosDigitales\Pages\EditActivoDigital;
 use App\Filament\Resources\ActivosDigitales\Pages\ListActivosDigitales;
+use App\Filament\Resources\ActivosDigitales\RelationManagers;
 use App\Filament\Resources\ActivosDigitales\Schemas\ActivoDigitalForm;
 use App\Filament\Resources\ActivosDigitales\Tables\ActivosDigitalesTable;
 use App\Models\ActivoDigital;
@@ -49,7 +50,9 @@ class ActivoDigitalResource extends Resource
 
     public static function getRelations(): array
     {
-        return [];
+        return [
+            RelationManagers\CredencialesRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ActivosDigitales/RelationManagers/CredencialesRelationManager.php
+++ b/app/Filament/Resources/ActivosDigitales/RelationManagers/CredencialesRelationManager.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\RelationManagers;
+
+use App\Models\ActivoDigitalCredencial;
+use App\Services\AuditService;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
+
+class CredencialesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'credenciales';
+
+    protected static ?string $title = 'Credenciales';
+
+    /**
+     * El tab de credenciales solo aparece para quien puede verlas:
+     * permiso `ver_credenciales` o ser el responsable de la cuenta.
+     */
+    public static function canViewForRecord($ownerRecord, string $pageClass): bool
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        return $user->can('ver_credenciales') || $ownerRecord->responsable_id === $user->id;
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                TextInput::make('etiqueta')
+                    ->label('Etiqueta')
+                    ->placeholder('Admin principal, API key, cuenta de respaldo...')
+                    ->required()
+                    ->maxLength(255)
+                    ->columnSpanFull(),
+                TextInput::make('usuario')
+                    ->label('Usuario / correo')
+                    ->maxLength(255)
+                    ->autocomplete(false),
+                TextInput::make('password')
+                    ->label('Contraseña')
+                    ->password()
+                    ->revealable()
+                    ->autocomplete('new-password'),
+                TextInput::make('dato_2fa')
+                    ->label('2FA / TOTP seed')
+                    ->password()
+                    ->revealable()
+                    ->helperText('Semilla del autenticador, si aplica'),
+                Textarea::make('recovery')
+                    ->label('Códigos de recuperación')
+                    ->rows(2),
+                Textarea::make('notas')
+                    ->label('Notas')
+                    ->rows(2)
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('etiqueta')
+                    ->label('Etiqueta')
+                    ->weight('medium')
+                    ->searchable(),
+                TextColumn::make('usuario')
+                    ->label('Usuario')
+                    ->formatStateUsing(fn ($state): string => filled($state) ? '••••••••' : '—'),
+                TextColumn::make('password')
+                    ->label('Contraseña')
+                    ->state('••••••••'),
+                TextColumn::make('updated_at')
+                    ->label('Actualizada')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ])
+            ->recordActions([
+                Action::make('revelar')
+                    ->label('Ver')
+                    ->icon('heroicon-o-eye')
+                    ->color('warning')
+                    ->visible(fn (ActivoDigitalCredencial $record): bool => auth()->user()?->can('view', $record) ?? false)
+                    ->modalHeading('Credenciales')
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Cerrar')
+                    ->modalContent(function (ActivoDigitalCredencial $record): HtmlString {
+                        // Registrar el acceso a credenciales sensibles en auditoria
+                        AuditService::log(
+                            accion: 'credencial_revelada',
+                            entidad: 'ActivoDigitalCredencial',
+                            entidadId: $record->id,
+                            datosNuevos: ['etiqueta' => $record->etiqueta, 'activo_digital_id' => $record->activo_digital_id],
+                        );
+
+                        $row = fn (string $label, ?string $value): string => '<div class="py-2 border-b border-gray-100 dark:border-gray-800">'
+                            . '<p class="text-xs font-medium text-gray-500">' . e($label) . '</p>'
+                            . '<p class="text-sm text-gray-900 dark:text-gray-100 font-mono break-all">' . (filled($value) ? e($value) : '—') . '</p></div>';
+
+                        return new HtmlString(
+                            $row('Etiqueta', $record->etiqueta)
+                            . $row('Usuario / correo', $record->usuario)
+                            . $row('Contraseña', $record->password)
+                            . $row('2FA / TOTP seed', $record->dato_2fa)
+                            . $row('Códigos de recuperación', $record->recovery)
+                            . $row('Notas', $record->notas)
+                        );
+                    }),
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->emptyStateHeading('Sin credenciales registradas')
+            ->emptyStateDescription('Las credenciales se guardan cifradas y solo son visibles para usuarios autorizados.');
+    }
+}

--- a/app/Policies/ActivoDigitalCredencialPolicy.php
+++ b/app/Policies/ActivoDigitalCredencialPolicy.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ActivoDigitalCredencial;
+use App\Models\User;
+
+class ActivoDigitalCredencialPolicy
+{
+    /**
+     * Solo super_admin y admin_empresa gestionan el modulo de activos digitales.
+     */
+    private function gestiona(User $user): bool
+    {
+        return $user->hasRole(['super_admin', 'admin_empresa']);
+    }
+
+    /**
+     * ¿Puede ver/descifrar credenciales? Requiere el permiso explicito
+     * `ver_credenciales` o ser el responsable de la cuenta.
+     */
+    public function view(User $user, ActivoDigitalCredencial $credencial): bool
+    {
+        if ($user->can('ver_credenciales')) {
+            return true;
+        }
+
+        return $credencial->activoDigital?->responsable_id === $user->id;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->gestiona($user) || $user->can('ver_credenciales');
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->gestiona($user);
+    }
+
+    public function update(User $user, ActivoDigitalCredencial $credencial): bool
+    {
+        return $this->gestiona($user);
+    }
+
+    public function delete(User $user, ActivoDigitalCredencial $credencial): bool
+    {
+        return $this->gestiona($user);
+    }
+}

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -35,6 +35,8 @@ class RolePermissionSeeder extends Seeder
         Permission::firstOrCreate(['name' => 'gestionar_empresa_propia']);
         Permission::firstOrCreate(['name' => 'ver_notas_internas']);
         Permission::firstOrCreate(['name' => 'asignar_tickets']);
+        // Activos digitales (EP-19): acceso a credenciales sensibles
+        Permission::firstOrCreate(['name' => 'ver_credenciales']);
 
         // Roles
         $superAdmin = Role::firstOrCreate(['name' => 'super_admin']);
@@ -47,6 +49,7 @@ class RolePermissionSeeder extends Seeder
             'ver_tickets', 'crear_tickets',
             'ver_exportar', 'crear_exportar',
             'gestionar_empresa_propia',
+            'ver_credenciales',
         ]);
 
         $usuario = Role::firstOrCreate(['name' => 'usuario']);


### PR DESCRIPTION
## Summary
- **CredencialesRelationManager** en el `ActivoDigitalResource`: CRUD de credenciales con campos `password` revelables en el form
- **Tabla enmascarada**: usuario/contraseña se muestran como `••••••••`, nunca en texto plano en el listado
- **Accion "Ver"**: descifra las credenciales en un modal y **registra el acceso en `audit_logs`** (`AuditService`, accion `credencial_revelada`)
- **Permiso** `ver_credenciales` (spatie) agregado al seeder → super_admin y admin_empresa
- **ActivoDigitalCredencialPolicy**: `view` requiere el permiso o ser el responsable de la cuenta; `create/update/delete` solo super_admin/admin_empresa
- El tab de credenciales se oculta para usuarios no autorizados (`canViewForRecord`)

Tercera story de **EP-19: Control de Activos Digitales**. Los campos sensibles ya se cifran en reposo (cast `encrypted`, SEN-126); esta story controla quien puede descifrarlos y deja traza de auditoria.

closes SEN-128

## Security checklist
- [x] SQL: Eloquent only
- [x] CSRF: Filament lo maneja
- [x] XSS: el modal usa `e()` en toda salida; sin `{!! !!}` con datos crudos
- [x] Auth: Policy + permiso `ver_credenciales` + `canViewForRecord`
- [x] Tenant: Global Scope activo via `BelongsToEmpresa` (cuenta padre)
- [x] Uploads: N/A
- [x] Credenciales: cifradas en reposo, enmascaradas en tabla, acceso auditado

## Functional checklist
- [x] Funcionalidad segun la user story
- [x] Sin errores PHP (lint OK)
- [x] Policy auto-descubierta + permiso verificado por rol (admin si, usuario no)
- [x] Tests pasan (11 passed)
- [ ] Probado en navegador (pendiente smoke test manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)