### PR TITLE
[SEN-131] feat: integracion con registros PSC y equipos

### DIFF
--- a/app/Filament/Resources/ActivosDigitales/Schemas/ActivoDigitalForm.php
+++ b/app/Filament/Resources/ActivosDigitales/Schemas/ActivoDigitalForm.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ActivosDigitales\Schemas;
 use App\Enums\EstadoActivoDigital;
 use App\Enums\ModalidadPago;
 use App\Enums\TipoActivoDigital;
+use App\Models\Registro;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -13,6 +14,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Builder;
 
 class ActivoDigitalForm
 {
@@ -143,6 +145,34 @@ class ActivoDigitalForm
                             ->required()
                             ->native(false),
                     ]),
+
+                Section::make('Vinculacion (PSC / Equipos)')
+                    ->icon('heroicon-o-link')
+                    ->description('Relaciona opcionalmente esta cuenta con un registro de seguridad o un equipo.')
+                    ->columns(2)
+                    ->schema([
+                        Select::make('registro_id')
+                            ->label('Registro de seguridad')
+                            ->relationship(
+                                'registro',
+                                'numero_registro',
+                                fn (Builder $query) => $query->whereIn('tipo_formato', ['F03', 'F07', 'F13']),
+                            )
+                            ->getOptionLabelFromRecordUsing(fn (Registro $r): string => "{$r->numero_registro} ({$r->tipo_formato})")
+                            ->searchable()
+                            ->preload()
+                            ->placeholder('Sin vincular')
+                            ->helperText('F03 prestadores, F07 inventario, F13 destruccion/baja'),
+                        Select::make('equipo_id')
+                            ->label('Equipo')
+                            ->relationship('equipo', 'codigo_interno')
+                            ->searchable()
+                            ->preload()
+                            ->placeholder('Sin vincular')
+                            ->helperText('Equipo fisico asociado a esta cuenta'),
+                    ])
+                    ->collapsible()
+                    ->collapsed(),
 
                 Section::make('Observaciones')
                     ->schema([

--- a/app/Filament/Resources/ActivosDigitales/Tables/ActivosDigitalesTable.php
+++ b/app/Filament/Resources/ActivosDigitales/Tables/ActivosDigitalesTable.php
@@ -69,6 +69,15 @@ class ActivosDigitalesTable
                     ->badge()
                     ->color(fn (EstadoActivoDigital $state): string => $state->color())
                     ->formatStateUsing(fn (EstadoActivoDigital $state): string => $state->label()),
+                TextColumn::make('vinculo')
+                    ->label('Vinculado a')
+                    ->state(fn ($record): string => collect([
+                        $record->registro?->numero_registro,
+                        $record->equipo?->codigo_interno,
+                    ])->filter()->implode(' · ') ?: '—')
+                    ->badge()
+                    ->color('gray')
+                    ->toggleable(),
                 TextColumn::make('created_at')
                     ->label('Registrado')
                     ->dateTime('d/m/Y')
@@ -93,6 +102,11 @@ class ActivosDigitalesTable
                         ->whereIn('modalidad_pago', [ModalidadPago::Mensual->value, ModalidadPago::Anual->value])
                         ->whereNotNull('fecha_vencimiento')
                         ->whereDate('fecha_vencimiento', '<=', now()->addDays(30))),
+                Filter::make('vinculados')
+                    ->label('Solo vinculados a PSC/equipo')
+                    ->toggle()
+                    ->query(fn (Builder $query): Builder => $query
+                        ->where(fn (Builder $q) => $q->whereNotNull('registro_id')->orWhereNotNull('equipo_id'))),
                 TrashedFilter::make(),
             ])
             ->recordActions([

--- a/app/Filament/Resources/Equipos/EquipoResource.php
+++ b/app/Filament/Resources/Equipos/EquipoResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Equipos;
 use App\Filament\Resources\Equipos\Pages\CreateEquipo;
 use App\Filament\Resources\Equipos\Pages\EditEquipo;
 use App\Filament\Resources\Equipos\Pages\ListEquipos;
+use App\Filament\Resources\Equipos\RelationManagers;
 use App\Filament\Resources\Equipos\Schemas\EquipoForm;
 use App\Filament\Resources\Equipos\Tables\EquiposTable;
 use App\Models\Equipo;
@@ -47,7 +48,9 @@ class EquipoResource extends Resource
 
     public static function getRelations(): array
     {
-        return [];
+        return [
+            RelationManagers\ActivosDigitalesRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/Equipos/RelationManagers/ActivosDigitalesRelationManager.php
+++ b/app/Filament/Resources/Equipos/RelationManagers/ActivosDigitalesRelationManager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Resources\Equipos\RelationManagers;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\TipoActivoDigital;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ActivosDigitalesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'activosDigitales';
+
+    protected static ?string $title = 'Activos digitales vinculados';
+
+    public static function canViewForRecord($ownerRecord, string $pageClass): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('codigo_interno')->label('Codigo'),
+                TextColumn::make('nombre')->label('Cuenta')->limit(30),
+                TextColumn::make('tipo')
+                    ->label('Tipo')
+                    ->badge()
+                    ->formatStateUsing(fn (TipoActivoDigital $state): string => $state->label()),
+                TextColumn::make('estado')
+                    ->label('Estado')
+                    ->badge()
+                    ->color(fn (EstadoActivoDigital $state): string => $state->color())
+                    ->formatStateUsing(fn (EstadoActivoDigital $state): string => $state->label()),
+            ])
+            ->emptyStateHeading('Sin activos digitales vinculados')
+            ->emptyStateDescription('Vincula cuentas desde el modulo de Activos Digitales.');
+    }
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+}

