### PR TITLE
[SEN-130] feat: control de vencimientos + alertas email/panel

### DIFF
--- a/app/Console/Commands/CheckActivosVencimientos.php
+++ b/app/Console/Commands/CheckActivosVencimientos.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\ModalidadPago;
+use App\Models\ActivoDigital;
+use App\Models\EmailTemplate;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class CheckActivosVencimientos extends Command
+{
+    protected $signature = 'activos:check-vencimientos';
+
+    protected $description = 'Marca activos digitales vencidos y envia alertas de renovacion proxima (30/7/1 dias)';
+
+    /** Dias de anticipacion para avisar de un vencimiento proximo. */
+    private const DIAS_AVISO = [30, 7, 1];
+
+    public function handle(): void
+    {
+        $this->checkProximos();
+        $this->checkVencidos();
+    }
+
+    private function recurrentes()
+    {
+        return ActivoDigital::query()
+            ->withoutGlobalScopes()
+            ->whereIn('modalidad_pago', [ModalidadPago::Mensual->value, ModalidadPago::Anual->value])
+            ->whereNotNull('fecha_vencimiento');
+    }
+
+    private function checkProximos(): void
+    {
+        foreach (self::DIAS_AVISO as $dias) {
+            $fecha = now()->addDays($dias)->toDateString();
+
+            $proximos = $this->recurrentes()
+                ->where('estado', '!=', EstadoActivoDigital::Cancelado->value)
+                ->whereDate('fecha_vencimiento', $fecha)
+                ->get();
+
+            foreach ($proximos as $activo) {
+                $this->notificar($activo, 'activo-por-vencer', [
+                    'fecha_vencimiento' => $activo->fecha_vencimiento->format('d/m/Y'),
+                    'dias' => (string) $dias,
+                ]);
+
+                $this->info("Por vencer ({$dias}d): {$activo->codigo_interno} {$activo->nombre}");
+            }
+        }
+    }
+
+    private function checkVencidos(): void
+    {
+        $vencidos = $this->recurrentes()
+            ->whereIn('estado', [EstadoActivoDigital::Activo->value, EstadoActivoDigital::Suspendido->value])
+            ->whereDate('fecha_vencimiento', '<', now()->toDateString())
+            ->get();
+
+        foreach ($vencidos as $activo) {
+            $activo->update(['estado' => EstadoActivoDigital::Vencido->value]);
+
+            $this->notificar($activo, 'activo-vencido', [
+                'fecha_vencimiento' => $activo->fecha_vencimiento->format('d/m/Y'),
+            ]);
+
+            $this->warn("Vencido: {$activo->codigo_interno} {$activo->nombre}");
+        }
+    }
+
+    /**
+     * Envia el correo a admins de la empresa + responsables de la cuenta.
+     */
+    private function notificar(ActivoDigital $activo, string $slug, array $extraVars): void
+    {
+        $template = EmailTemplate::findBySlug($slug);
+
+        if (! $template) {
+            return;
+        }
+
+        $admins = User::where('empresa_id', $activo->empresa_id)
+            ->role('admin_empresa')
+            ->get();
+
+        $destinatarios = $admins->merge($activo->responsables)->unique('id');
+
+        foreach ($destinatarios as $user) {
+            $vars = array_merge([
+                'nombre' => $user->name,
+                'nombre_activo' => $activo->nombre,
+                'codigo' => $activo->codigo_interno,
+                'proveedor' => $activo->proveedor ?? '—',
+                'empresa' => $activo->empresa?->razon_social ?? '',
+            ], $extraVars);
+
+            $subject = $template->renderAsunto($vars);
+            $body = $template->renderContenido($vars);
+
+            Mail::raw(strip_tags($body), function ($message) use ($user, $subject) {
+                $message->to($user->email)->subject($subject);
+            });
+        }
+    }
+}

--- a/app/Filament/Widgets/ActivosPorVencer.php
+++ b/app/Filament/Widgets/ActivosPorVencer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\ModalidadPago;
+use App\Models\ActivoDigital;
+use Filament\Facades\Filament;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+
+class ActivosPorVencer extends BaseWidget
+{
+    protected static ?int $sort = 10;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $heading = 'Activos digitales por vencer';
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public function table(Table $table): Table
+    {
+        $empresaId = Filament::getTenant()?->id;
+
+        return $table
+            ->query(
+                ActivoDigital::query()
+                    ->where('empresa_id', $empresaId)
+                    ->whereIn('modalidad_pago', [ModalidadPago::Mensual->value, ModalidadPago::Anual->value])
+                    ->whereNotNull('fecha_vencimiento')
+                    ->whereNot('estado', 'cancelado')
+                    ->where(fn (Builder $q) => $q
+                        ->whereDate('fecha_vencimiento', '<', now())
+                        ->orWhereDate('fecha_vencimiento', '<=', now()->addDays(30)))
+                    ->orderBy('fecha_vencimiento')
+            )
+            ->columns([
+                TextColumn::make('codigo_interno')
+                    ->label('Codigo'),
+                TextColumn::make('nombre')
+                    ->label('Cuenta')
+                    ->limit(30),
+                TextColumn::make('proveedor')
+                    ->label('Proveedor')
+                    ->placeholder('—'),
+                TextColumn::make('fecha_vencimiento')
+                    ->label('Vence')
+                    ->date('d/m/Y')
+                    ->badge()
+                    ->color(fn ($record): string => $record->estaVencido() ? 'danger' : 'warning'),
+                TextColumn::make('dias_restantes')
+                    ->label('Estado')
+                    ->badge()
+                    ->state(fn ($record): string => $record->estaVencido()
+                        ? 'Vencido'
+                        : 'En ' . (int) ceil(now()->diffInDays($record->fecha_vencimiento, false)) . ' dias')
+                    ->color(fn ($record): string => $record->estaVencido() ? 'danger' : 'warning'),
+            ])
+            ->paginated([5, 10])
+            ->emptyStateHeading('Sin vencimientos proximos')
+            ->emptyStateDescription('Ninguna cuenta vence en los proximos 30 dias.');
+    }
+}

