### PR TITLE
feat(mcp): ingesta conversacional — servidor MCP + tool de activos digitales (Fase 0)

### DIFF
--- a/app/Console/Commands/McpTokenCommand.php
+++ b/app/Console/Commands/McpTokenCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+/**
+ * Emite un token de API (Sanctum) para conectar un cliente MCP (Claude Code,
+ * Claude Desktop, Cline, etc.) como un usuario concreto. El cliente usará el
+ * token en el header Authorization; cada herramienta correrá como ese usuario
+ * y respetará su empresa (tenant) y permisos.
+ *
+ * Uso: php artisan mcp:token carlos@palacios.pe
+ */
+class McpTokenCommand extends Command
+{
+    protected $signature = 'mcp:token {email : Email del usuario} {--name=cliente-mcp : Nombre/etiqueta del token}';
+
+    protected $description = 'Emite un token de API (Sanctum) para conectar un cliente MCP como el usuario indicado';
+
+    public function handle(): int
+    {
+        $user = User::where('email', $this->argument('email'))->first();
+
+        if (! $user) {
+            $this->error("No existe un usuario con el email {$this->argument('email')}.");
+
+            return self::FAILURE;
+        }
+
+        if (! $user->hasRole(['super_admin', 'admin_empresa'])) {
+            $this->warn('Aviso: este usuario no tiene rol de gestión (super_admin/admin_empresa); los tools de ingesta lo rechazarán.');
+        }
+
+        $token = $user->createToken($this->option('name'))->plainTextToken;
+        $url = rtrim((string) config('app.url'), '/').'/mcp/ingesta';
+        $alcance = $user->empresa_id ? "empresa #{$user->empresa_id}" : 'super admin (todas las empresas)';
+
+        $this->newLine();
+        $this->info("Token para {$user->name} <{$user->email}> — {$alcance}:");
+        $this->line("  {$token}");
+        $this->newLine();
+        $this->comment('Conéctalo en Claude Code (ajusta el host si no es local):');
+        $this->line("  claude mcp add --transport http securiform {$url} --header \"Authorization: Bearer {$token}\"");
+        $this->newLine();
+        $this->comment('El token solo se muestra ahora. Guárdalo en un lugar seguro; revócalo con: $user->tokens()->delete().');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Mcp/Servers/IngestaServer.php
+++ b/app/Mcp/Servers/IngestaServer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\CrearActivoDigitalTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('SecuriForm Ingesta')]
+#[Version('0.1.0')]
+#[Instructions(
+    'Servidor para ingresar información a SecuriForm de forma conversacional. '.
+    'Usa las herramientas para registrar información (hoy: activos digitales; próximamente registros PSC, equipos y empresas). '.
+    'Todas las acciones se ejecutan como el usuario autenticado y respetan su empresa (tenant) y sus permisos. '.
+    'Nunca solicites ni envíes credenciales de acceso (contraseñas/2FA) por este canal.'
+)]
+class IngestaServer extends Server
+{
+    /**
+     * @var array<int, class-string<Tool>>
+     */
+    protected array $tools = [
+        CrearActivoDigitalTool::class,
+    ];
+
+    /**
+     * @var array<int, class-string>
+     */
+    protected array $resources = [
+        //
+    ];
+
+    /**
+     * @var array<int, class-string>
+     */
+    protected array $prompts = [
+        //
+    ];
+}

