### PR TITLE
[fix] tests: evitar que la suite borre la BD de desarrollo

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,14 +18,16 @@
         </include>
     </source>
     <php>
-        <env name="APP_ENV" value="testing"/>
+        <env name="APP_ENV" value="testing" force="true"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_URL" value=""/>
+        <!-- force=true: evita que las DB_* del contenedor (mysql) sobrescriban
+             esto; sin force, los tests con RefreshDatabase borran la BD real -->
+        <env name="DB_CONNECTION" value="sqlite" force="true"/>
+        <env name="DB_DATABASE" value=":memory:" force="true"/>
+        <env name="DB_URL" value="" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,26 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * Salvaguarda: los tests SIEMPRE corren contra sqlite en memoria.
+     *
+     * docker-compose inyecta DB_CONNECTION=mysql como variable real del
+     * proceso, que queda en $_SERVER/$_ENV. El helper env() de Laravel lee
+     * $_SERVER antes que getenv(), por lo que el `force="true"` de phpunit.xml
+     * (que solo toca putenv) no basta. Sin esto, los tests con RefreshDatabase
+     * ejecutarian migrate:fresh sobre la BD de desarrollo y la borrarian.
+     */
+    protected function setUp(): void
+    {
+        foreach ([
+            'DB_CONNECTION' => 'sqlite',
+            'DB_DATABASE' => ':memory:',
+            'DB_URL' => '',
+        ] as $key => $value) {
+            $_SERVER[$key] = $_ENV[$key] = $value;
+            putenv("{$key}={$value}");
+        }
+
+        parent::setUp();
+    }
 }


### PR DESCRIPTION
## Summary
Bug critico de entorno: correr `php artisan test` (o `make test`) **borraba la base de datos de desarrollo**.

**Causa raiz (confirmada empiricamente):** `docker-compose.yml` inyecta `DB_CONNECTION=mysql` como variable real del proceso, que queda en `$_SERVER`. El helper `env()` de Laravel lee `$_SERVER` antes que `getenv()`, y el `force="true"` de phpunit.xml solo actualiza `putenv()`. Resultado: los tests con `RefreshDatabase` ejecutaban `migrate:fresh` sobre la BD MySQL real.

Diagnostico que lo confirmo: `config=mysql env=mysql getenv=sqlite $_SERVER=mysql`.

**Fix:**
- `tests/TestCase::setUp()` fuerza `$_SERVER/$_ENV/putenv` a sqlite `:memory:` antes de bootear la app.
- `phpunit.xml`: `force="true"` en `DB_CONNECTION/DB_DATABASE/DB_URL` (defensa en profundidad).

**Verificacion:** seed -> 7 users -> `php artisan test` (11 passed) -> sigue con 7 users. Ademas la suite bajo de 4.8s a 0.37s (ahora usa sqlite en memoria como debe).

> Afectaba a cualquiera que corriera `make test`, no solo a un entorno puntual.

## Functional checklist
- [x] Tests pasan (11 passed)
- [x] La BD de desarrollo sobrevive a la suite (verificado)
- [x] Sin cambios de comportamiento en produccion (solo entorno de test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)