--- a/database/seeders/EmailTemplateSeeder.php
+++ b/database/seeders/EmailTemplateSeeder.php
@@ -149,6 +149,34 @@ HTML,
 <p><a href="{{enlace_plataforma}}">Ir a aceptar</a></p>
 HTML,
             ],
+            [
+                'slug' => 'activo-por-vencer',
+                'nombre' => 'Activo digital por vencer',
+                'asunto' => 'Activo digital por vencer en {{dias}} dias: {{nombre_activo}}',
+                'variables_disponibles' => ['nombre', 'nombre_activo', 'codigo', 'proveedor', 'fecha_vencimiento', 'dias', 'empresa'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>El siguiente activo digital esta por vencer y requiere renovacion:</p>
+<p><strong>{{nombre_activo}}</strong> ({{codigo}})<br>
+<strong>Proveedor:</strong> {{proveedor}}<br>
+<strong>Vence:</strong> {{fecha_vencimiento}} (en {{dias}} dias)</p>
+<p>Por favor coordina la renovacion o el pago para evitar la suspension del servicio.</p>
+HTML,
+            ],
+            [
+                'slug' => 'activo-vencido',
+                'nombre' => 'Activo digital vencido',
+                'asunto' => 'Activo digital VENCIDO: {{nombre_activo}}',
+                'variables_disponibles' => ['nombre', 'nombre_activo', 'codigo', 'proveedor', 'fecha_vencimiento', 'empresa'],
+                'contenido' => <<<'HTML'
+<p>Hola <strong>{{nombre}}</strong>,</p>
+<p>El siguiente activo digital ha <strong>vencido</strong>:</p>
+<p><strong>{{nombre_activo}}</strong> ({{codigo}})<br>
+<strong>Proveedor:</strong> {{proveedor}}<br>
+<strong>Vencio el:</strong> {{fecha_vencimiento}}</p>
+<p>El estado de la cuenta se marco como <strong>Vencido</strong>. Regulariza el pago a la brevedad.</p>
+HTML,
+            ],
         ];
     }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,6 +10,8 @@ Artisan::command('inspire', function () {
 
 Schedule::command('backups:check-alarms')->dailyAt('08:00');
 
+Schedule::command('activos:check-vencimientos')->dailyAt('08:15');
+
 Schedule::command('queue:work --stop-when-empty --max-time=55')
     ->everyMinute()
     ->withoutOverlapping();


### PR DESCRIPTION
## Summary
- **Comando** `activos:check-vencimientos`: marca cuentas recurrentes vencidas (`estado -> vencido`) y avisa de vencimientos proximos a **30/7/1 dias**
- Notifica por email a **admin_empresa + responsables** de cada cuenta (idempotente, no re-marca ni duplica)
- **Plantillas de email** `activo-por-vencer` / `activo-vencido` (seeder, reusa EmailTemplate)
- **Scheduler** diario 08:15
- **Widget de dashboard** "Activos digitales por vencer" (vencidos + proximos 30 dias)

Sexta story de **EP-19: Control de Activos Digitales**.

closes SEN-130

## Verificacion (en vivo)
- Comando detecto AD-001 (30d) y AD-008 Canva (7d); no re-marco los ya vencidos
- **4 correos en MailHog**: WhatsApp(30d)->carlos+maria, Canva(7d)->carlos+pedro
- `schedule:list` muestra la tarea (Next Due 8:15)
- Widget visible en el dashboard con cuentas vencidas/por vencer

## Security checklist
- [x] SQL: Eloquent only
- [x] XSS: emails con strip_tags; widget via componentes Filament
- [x] Auth: widget `canView` por rol; comando solo via scheduler/CLI
- [x] Tenant: widget filtra por tenant; comando recorre por empresa_id

## Functional checklist
- [x] Funcionalidad segun la user story (vencimientos + alertas email + panel)
- [x] Sin errores PHP (lint OK)
- [x] Tests pasan (11 passed)
- [x] Probado en navegador + MailHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)