--- a/app/Mcp/Tools/CrearActivoDigitalTool.php
+++ b/app/Mcp/Tools/CrearActivoDigitalTool.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\ModalidadPago;
+use App\Enums\TipoActivoDigital;
+use App\Services\Ingesta\ActivoDigitalIngestaService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description(
+    'Registra un nuevo activo digital en SecuriForm (cuenta WhatsApp/Meta, suscripción SaaS, '.
+    'dominio, licencia, etc.) para la empresa del usuario autenticado. NO maneja credenciales de acceso.'
+)]
+class CrearActivoDigitalTool extends Tool
+{
+    public function handle(Request $request, ActivoDigitalIngestaService $service): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return Response::error('No autenticado. Configura un token de API válido para usar esta herramienta.');
+        }
+
+        try {
+            $activo = $service->crear($request->all(), $user);
+        } catch (AuthorizationException $e) {
+            return Response::error($e->getMessage());
+        } catch (ValidationException $e) {
+            return Response::error('No se pudo crear el activo: '.collect($e->errors())->flatten()->implode(' '));
+        }
+
+        return Response::text(sprintf(
+            '✅ Activo digital creado: %s — "%s" (%s · %s) para la empresa #%d. Estado: %s. Vencimiento: %s.',
+            $activo->codigo_interno,
+            $activo->nombre,
+            $activo->tipo->label(),
+            $activo->modalidad_pago->label(),
+            $activo->empresa_id,
+            $activo->estado->label(),
+            $activo->fecha_vencimiento?->format('d/m/Y') ?? 'sin vencimiento',
+        ));
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'nombre' => $schema->string()
+                ->description('Nombre de la cuenta o activo, ej. "WhatsApp Ventas", "Google Workspace".')
+                ->required(),
+            'tipo' => $schema->string()
+                ->enum(array_column(TipoActivoDigital::cases(), 'value'))
+                ->description('Tipo: whatsapp, meta, suscripcion_saas, dominio, licencia_unica, correo, redes_sociales, otro.')
+                ->required(),
+            'proveedor' => $schema->string()
+                ->description('Proveedor del servicio, ej. Meta, Google, Adobe, GoDaddy.'),
+            'url' => $schema->string()
+                ->description('URL del panel de acceso, ej. https://business.facebook.com.'),
+            'identificador' => $schema->string()
+                ->description('Cómo se identifica la cuenta en el proveedor: nro de teléfono, email o business ID.'),
+            'modalidad_pago' => $schema->string()
+                ->enum(array_column(ModalidadPago::cases(), 'value'))
+                ->description('Modalidad: mensual, anual, pago_unico, gratuito. Por defecto mensual.'),
+            'costo' => $schema->number()
+                ->description('Costo del periodo (>= 0). Omitir si es gratuito.'),
+            'moneda' => $schema->string()
+                ->enum(['PEN', 'USD', 'EUR'])
+                ->description('Moneda del costo. Por defecto PEN.'),
+            'metodo_pago' => $schema->string()
+                ->description('Método de pago, ej. "Visa ***1234", transferencia, PayPal.'),
+            'renovacion_automatica' => $schema->boolean()
+                ->description('Si la suscripción se renueva automáticamente.'),
+            'estado' => $schema->string()
+                ->enum(array_column(EstadoActivoDigital::cases(), 'value'))
+                ->description('Estado: activo, suspendido, vencido, cancelado. Por defecto activo.'),
+            'nivel_sensibilidad' => $schema->string()
+                ->enum(['publico', 'interno', 'confidencial', 'sensible'])
+                ->description('Nivel de sensibilidad de la información. Por defecto interno.'),
+            'fecha_adquisicion' => $schema->string()
+                ->description('Fecha de adquisición en formato YYYY-MM-DD.'),
+            'fecha_vencimiento' => $schema->string()
+                ->description('Próximo vencimiento/renovación (YYYY-MM-DD). Solo aplica a mensual/anual.'),
+            'observaciones' => $schema->string()
+                ->description('Notas adicionales sobre el activo.'),
+            'empresa_id' => $schema->integer()
+                ->description('Solo para super admin: ID de la empresa destino. Los admin de empresa lo ignoran (usan su propia empresa).'),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,17 +8,19 @@ use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
+use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements FilamentUser, HasTenants
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, HasRoles, Notifiable;
+    use HasApiTokens, HasFactory, HasRoles, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -153,7 +155,7 @@ class User extends Authenticatable implements FilamentUser, HasTenants
         return collect();
     }
 
-    public function canAccessTenant(\Illuminate\Database\Eloquent\Model $tenant): bool
+    public function canAccessTenant(Model $tenant): bool
     {
         if ($this->hasRole(['super_admin', 'agente_helpdesk'])) {
             return true;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,15 @@
 
 namespace App\Providers;
 
+use App\Models\ActivoDigital;
 use App\Models\Empresa;
+use App\Models\Politica;
 use App\Models\Registro;
 use App\Models\Ticket;
 use App\Models\User;
 use App\Observers\AuditableObserver;
+use App\Observers\PoliticaObserver;
+use App\Observers\RegistroObserver;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -30,10 +34,11 @@ class AppServiceProvider extends ServiceProvider
         }
 
         Registro::observe(AuditableObserver::class);
-        Registro::observe(\App\Observers\RegistroObserver::class);
+        Registro::observe(RegistroObserver::class);
         Ticket::observe(AuditableObserver::class);
         Empresa::observe(AuditableObserver::class);
         User::observe(AuditableObserver::class);
-        \App\Models\Politica::observe(\App\Observers\PoliticaObserver::class);
+        ActivoDigital::observe(AuditableObserver::class);
+        Politica::observe(PoliticaObserver::class);
     }
 }

