### PR TITLE
[SEN-129] feat: historial de pagos con comprobante

### DIFF
--- a/app/Filament/Resources/ActivosDigitales/ActivoDigitalResource.php
+++ b/app/Filament/Resources/ActivosDigitales/ActivoDigitalResource.php
@@ -77,6 +77,7 @@ class ActivoDigitalResource extends Resource
     {
         return [
             RelationManagers\CredencialesRelationManager::class,
+            RelationManagers\PagosRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/ActivosDigitales/RelationManagers/PagosRelationManager.php
+++ b/app/Filament/Resources/ActivosDigitales/RelationManagers/PagosRelationManager.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Filament\Resources\ActivosDigitales\RelationManagers;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Storage;
+
+class PagosRelationManager extends RelationManager
+{
+    protected static string $relationship = 'pagos';
+
+    protected static ?string $title = 'Historial de pagos';
+
+    /** ¿El usuario puede registrar/editar pagos? */
+    protected static function puedeGestionar(): bool
+    {
+        $user = auth()->user();
+
+        return $user?->hasRole(['super_admin', 'admin_empresa'])
+            || $user?->can('registrar_pagos')
+            || false;
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                DatePicker::make('fecha_pago')
+                    ->label('Fecha de pago')
+                    ->required()
+                    ->default(now())
+                    ->maxDate(now()),
+                TextInput::make('monto')
+                    ->label('Monto')
+                    ->numeric()
+                    ->minValue(0)
+                    ->step('0.01')
+                    ->required()
+                    ->prefix(fn (Get $get): string => $get('moneda') ?: 'PEN'),
+                Select::make('moneda')
+                    ->label('Moneda')
+                    ->options([
+                        'PEN' => 'PEN — Soles',
+                        'USD' => 'USD — Dolares',
+                        'EUR' => 'EUR — Euros',
+                    ])
+                    ->default(fn (): string => $this->getOwnerRecord()->moneda ?? 'PEN')
+                    ->required()
+                    ->live(),
+                TextInput::make('metodo')
+                    ->label('Metodo de pago')
+                    ->placeholder('Tarjeta Visa, transferencia, PayPal...')
+                    ->maxLength(255),
+                DatePicker::make('periodo_desde')
+                    ->label('Periodo desde'),
+                DatePicker::make('periodo_hasta')
+                    ->label('Periodo hasta')
+                    ->afterOrEqual('periodo_desde'),
+                FileUpload::make('comprobante')
+                    ->label('Comprobante')
+                    ->disk('local')
+                    ->directory('activos-digitales/comprobantes')
+                    ->visibility('private')
+                    ->acceptedFileTypes(['application/pdf', 'image/jpeg', 'image/png'])
+                    ->maxSize(5120)
+                    ->downloadable()
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('fecha_pago')
+                    ->label('Fecha')
+                    ->date('d/m/Y')
+                    ->sortable(),
+                TextColumn::make('monto')
+                    ->label('Monto')
+                    ->formatStateUsing(fn ($state, $record): string => $record->moneda . ' ' . number_format((float) $state, 2))
+                    ->summarize(Sum::make()->label('Total')->numeric(decimalPlaces: 2)),
+                TextColumn::make('metodo')
+                    ->label('Metodo')
+                    ->placeholder('—'),
+                TextColumn::make('periodo')
+                    ->label('Periodo')
+                    ->state(fn ($record): string => $record->periodo_desde
+                        ? $record->periodo_desde->format('d/m/Y') . ' → ' . ($record->periodo_hasta?->format('d/m/Y') ?? '...')
+                        : '—'),
+                TextColumn::make('registradoPor.name')
+                    ->label('Registrado por')
+                    ->placeholder('—')
+                    ->toggleable(),
+            ])
+            ->defaultSort('fecha_pago', 'desc')
+            ->recordActions([
+                Action::make('comprobante')
+                    ->label('Comprobante')
+                    ->icon('heroicon-o-document-arrow-down')
+                    ->color('info')
+                    ->visible(fn ($record): bool => filled($record->comprobante))
+                    ->action(fn ($record) => Storage::disk('local')->download($record->comprobante)),
+                EditAction::make()
+                    ->visible(fn (): bool => static::puedeGestionar()),
+                DeleteAction::make()
+                    ->visible(fn (): bool => static::puedeGestionar()),
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->visible(fn (): bool => static::puedeGestionar()),
+            ])
+            ->emptyStateHeading('Sin pagos registrados')
+            ->emptyStateDescription('Registra aqui cada pago de la cuenta para llevar el historial y el costo acumulado.');
+    }
+}

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -37,6 +37,7 @@ class RolePermissionSeeder extends Seeder
         Permission::firstOrCreate(['name' => 'asignar_tickets']);
         // Activos digitales (EP-19): acceso a credenciales sensibles
         Permission::firstOrCreate(['name' => 'ver_credenciales']);
+        Permission::firstOrCreate(['name' => 'registrar_pagos']);
 
         // Roles
         $superAdmin = Role::firstOrCreate(['name' => 'super_admin']);
@@ -50,6 +51,7 @@ class RolePermissionSeeder extends Seeder
             'ver_exportar', 'crear_exportar',
             'gestionar_empresa_propia',
             'ver_credenciales',
+            'registrar_pagos',
         ]);
 
         $usuario = Role::firstOrCreate(['name' => 'usuario']);


### PR DESCRIPTION
## Summary
- **PagosRelationManager** en el `ActivoDigitalResource`: registrar pagos con fecha, monto, moneda, metodo, periodo (desde/hasta) y **comprobante adjunto** (FileUpload privado, PDF/JPG/PNG)
- **Total acumulado** en el footer de la tabla (summarizer Sum) + descarga de comprobante
- `registrado_por` se auto-asigna al usuario actual
- Permiso **`registrar_pagos`** (seeder) para super_admin y admin_empresa; crear/editar/eliminar pagos gateado por ese permiso/rol

Quinta story de **EP-19: Control de Activos Digitales**.

closes SEN-129

## Security checklist
- [x] SQL: Eloquent only
- [x] CSRF: Filament lo maneja
- [x] XSS: salida via componentes Filament
- [x] Auth: gating de gestion por permiso `registrar_pagos`/rol
- [x] Tenant: Global Scope (empresa) via cuenta padre
- [x] Uploads: FileUpload con MIME validado (pdf/jpg/png), disco privado, max 5MB

## Functional checklist
- [x] Funcionalidad segun la user story
- [x] Sin errores PHP (lint OK)
- [x] Tests pasan (11 passed)
- [x] Probado en navegador: muestra historial + Total acumulado (360.00)

🤖 Generated with [Claude Code](https://claude.com/claude-code)