--- a/app/Models/Equipo.php
+++ b/app/Models/Equipo.php
@@ -99,6 +99,11 @@ class Equipo extends Model
         return $this->hasMany(BackupProgramacion::class, 'equipo_id');
     }
 
+    public function activosDigitales(): HasMany
+    {
+        return $this->hasMany(ActivoDigital::class, 'equipo_id');
+    }
+
     public function esTecnologico(): bool
     {
         return $this->categoria === 'tecnologico';

--- a/app/Models/Registro.php
+++ b/app/Models/Registro.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Concerns\BelongsToEmpresa;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Registro extends Model
@@ -47,5 +48,10 @@ class Registro extends Model
     public function equipo(): BelongsTo
     {
         return $this->belongsTo(Equipo::class, 'equipo_id');
+    }
+
+    public function activosDigitales(): HasMany
+    {
+        return $this->hasMany(ActivoDigital::class, 'registro_id');
     }
 }


### PR DESCRIPTION
## Summary
- **Form**: seccion "Vinculacion (PSC / Equipos)" con selectores opcionales de registro de seguridad (filtrado a F03/F07/F13) y equipo
- **Table**: columna "Vinculado a" + filtro "solo vinculados a PSC/equipo"
- **Relaciones inversas**: `Equipo->activosDigitales`, `Registro->activosDigitales`
- **RelationManager read-only** de activos digitales en `EquipoResource` (direccion inversa visible)

Las columnas FK `registro_id`/`equipo_id` ya existian (SEN-126); esta story las expone en la UI en ambas direcciones.

closes SEN-131

## Verificacion (en vivo)
- AD-001 vinculado a INV-2026-001 (F07); la columna "Vinculado a" lo muestra en la tabla
- Relacion inversa `registro->activosDigitales` devuelve 1

## Security checklist
- [x] SQL: Eloquent only (relationship selects con Builder)
- [x] XSS: salida via componentes Filament
- [x] Auth: RelationManager inverso `canViewForRecord` por rol
- [x] Tenant: relaciones respetan Global Scope por empresa
- [x] Uploads: N/A

## Functional checklist
- [x] Funcionalidad segun la user story (referencia bidireccional + filtro)
- [x] Sin errores PHP (lint OK)
- [x] Tests pasan (11 passed)
- [x] Probado en navegador

🤖 Generated with [Claude Code](https://claude.com/claude-code)