--- a/app/Services/Ingesta/ActivoDigitalIngestaService.php
+++ b/app/Services/Ingesta/ActivoDigitalIngestaService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Services\Ingesta;
+
+use App\Enums\EstadoActivoDigital;
+use App\Enums\ModalidadPago;
+use App\Enums\TipoActivoDigital;
+use App\Models\ActivoDigital;
+use App\Models\Empresa;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Núcleo de ingesta de Activos Digitales: valida, autoriza y persiste un
+ * activo respetando el tenant del actor. Es agnóstico del canal — hoy lo
+ * usa el servidor MCP; mañana el chat in-app puede reusar el mismo método.
+ *
+ * La auditoría la registra automáticamente AuditableObserver (ver
+ * AppServiceProvider), por lo que aquí no se llama a AuditService.
+ */
+class ActivoDigitalIngestaService
+{
+    /** Roles autorizados a gestionar (crear) activos digitales. */
+    private const ROLES_GESTION = ['super_admin', 'admin_empresa'];
+
+    /**
+     * @param  array<string,mixed>  $payload
+     *
+     * @throws AuthorizationException si el rol del actor no permite gestionar activos
+     * @throws ValidationException si el payload es inválido o falta la empresa destino
+     */
+    public function crear(array $payload, User $actor): ActivoDigital
+    {
+        if (! $actor->hasRole(self::ROLES_GESTION)) {
+            throw new AuthorizationException(
+                'Tu rol no permite registrar activos digitales (requiere admin de empresa o super admin).'
+            );
+        }
+
+        $empresaId = $this->resolverEmpresa($payload, $actor);
+
+        $data = $this->validar($payload);
+        $data['empresa_id'] = $empresaId;
+
+        return ActivoDigital::create($data);
+    }
+
+    /**
+     * Resuelve la empresa destino. Un admin de empresa solo puede crear en la
+     * suya (nunca en otra); un super admin debe indicar empresa_id explícito.
+     *
+     * @param  array<string,mixed>  $payload
+     */
+    private function resolverEmpresa(array $payload, User $actor): int
+    {
+        if ($actor->empresa_id) {
+            return (int) $actor->empresa_id;
+        }
+
+        $empresaId = $payload['empresa_id'] ?? null;
+
+        if (! $empresaId || ! Empresa::query()->whereKey($empresaId)->exists()) {
+            throw ValidationException::withMessages([
+                'empresa_id' => 'Como super admin debes indicar un empresa_id válido (la empresa destino).',
+            ]);
+        }
+
+        return (int) $empresaId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function validar(array $payload): array
+    {
+        $data = Validator::make($payload, [
+            'nombre' => ['required', 'string', 'max:255'],
+            'tipo' => ['required', Rule::enum(TipoActivoDigital::class)],
+            'proveedor' => ['nullable', 'string', 'max:255'],
+            'url' => ['nullable', 'url', 'max:255'],
+            'identificador' => ['nullable', 'string', 'max:255'],
+            'modalidad_pago' => ['nullable', Rule::enum(ModalidadPago::class)],
+            'costo' => ['nullable', 'numeric', 'min:0'],
+            'moneda' => ['nullable', 'in:PEN,USD,EUR'],
+            'metodo_pago' => ['nullable', 'string', 'max:255'],
+            'renovacion_automatica' => ['nullable', 'boolean'],
+            'estado' => ['nullable', Rule::enum(EstadoActivoDigital::class)],
+            'nivel_sensibilidad' => ['nullable', 'in:publico,interno,confidencial,sensible'],
+            'fecha_adquisicion' => ['nullable', 'date'],
+            'fecha_vencimiento' => ['nullable', 'date'],
+            'observaciones' => ['nullable', 'string'],
+        ])->validate();
+
+        // Defaults coherentes con el formulario de Filament (ActivoDigitalForm).
+        $data['modalidad_pago'] ??= ModalidadPago::Mensual->value;
+        $data['moneda'] ??= 'PEN';
+        $data['estado'] ??= EstadoActivoDigital::Activo->value;
+        $data['nivel_sensibilidad'] ??= 'interno';
+
+        return $data;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,8 @@
         "php": "^8.2",
         "filament/filament": "^5.4",
         "laravel/framework": "^12.0",
+        "laravel/mcp": "^0.7.2",
+        "laravel/sanctum": "^4.3",
         "laravel/tinker": "^2.10.1",
         "mpdf/mpdf": "^8.3",
         "openplain/filament-shadcn-theme": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6b060b1d6f287a05bd2a8d32e580d78",
+    "content-hash": "43302fad4baca83b8779ff7d8dfe64e5",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -2320,6 +2320,80 @@
             "time": "2026-03-26T14:51:54+00:00"
         },
         {
+            "name": "laravel/mcp",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "08962a276357f89164f78b38407c08187ab26cfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/08962a276357f89164f78b38407c08187ab26cfe",
+                "reference": "08962a276357f89164f78b38407c08187ab26cfe",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2",
+                "symfony/process": "^7.4.5|^8.0.5"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-05-22T11:45:29+00:00"
+        },
+        {
             "name": "laravel/prompts",
             "version": "v0.3.16",
             "source": {
@@ -2377,6 +2451,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.16"
             },
             "time": "2026-03-23T14:35:33+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-04-30T11:46:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/database/migrations/2026_06_04_150414_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_06_04_150414_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Mcp\Servers\IngestaServer;
+use Laravel\Mcp\Facades\Mcp;
+
+/*
+|--------------------------------------------------------------------------
+| MCP Servers
+|--------------------------------------------------------------------------
+|
+| Servidor de ingesta conversacional. Se autentica con un token de API de
+| Sanctum (header Authorization: Bearer <token>); cada herramienta corre
+| como el usuario del token y respeta su empresa (tenant) y permisos.
+|
+*/
+
+Mcp::web('/mcp/ingesta', IngestaServer::class)
+    ->middleware('auth:sanctum');

--- a/tests/Feature/Mcp/CrearActivoDigitalToolTest.php
+++ b/tests/Feature/Mcp/CrearActivoDigitalToolTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\Servers\IngestaServer;
+use App\Mcp\Tools\CrearActivoDigitalTool;
+use App\Models\Empresa;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CrearActivoDigitalToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    private function empresa(string $ruc): Empresa
+    {
+        return Empresa::create(['ruc' => $ruc, 'razon_social' => 'Empresa '.$ruc]);
+    }
+
+    private function usuarioCon(string $rol, ?int $empresaId): User
+    {
+        $user = User::create([
+            'name' => ucfirst($rol),
+            'email' => $rol.'-'.uniqid().'@test.local',
+            'password' => 'secret123',
+            'empresa_id' => $empresaId,
+            'estado' => 'activo',
+        ]);
+        $user->syncRoles($rol);
+
+        return $user;
+    }
+
+    public function test_admin_empresa_crea_activo_en_su_empresa_y_audita(): void
+    {
+        $empresa = $this->empresa('20100000001');
+        $admin = $this->usuarioCon('admin_empresa', $empresa->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearActivoDigitalTool::class, [
+                'nombre' => 'WhatsApp Ventas',
+                'tipo' => 'whatsapp',
+                'modalidad_pago' => 'mensual',
+                'costo' => 120,
+            ])
+            ->assertOk()
+            ->assertSee('Activo digital creado');
+
+        $this->assertDatabaseHas('activos_digitales', [
+            'empresa_id' => $empresa->id,
+            'nombre' => 'WhatsApp Ventas',
+            'tipo' => 'whatsapp',
+            'estado' => 'activo', // default aplicado por el servicio
+        ]);
+
+        // La creación quedó auditada por AuditableObserver.
+        $this->assertDatabaseHas('audit_logs', [
+            'entidad' => 'activos_digitales',
+            'accion' => 'crear',
+        ]);
+    }
+
+    public function test_usuario_sin_rol_de_gestion_es_rechazado(): void
+    {
+        $empresa = $this->empresa('20100000002');
+        $usuario = $this->usuarioCon('usuario', $empresa->id);
+
+        IngestaServer::actingAs($usuario)
+            ->tool(CrearActivoDigitalTool::class, [
+                'nombre' => 'No permitido',
+                'tipo' => 'otro',
+            ])
+            ->assertHasErrors();
+
+        $this->assertDatabaseCount('activos_digitales', 0);
+    }
+
+    public function test_admin_empresa_no_puede_crear_en_otra_empresa(): void
+    {
+        $propia = $this->empresa('20100000003');
+        $otra = $this->empresa('20100000004');
+        $admin = $this->usuarioCon('admin_empresa', $propia->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearActivoDigitalTool::class, [
+                'nombre' => 'Intento cross-tenant',
+                'tipo' => 'suscripcion_saas',
+                'empresa_id' => $otra->id, // debe ignorarse
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('activos_digitales', [
+            'nombre' => 'Intento cross-tenant',
+            'empresa_id' => $propia->id,
+        ]);
+        $this->assertDatabaseMissing('activos_digitales', [
+            'nombre' => 'Intento cross-tenant',
+            'empresa_id' => $otra->id,
+        ]);
+    }
+
+    public function test_super_admin_requiere_empresa_id_explicito(): void
+    {
+        $super = $this->usuarioCon('super_admin', null);
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearActivoDigitalTool::class, [
+                'nombre' => 'Sin empresa',
+                'tipo' => 'otro',
+            ])
+            ->assertHasErrors();
+
+        $empresa = $this->empresa('20100000005');
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearActivoDigitalTool::class, [
+                'nombre' => 'Con empresa',
+                'tipo' => 'otro',
+                'empresa_id' => $empresa->id,
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('activos_digitales', [
+            'nombre' => 'Con empresa',
+            'empresa_id' => $empresa->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Fase 0 — Plomería del feature de **ingesta conversacional**

Levanta el **motor de ingesta reusable** + un **servidor MCP** (paquete oficial `laravel/mcp`) autenticado con Sanctum, con el primer tool funcionando de punta a punta: **crear activo digital**.

El razonamiento conversacional lo hace el **cliente MCP (tu Claude)**; el servidor solo valida y persiste → **sin costo de API de IA** en esta fase.

### Arquitectura (core + canales)
```
Claude (cliente MCP)  →  /mcp/ingesta (auth:sanctum)  →  CrearActivoDigitalTool
                                                              ↓
                                              ActivoDigitalIngestaService  ← motor reusable
                                              (valida · autoriza · tenant · audit)
                                                              ↓  Eloquent
```
El `ActivoDigitalIngestaService` es **agnóstico de canal**: mañana el chat in-app (Fase 2) lo reusa tal cual.

### Qué incluye
- **`ActivoDigitalIngestaService`**: valida el payload, autoriza por rol (`super_admin`/`admin_empresa`), resuelve la empresa destino (propia para admin de empresa; **explícita** para super admin) y crea el activo respetando el tenant.
- **Servidor MCP** `IngestaServer` + tool `CrearActivoDigitalTool` (schema tipado con enums), montado en `/mcp/ingesta` con `auth:sanctum`.
- **Sanctum**: `User` usa `HasApiTokens`; migración `personal_access_tokens`.
- **Auditoría**: `ActivoDigital` ahora se audita vía `AuditableObserver` (cierra un hueco real en una entidad sensible; auditoría consistente entre Filament y MCP).

### Seguridad
- Token **por usuario** → cada tool corre como ese usuario y respeta empresa + permisos.
- Un `admin_empresa` **no puede** crear en otra empresa (el `empresa_id` del payload se ignora para él).
- El servidor instruye **nunca** enviar credenciales (contraseñas/2FA) por este canal.

### Pruebas
- HTTP real: sin token → **401**; con token Sanctum → **200** (handshake `initialize` OK).
- 4 tests del camino MCP: creación + auditoría, rechazo por rol, aislamiento por tenant, super_admin requiere `empresa_id`. **Suite: 15 passed.**

### Cómo probarlo (cliente MCP local)
```bash
# 1) generar un token para un usuario admin de empresa
docker compose exec app php artisan tinker --execute="echo \App\Models\User::where('email','carlos@palacios.pe')->first()->createToken('claude-code')->plainTextToken;"

# 2) registrar el server en Claude Code
claude mcp add --transport http securiform http://localhost:8082/mcp/ingesta --header "Authorization: Bearer <TOKEN>"

# 3) en el chat: "registra un activo: WhatsApp Ventas, tipo whatsapp, mensual, 120 PEN, vence el 30/07/2026"
```

### Próximo (Fase 1)
Más tools sobre el mismo motor: **registros PSC (13 formatos)**, **equipos (PCs)** y **empresas/usuarios**. Y un comando `mcp:token` para emitir tokens sin tinker.

> Nota: no incluye cambios ajenos en curso (PoliticaSeeder/empresa) que estaban en el working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)