### PR TITLE
feat(mcp): Fase 1 — registros PSC + equipos + usuarios por MCP

### DIFF
--- a/app/Mcp/Servers/IngestaServer.php
+++ b/app/Mcp/Servers/IngestaServer.php
@@ -3,7 +3,9 @@
 namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\CrearActivoDigitalTool;
+use App\Mcp\Tools\CrearEquipoTool;
 use App\Mcp\Tools\CrearRegistroTool;
+use App\Mcp\Tools\CrearUsuarioTool;
 use App\Mcp\Tools\FormatosRegistroTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
@@ -12,10 +14,10 @@ use Laravel\Mcp\Server\Attributes\Version;
 use Laravel\Mcp\Server\Tool;
 
 #[Name('SecuriForm Ingesta')]
-#[Version('0.2.0')]
+#[Version('0.3.0')]
 #[Instructions(
     'Servidor para ingresar información a SecuriForm de forma conversacional. '.
-    'Hoy puedes registrar activos digitales y registros de seguridad PSC (13 formatos F01–F13); próximamente equipos y empresas. '.
+    'Puedes registrar: activos digitales, registros de seguridad PSC (13 formatos F01–F13, incluye incidencias F09), equipos del inventario y usuarios. '.
     'Para registros, primero consulta formatos-registro para saber los campos del formato, luego usa crear-registro. '.
     'Todas las acciones se ejecutan como el usuario autenticado y respetan su empresa (tenant) y sus permisos. '.
     'Nunca solicites ni envíes credenciales de acceso (contraseñas/2FA) por este canal.'
@@ -29,6 +31,8 @@ class IngestaServer extends Server
         CrearActivoDigitalTool::class,
         FormatosRegistroTool::class,
         CrearRegistroTool::class,
+        CrearEquipoTool::class,
+        CrearUsuarioTool::class,
     ];
 
     /**

--- a/app/Mcp/Servers/IngestaServer.php
+++ b/app/Mcp/Servers/IngestaServer.php
@@ -3,6 +3,8 @@
 namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\CrearActivoDigitalTool;
+use App\Mcp\Tools\CrearRegistroTool;
+use App\Mcp\Tools\FormatosRegistroTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
 use Laravel\Mcp\Server\Attributes\Name;
@@ -10,10 +12,11 @@ use Laravel\Mcp\Server\Attributes\Version;
 use Laravel\Mcp\Server\Tool;
 
 #[Name('SecuriForm Ingesta')]
-#[Version('0.1.0')]
+#[Version('0.2.0')]
 #[Instructions(
     'Servidor para ingresar información a SecuriForm de forma conversacional. '.
-    'Usa las herramientas para registrar información (hoy: activos digitales; próximamente registros PSC, equipos y empresas). '.
+    'Hoy puedes registrar activos digitales y registros de seguridad PSC (13 formatos F01–F13); próximamente equipos y empresas. '.
+    'Para registros, primero consulta formatos-registro para saber los campos del formato, luego usa crear-registro. '.
     'Todas las acciones se ejecutan como el usuario autenticado y respetan su empresa (tenant) y sus permisos. '.
     'Nunca solicites ni envíes credenciales de acceso (contraseñas/2FA) por este canal.'
 )]
@@ -24,6 +27,8 @@ class IngestaServer extends Server
      */
     protected array $tools = [
         CrearActivoDigitalTool::class,
+        FormatosRegistroTool::class,
+        CrearRegistroTool::class,
     ];
 
     /**

--- a/app/Mcp/Tools/CrearActivoDigitalTool.php
+++ b/app/Mcp/Tools/CrearActivoDigitalTool.php
@@ -12,8 +12,10 @@ use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tool;
 
+#[Name('crear-activo-digital')]
 #[Description(
     'Registra un nuevo activo digital en SecuriForm (cuenta WhatsApp/Meta, suscripción SaaS, '.
     'dominio, licencia, etc.) para la empresa del usuario autenticado. NO maneja credenciales de acceso.'

--- a/app/Mcp/Tools/CrearEquipoTool.php
+++ b/app/Mcp/Tools/CrearEquipoTool.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Services\Ingesta\EquipoIngestaService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('crear-equipo')]
+#[Description(
+    'Registra un equipo en el inventario de SecuriForm (PC, laptop, impresora, servidor, USB, '.
+    'expediente físico, etc.) para la empresa del usuario autenticado. El código interno (EQ-001) '.
+    'se genera automáticamente si no se indica.'
+)]
+class CrearEquipoTool extends Tool
+{
+    public function handle(Request $request, EquipoIngestaService $service): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return Response::error('No autenticado. Configura un token de API válido para usar esta herramienta.');
+        }
+
+        try {
+            $equipo = $service->crear($request->all(), $user);
+        } catch (AuthorizationException $e) {
+            return Response::error($e->getMessage());
+        } catch (ValidationException $e) {
+            return Response::error('No se pudo registrar el equipo: '.collect($e->errors())->flatten()->implode(' '));
+        }
+
+        return Response::text(sprintf(
+            '✅ Equipo registrado: %s — %s %s (%s) para la empresa #%d. Estado: %s.',
+            $equipo->codigo_interno,
+            $equipo->marca ?: 's/marca',
+            $equipo->modelo ?: '',
+            $equipo->tipo,
+            $equipo->empresa_id,
+            $equipo->estado,
+        ));
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'tipo' => $schema->string()
+                ->enum(['pc_escritorio', 'laptop', 'impresora', 'servidor', 'usb', 'disco_externo', 'telefono', 'tablet', 'dispositivo_red', 'dvd_cd', 'expediente_fisico', 'soporte_nube', 'otro'])
+                ->description('Tipo de equipo o soporte.')
+                ->required(),
+            'marca' => $schema->string()->description('Marca, ej. Lenovo, HP, Dell.'),
+            'modelo' => $schema->string()->description('Modelo, ej. ThinkPad T14.'),
+            'numero_serie' => $schema->string()->description('Número de serie (único). Opcional.'),
+            'codigo_interno' => $schema->string()->description('Código de inventario. Si lo omites se genera EQ-XXX.'),
+            'categoria' => $schema->string()->enum(['tecnologico', 'no_tecnologico'])->description('Categoría del activo. Por defecto tecnologico.'),
+            'clasificacion_soporte' => $schema->string()->enum(['hdd_interno', 'hdd_externo', 'usb', 'servidor', 'nube', 'dvd', 'expediente_fisico', 'otro'])->description('Clasificación del soporte de información.'),
+            'contenido_datos' => $schema->string()->description('Descripción de los datos que almacena.'),
+            'sistema_operativo' => $schema->string()->description('Sistema operativo (solo equipos tecnológicos).'),
+            'procesador' => $schema->string()->description('Procesador (solo equipos tecnológicos).'),
+            'ram_gb' => $schema->integer()->description('RAM en GB.'),
+            'disco_gb' => $schema->integer()->description('Disco en GB.'),
+            'ubicacion' => $schema->string()->description('Ubicación física, ej. "Oficina principal - Piso 2".'),
+            'estado' => $schema->string()->enum(['activo', 'mantenimiento', 'obsoleto', 'dado_de_baja'])->description('Estado. Por defecto activo.'),
+            'nivel_sensibilidad' => $schema->string()->enum(['publico', 'interno', 'confidencial', 'sensible'])->description('Sensibilidad de la información. Por defecto interno.'),
+            'fecha_adquisicion' => $schema->string()->description('Fecha de adquisición (YYYY-MM-DD).'),
+            'fecha_garantia' => $schema->string()->description('Vencimiento de garantía (YYYY-MM-DD).'),
+            'observaciones' => $schema->string()->description('Notas adicionales.'),
+            'empresa_id' => $schema->integer()->description('Solo para super admin: ID de la empresa destino.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/CrearRegistroTool.php
+++ b/app/Mcp/Tools/CrearRegistroTool.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\TipoFormato;
+use App\Services\Ingesta\RegistroIngestaService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('crear-registro')]
+#[Description(
+    'Crea un registro de seguridad PSC (uno de los 13 formatos F01–F13) para la empresa del usuario autenticado. '.
+    'Si no conoces los campos exactos del formato, llama antes a formatos-registro. '.
+    'El número de registro (p. ej. INC-2026-004) se genera automáticamente.'
+)]
+class CrearRegistroTool extends Tool
+{
+    public function handle(Request $request, RegistroIngestaService $service): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return Response::error('No autenticado. Configura un token de API válido para usar esta herramienta.');
+        }
+
+        $empresaId = $request->get('empresa_id');
+
+        try {
+            $registro = $service->crear(
+                (string) $request->get('tipo_formato'),
+                (array) ($request->get('datos') ?? []),
+                $user,
+                $empresaId !== null ? (int) $empresaId : null,
+            );
+        } catch (AuthorizationException $e) {
+            return Response::error($e->getMessage());
+        } catch (ValidationException $e) {
+            return Response::error('No se pudo crear el registro: '.collect($e->errors())->flatten()->implode(' '));
+        }
+
+        return Response::text(sprintf(
+            '✅ Registro creado: %s (%s) para la empresa #%d. Estado: %s.',
+            $registro->numero_registro,
+            $registro->tipo_formato,
+            $registro->empresa_id,
+            $registro->estado,
+        ));
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'tipo_formato' => $schema->string()
+                ->enum(array_column(TipoFormato::cases(), 'value'))
+                ->description('Código del formato de seguridad: F01–F13 (ver formatos-registro).')
+                ->required(),
+            'datos' => $schema->object()
+                ->description('Objeto con los campos del formato (consulta formatos-registro para saber cuáles). Fechas en YYYY-MM-DD, fecha/hora en YYYY-MM-DD HH:MM.')
+                ->required(),
+            'empresa_id' => $schema->integer()
+                ->description('Solo para super admin: ID de la empresa destino. Los demás roles lo ignoran (usan su propia empresa).'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/CrearUsuarioTool.php
+++ b/app/Mcp/Tools/CrearUsuarioTool.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Services\Ingesta\UsuarioIngestaService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('crear-usuario')]
+#[Description(
+    'Crea un usuario en SecuriForm. Solo super admin y admin de empresa pueden usarlo. '.
+    'Un admin de empresa solo crea usuarios de SU empresa con roles de empresa (admin_empresa, usuario, solo_lectura). '.
+    'Si no envías contraseña se genera una y el usuario deberá establecerla con "Olvidé mi contraseña". '.
+    'Nunca se devuelve la contraseña.'
+)]
+class CrearUsuarioTool extends Tool
+{
+    public function handle(Request $request, UsuarioIngestaService $service): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return Response::error('No autenticado. Configura un token de API válido para usar esta herramienta.');
+        }
+
+        try {
+            $nuevo = $service->crear($request->all(), $user);
+        } catch (AuthorizationException $e) {
+            return Response::error($e->getMessage());
+        } catch (ValidationException $e) {
+            return Response::error('No se pudo crear el usuario: '.collect($e->errors())->flatten()->implode(' '));
+        }
+
+        $passwordPropia = filled($request->get('password'));
+        $nota = $passwordPropia
+            ? 'Contraseña establecida.'
+            : 'Sin contraseña enviada: el usuario debe establecerla con "Olvidé mi contraseña".';
+
+        return Response::text(sprintf(
+            '✅ Usuario creado: %s <%s> — rol %s, %s. %s',
+            $nuevo->name,
+            $nuevo->email,
+            $nuevo->rol,
+            $nuevo->empresa_id ? "empresa #{$nuevo->empresa_id}" : 'sin empresa (staff)',
+            $nota,
+        ));
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->description('Nombre completo del usuario.')->required(),
+            'email' => $schema->string()->description('Correo (único).')->required(),
+            'rol' => $schema->string()
+                ->enum(['super_admin', 'agente_helpdesk', 'admin_empresa', 'usuario', 'solo_lectura'])
+                ->description('Rol. Un admin de empresa solo puede asignar admin_empresa, usuario o solo_lectura.')
+                ->required(),
+            'estado' => $schema->string()->enum(['activo', 'inactivo'])->description('Estado. Por defecto activo.'),
+            'password' => $schema->string()->description('Contraseña inicial (mín. 8). Si la omites se genera una y no se devuelve.'),
+            'empresa_id' => $schema->integer()->description('Empresa del usuario. Solo super admin la indica; un admin de empresa siempre crea en la suya. Los roles de staff (super_admin/agente_helpdesk) van sin empresa.'),
+            'dni' => $schema->string()->description('DNI / documento. Opcional.'),
+            'telefono' => $schema->string()->description('Teléfono. Opcional.'),
+            'puesto' => $schema->string()->description('Puesto / cargo. Opcional.'),
+            'direccion' => $schema->string()->description('Dirección. Opcional.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/FormatosRegistroTool.php
+++ b/app/Mcp/Tools/FormatosRegistroTool.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\TipoFormato;
+use App\Services\RegistroSchemaService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('formatos-registro')]
+#[Description(
+    'Consulta los formatos de seguridad PSC (F01–F13). Sin argumentos lista los 13 con su nombre y para qué sirven. '.
+    'Con tipo_formato=<código> devuelve los campos exactos de ese formato (obligatorios/opcionales y opciones válidas). '.
+    'Úsalo antes de crear-registro para saber qué datos enviar.'
+)]
+class FormatosRegistroTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $arg = $request->get('tipo_formato');
+
+        if ($arg) {
+            $tipo = TipoFormato::tryFrom(strtoupper(trim((string) $arg)));
+
+            if (! $tipo) {
+                return Response::error('Formato inválido. Códigos válidos: F01 a F13.');
+            }
+
+            $lineas = ["Campos de {$tipo->label()} (prefijo {$tipo->prefix()}, {$tipo->psc()}):"];
+
+            foreach (RegistroSchemaService::fields($tipo) as $campo) {
+                $req = $campo['required'] ? 'OBLIGATORIO' : 'opcional';
+                $opciones = $campo['options'] ? ' — opciones: '.implode(', ', $campo['options']) : '';
+                $lineas[] = "- {$campo['name']} ({$req}, {$campo['type']}): {$campo['label']}{$opciones}";
+            }
+
+            $lineas[] = '';
+            $lineas[] = 'Envía estos campos dentro del objeto "datos" en crear-registro. Fechas en YYYY-MM-DD (o YYYY-MM-DD HH:MM para fecha/hora).';
+
+            return Response::text(implode("\n", $lineas));
+        }
+
+        $lineas = ['Formatos de seguridad PSC disponibles (usa el código en crear-registro):'];
+
+        foreach (TipoFormato::cases() as $tipo) {
+            $lineas[] = "- {$tipo->value} ({$tipo->prefix()}) {$tipo->label()}: {$tipo->description()}";
+        }
+
+        $lineas[] = '';
+        $lineas[] = 'Llama de nuevo con tipo_formato=<código> para ver los campos exactos de un formato.';
+
+        return Response::text(implode("\n", $lineas));
+    }
+
+    /**
+     * @return array<string, JsonSchema>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'tipo_formato' => $schema->string()
+                ->enum(array_column(TipoFormato::cases(), 'value'))
+                ->description('Código del formato (F01–F13) para ver sus campos. Omítelo para listar los 13 formatos.'),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\ActivoDigital;
 use App\Models\Empresa;
+use App\Models\Equipo;
 use App\Models\Politica;
 use App\Models\Registro;
 use App\Models\Ticket;
@@ -39,6 +40,7 @@ class AppServiceProvider extends ServiceProvider
         Empresa::observe(AuditableObserver::class);
         User::observe(AuditableObserver::class);
         ActivoDigital::observe(AuditableObserver::class);
+        Equipo::observe(AuditableObserver::class);
         Politica::observe(PoliticaObserver::class);
     }
 }

--- a/app/Services/Ingesta/ActivoDigitalIngestaService.php
+++ b/app/Services/Ingesta/ActivoDigitalIngestaService.php
@@ -6,8 +6,8 @@ use App\Enums\EstadoActivoDigital;
 use App\Enums\ModalidadPago;
 use App\Enums\TipoActivoDigital;
 use App\Models\ActivoDigital;
-use App\Models\Empresa;
 use App\Models\User;
+use App\Services\Ingesta\Concerns\ResuelveEmpresa;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -23,6 +23,8 @@ use Illuminate\Validation\ValidationException;
  */
 class ActivoDigitalIngestaService
 {
+    use ResuelveEmpresa;
+
     /** Roles autorizados a gestionar (crear) activos digitales. */
     private const ROLES_GESTION = ['super_admin', 'admin_empresa'];
 
@@ -40,35 +42,12 @@ class ActivoDigitalIngestaService
             );
         }
 
-        $empresaId = $this->resolverEmpresa($payload, $actor);
+        $empresaId = $this->resolverEmpresa($actor, isset($payload['empresa_id']) ? (int) $payload['empresa_id'] : null);
 
         $data = $this->validar($payload);
         $data['empresa_id'] = $empresaId;
 
         return ActivoDigital::create($data);
-    }
-
-    /**
-     * Resuelve la empresa destino. Un admin de empresa solo puede crear en la
-     * suya (nunca en otra); un super admin debe indicar empresa_id explícito.
-     *
-     * @param  array<string,mixed>  $payload
-     */
-    private function resolverEmpresa(array $payload, User $actor): int
-    {
-        if ($actor->empresa_id) {
-            return (int) $actor->empresa_id;
-        }
-
-        $empresaId = $payload['empresa_id'] ?? null;
-
-        if (! $empresaId || ! Empresa::query()->whereKey($empresaId)->exists()) {
-            throw ValidationException::withMessages([
-                'empresa_id' => 'Como super admin debes indicar un empresa_id válido (la empresa destino).',
-            ]);
-        }
-
-        return (int) $empresaId;
     }
 
     /**

--- a/app/Services/Ingesta/Concerns/ResuelveEmpresa.php
+++ b/app/Services/Ingesta/Concerns/ResuelveEmpresa.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Ingesta\Concerns;
+
+use App\Models\Empresa;
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Resuelve la empresa destino de una ingesta respetando el tenant:
+ *  - admin_empresa/usuario → siempre su propia empresa (no pueden elegir otra).
+ *  - super_admin (sin empresa propia) → debe indicar un empresa_id válido.
+ */
+trait ResuelveEmpresa
+{
+    protected function resolverEmpresa(User $actor, ?int $empresaId): int
+    {
+        if ($actor->empresa_id) {
+            return (int) $actor->empresa_id;
+        }
+
+        if (! $empresaId || ! Empresa::query()->whereKey($empresaId)->exists()) {
+            throw ValidationException::withMessages([
+                'empresa_id' => 'Como super admin debes indicar un empresa_id válido (la empresa destino).',
+            ]);
+        }
+
+        return (int) $empresaId;
+    }
+}

--- a/app/Services/Ingesta/EquipoIngestaService.php
+++ b/app/Services/Ingesta/EquipoIngestaService.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Services\Ingesta;
+
+use App\Models\Equipo;
+use App\Models\EquipoAsignacion;
+use App\Models\User;
+use App\Services\Ingesta\Concerns\ResuelveEmpresa;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Núcleo de ingesta de Equipos (inventario de PCs/hardware/soportes). Valida,
+ * autoriza por rol, resuelve el tenant, genera el código interno (EQ-XXX) y
+ * registra el asiento de "ingreso_nuevo" en el historial. Agnóstico de canal.
+ *
+ * La auditoría la registra AuditableObserver al crear el modelo.
+ */
+class EquipoIngestaService
+{
+    use ResuelveEmpresa;
+
+    private const ROLES_GESTION = ['super_admin', 'admin_empresa'];
+
+    private const TIPOS = [
+        'pc_escritorio', 'laptop', 'impresora', 'servidor', 'usb', 'disco_externo',
+        'telefono', 'tablet', 'dispositivo_red', 'dvd_cd', 'expediente_fisico', 'soporte_nube', 'otro',
+    ];
+
+    private const ESTADOS = ['activo', 'mantenimiento', 'obsoleto', 'dado_de_baja'];
+
+    private const CATEGORIAS = ['tecnologico', 'no_tecnologico'];
+
+    private const SENSIBILIDAD = ['publico', 'interno', 'confidencial', 'sensible'];
+
+    private const CLASIFICACION = ['hdd_interno', 'hdd_externo', 'usb', 'servidor', 'nube', 'dvd', 'expediente_fisico', 'otro'];
+
+    /**
+     * @param  array<string,mixed>  $payload
+     *
+     * @throws AuthorizationException si el rol no permite gestionar equipos
+     * @throws ValidationException si el payload es inválido
+     */
+    public function crear(array $payload, User $actor): Equipo
+    {
+        if (! $actor->hasRole(self::ROLES_GESTION)) {
+            throw new AuthorizationException('Tu rol no permite registrar equipos (requiere admin de empresa o super admin).');
+        }
+
+        $empresaId = $this->resolverEmpresa($actor, isset($payload['empresa_id']) ? (int) $payload['empresa_id'] : null);
+
+        $data = Validator::make($payload, [
+            'tipo' => ['required', Rule::in(self::TIPOS)],
+            'marca' => ['nullable', 'string', 'max:255'],
+            'modelo' => ['nullable', 'string', 'max:255'],
+            'numero_serie' => ['nullable', 'string', 'max:255', Rule::unique('equipos', 'numero_serie')],
+            'codigo_interno' => ['nullable', 'string', 'max:255'],
+            'categoria' => ['nullable', Rule::in(self::CATEGORIAS)],
+            'clasificacion_soporte' => ['nullable', Rule::in(self::CLASIFICACION)],
+            'contenido_datos' => ['nullable', 'string'],
+            'sistema_operativo' => ['nullable', 'string', 'max:255'],
+            'procesador' => ['nullable', 'string', 'max:255'],
+            'ram_gb' => ['nullable', 'integer', 'min:0'],
+            'disco_gb' => ['nullable', 'integer', 'min:0'],
+            'ubicacion' => ['nullable', 'string', 'max:255'],
+            'estado' => ['nullable', Rule::in(self::ESTADOS)],
+            'nivel_sensibilidad' => ['nullable', Rule::in(self::SENSIBILIDAD)],
+            'fecha_adquisicion' => ['nullable', 'date'],
+            'fecha_garantia' => ['nullable', 'date'],
+            'observaciones' => ['nullable', 'string'],
+        ])->validate();
+
+        $data['empresa_id'] = $empresaId;
+        $data['categoria'] ??= 'tecnologico';
+        $data['estado'] ??= 'activo';
+        $data['nivel_sensibilidad'] ??= 'interno';
+
+        if (empty($data['codigo_interno'])) {
+            $data['codigo_interno'] = $this->generarCodigoInterno($empresaId);
+        }
+
+        $equipo = Equipo::create($data);
+
+        // Registra el ingreso en el historial (igual que CreateEquipo en Filament).
+        EquipoAsignacion::create([
+            'equipo_id' => $equipo->id,
+            'user_id' => null,
+            'tipo' => 'ingreso_nuevo',
+            'fecha_inicio' => now(),
+            'fecha_fin' => now(),
+            'asignado_por' => $actor->id,
+        ]);
+
+        return $equipo;
+    }
+
+    /** Siguiente correlativo EQ-XXX por empresa. */
+    private function generarCodigoInterno(int $empresaId): string
+    {
+        $ultimo = Equipo::withTrashed()
+            ->withoutGlobalScopes()
+            ->where('empresa_id', $empresaId)
+            ->where('codigo_interno', 'like', 'EQ-%')
+            ->orderByDesc('id')
+            ->value('codigo_interno');
+
+        $secuencia = $ultimo ? ((int) substr($ultimo, 3)) + 1 : 1;
+
+        return 'EQ-'.str_pad((string) $secuencia, 3, '0', STR_PAD_LEFT);
+    }
+}

--- a/app/Services/Ingesta/RegistroIngestaService.php
+++ b/app/Services/Ingesta/RegistroIngestaService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services\Ingesta;
+
+use App\Enums\TipoFormato;
+use App\Models\Registro;
+use App\Models\User;
+use App\Services\Ingesta\Concerns\ResuelveEmpresa;
+use App\Services\RegistroNumberService;
+use App\Services\RegistroSchemaService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Núcleo de ingesta de Registros de seguridad (los 13 formatos PSC). Valida el
+ * array `datos` contra el esquema del formato (RegistroSchemaService), autoriza
+ * por rol, resuelve el tenant, genera el número correlativo y persiste.
+ * Agnóstico de canal: hoy lo usa el MCP; mañana el chat in-app.
+ *
+ * La auditoría la registra AuditableObserver; la notificación de incidencias
+ * (F09) la dispara RegistroObserver — ambos automáticos al crear el modelo.
+ */
+class RegistroIngestaService
+{
+    use ResuelveEmpresa;
+
+    /** Roles que pueden crear registros (solo_lectura y agente quedan fuera). */
+    private const ROLES_GESTION = ['super_admin', 'admin_empresa', 'usuario'];
+
+    /**
+     * @param  array<string,mixed>  $datos
+     *
+     * @throws AuthorizationException si el rol no permite crear registros
+     * @throws ValidationException si el formato o los datos son inválidos
+     */
+    public function crear(string $tipoFormato, array $datos, User $actor, ?int $empresaId = null): Registro
+    {
+        if (! $actor->hasRole(self::ROLES_GESTION)) {
+            throw new AuthorizationException('Tu rol no permite crear registros de seguridad.');
+        }
+
+        $tipo = TipoFormato::tryFrom(strtoupper(trim($tipoFormato)));
+
+        if (! $tipo) {
+            throw ValidationException::withMessages([
+                'tipo_formato' => 'Formato inválido. Usa uno de: '.implode(', ', array_column(TipoFormato::cases(), 'value')).'.',
+            ]);
+        }
+
+        $empresaId = $this->resolverEmpresa($actor, $empresaId);
+
+        $validado = Validator::make(
+            ['datos' => $datos],
+            RegistroSchemaService::rules($tipo),
+        )->validate();
+
+        return Registro::create([
+            'empresa_id' => $empresaId,
+            'tipo_formato' => $tipo->value,
+            'numero_registro' => RegistroNumberService::generate($empresaId, $tipo),
+            'datos' => $validado['datos'] ?? [],
+            'estado' => 'activo',
+            'creado_por' => $actor->id,
+        ]);
+    }
+}

--- a/app/Services/Ingesta/UsuarioIngestaService.php
+++ b/app/Services/Ingesta/UsuarioIngestaService.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services\Ingesta;
+
+use App\Models\Empresa;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Núcleo de ingesta de Usuarios. Es el más sensible: aplica guardas contra
+ * escalación de privilegios y aislamiento por empresa.
+ *
+ *  - Solo super_admin y admin_empresa pueden crear usuarios.
+ *  - admin_empresa solo puede asignar roles de empresa (no super_admin ni
+ *    agente_helpdesk) y el usuario queda forzado a SU empresa.
+ *  - super_admin puede asignar cualquier rol; para roles de empresa debe
+ *    indicar empresa_id; los roles de staff (super_admin/agente) van sin empresa.
+ *
+ * El password nunca se devuelve: si no lo dan, se genera uno aleatorio y el
+ * usuario debe establecerlo vía "Olvidé mi contraseña". La creación se audita
+ * por AuditableObserver.
+ */
+class UsuarioIngestaService
+{
+    private const ROLES_GESTION = ['super_admin', 'admin_empresa'];
+
+    /** Roles sin empresa (staff de plataforma). */
+    private const ROLES_STAFF = ['super_admin', 'agente_helpdesk'];
+
+    /**
+     * @param  array<string,mixed>  $payload
+     *
+     * @throws AuthorizationException si el actor no puede crear usuarios
+     * @throws ValidationException si los datos o el rol solicitado no son válidos
+     */
+    public function crear(array $payload, User $actor): User
+    {
+        if (! $actor->hasRole(self::ROLES_GESTION)) {
+            throw new AuthorizationException('Tu rol no permite crear usuarios (requiere admin de empresa o super admin).');
+        }
+
+        $rolesPermitidos = $actor->hasRole('super_admin')
+            ? ['super_admin', 'agente_helpdesk', 'admin_empresa', 'usuario', 'solo_lectura']
+            : ['admin_empresa', 'usuario', 'solo_lectura'];
+
+        $data = Validator::make($payload, [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')],
+            'rol' => ['required', Rule::in($rolesPermitidos)],
+            'estado' => ['nullable', Rule::in(['activo', 'inactivo'])],
+            'password' => ['nullable', 'string', 'min:8'],
+            'empresa_id' => ['nullable', 'integer'],
+            'dni' => ['nullable', 'string', 'max:20'],
+            'telefono' => ['nullable', 'string', 'max:50'],
+            'puesto' => ['nullable', 'string', 'max:255'],
+            'direccion' => ['nullable', 'string', 'max:255'],
+        ], [
+            'rol.in' => 'Tu rol no permite asignar ese rol al nuevo usuario.',
+        ])->validate();
+
+        $empresaId = $this->resolverEmpresaUsuario($data['rol'], $actor, isset($data['empresa_id']) ? (int) $data['empresa_id'] : null);
+
+        $usuario = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => $data['password'] ?? Str::password(16),
+            'empresa_id' => $empresaId,
+            'rol' => $data['rol'],
+            'estado' => $data['estado'] ?? 'activo',
+            'dni' => $data['dni'] ?? null,
+            'telefono' => $data['telefono'] ?? null,
+            'puesto' => $data['puesto'] ?? null,
+            'direccion' => $data['direccion'] ?? null,
+        ]);
+
+        $usuario->syncRoles($data['rol']);
+
+        return $usuario;
+    }
+
+    /**
+     * Resuelve la empresa del NUEVO usuario según su rol y el actor.
+     */
+    private function resolverEmpresaUsuario(string $rol, User $actor, ?int $empresaId): ?int
+    {
+        // Roles de staff de plataforma: sin empresa.
+        if (in_array($rol, self::ROLES_STAFF, true)) {
+            return null;
+        }
+
+        // admin_empresa: el nuevo usuario queda en SU empresa (no puede elegir otra).
+        if (! $actor->hasRole('super_admin')) {
+            return (int) $actor->empresa_id;
+        }
+
+        // super_admin creando un rol de empresa: debe indicar empresa_id válido.
+        if (! $empresaId || ! Empresa::query()->whereKey($empresaId)->exists()) {
+            throw ValidationException::withMessages([
+                'empresa_id' => 'Para un rol de empresa debes indicar un empresa_id válido.',
+            ]);
+        }
+
+        return $empresaId;
+    }
+}

--- a/app/Services/RegistroSchemaService.php
+++ b/app/Services/RegistroSchemaService.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TipoFormato;
+use Illuminate\Validation\Rule;
+
+/**
+ * Deriva, desde la fuente única FormatoFieldsService (los componentes Filament
+ * de cada uno de los 13 formatos), una metadata plana reutilizable fuera de
+ * Filament: para describir los campos a un cliente MCP y para validar el
+ * array `datos` en la ingesta. Así no se duplica la definición de campos.
+ */
+class RegistroSchemaService
+{
+    /**
+     * @return array<int,array{name:string,label:string,required:bool,type:string,options:array<int,string>}>
+     */
+    public static function fields(TipoFormato $tipo): array
+    {
+        $out = [];
+
+        foreach (FormatoFieldsService::getFields($tipo) as $component) {
+            $options = method_exists($component, 'getOptions')
+                ? array_keys($component->getOptions() ?: [])
+                : [];
+
+            $out[] = [
+                'name' => str_replace('datos.', '', (string) $component->getName()),
+                'label' => (string) $component->getLabel(),
+                'required' => (bool) $component->isRequired(),
+                'type' => class_basename($component),
+                'options' => array_values(array_map('strval', $options)),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Reglas de validación Laravel para el array `datos` del formato.
+     *
+     * @return array<string,array<int,mixed>>
+     */
+    public static function rules(TipoFormato $tipo): array
+    {
+        $rules = [];
+
+        foreach (self::fields($tipo) as $field) {
+            $rule = [$field['required'] ? 'required' : 'nullable'];
+
+            $rule = match ($field['type']) {
+                'DatePicker', 'DateTimePicker' => [...$rule, 'date'],
+                'Toggle' => [...$rule, 'boolean'],
+                'TagsInput' => [...$rule, 'array'],
+                default => $rule, // TimePicker/TextInput/Textarea/RichEditor/Select: string libre
+            };
+
+            if ($field['options']) {
+                $rule[] = Rule::in($field['options']);
+            }
+
+            $rules["datos.{$field['name']}"] = $rule;
+        }
+
+        return $rules;
+    }
+}

--- a/tests/Feature/Mcp/CrearEquipoToolTest.php
+++ b/tests/Feature/Mcp/CrearEquipoToolTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\Servers\IngestaServer;
+use App\Mcp\Tools\CrearEquipoTool;
+use App\Models\Empresa;
+use App\Models\Equipo;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CrearEquipoToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    private function empresa(string $ruc): Empresa
+    {
+        return Empresa::create(['ruc' => $ruc, 'razon_social' => 'Empresa '.$ruc]);
+    }
+
+    private function usuarioCon(string $rol, ?int $empresaId): User
+    {
+        $user = User::create([
+            'name' => ucfirst($rol),
+            'email' => $rol.'-'.uniqid().'@test.local',
+            'password' => 'secret123',
+            'empresa_id' => $empresaId,
+            'estado' => 'activo',
+        ]);
+        $user->syncRoles($rol);
+
+        return $user;
+    }
+
+    public function test_admin_empresa_crea_equipo_con_codigo_audita_e_ingreso(): void
+    {
+        $empresa = $this->empresa('20300000001');
+        $admin = $this->usuarioCon('admin_empresa', $empresa->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearEquipoTool::class, ['tipo' => 'laptop', 'marca' => 'Dell', 'modelo' => 'Latitude 5540'])
+            ->assertOk()
+            ->assertSee('EQ-');
+
+        $equipo = Equipo::withoutGlobalScopes()->where('empresa_id', $empresa->id)->first();
+        $this->assertNotNull($equipo);
+        $this->assertSame('EQ-001', $equipo->codigo_interno);
+        $this->assertTrue($equipo->asignaciones()->where('tipo', 'ingreso_nuevo')->exists());
+
+        $this->assertDatabaseHas('audit_logs', ['entidad' => 'equipos', 'accion' => 'crear']);
+    }
+
+    public function test_solo_lectura_no_puede_registrar_equipo(): void
+    {
+        $user = $this->usuarioCon('solo_lectura', $this->empresa('20300000002')->id);
+
+        IngestaServer::actingAs($user)
+            ->tool(CrearEquipoTool::class, ['tipo' => 'laptop'])
+            ->assertHasErrors();
+
+        $this->assertDatabaseCount('equipos', 0);
+    }
+
+    public function test_super_admin_requiere_empresa_id(): void
+    {
+        $super = $this->usuarioCon('super_admin', null);
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearEquipoTool::class, ['tipo' => 'servidor'])
+            ->assertHasErrors();
+
+        $empresa = $this->empresa('20300000003');
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearEquipoTool::class, ['tipo' => 'servidor', 'empresa_id' => $empresa->id])
+            ->assertOk();
+
+        $this->assertDatabaseHas('equipos', ['empresa_id' => $empresa->id, 'tipo' => 'servidor']);
+    }
+}

--- a/tests/Feature/Mcp/CrearRegistroToolTest.php
+++ b/tests/Feature/Mcp/CrearRegistroToolTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\Servers\IngestaServer;
+use App\Mcp\Tools\CrearRegistroTool;
+use App\Mcp\Tools\FormatosRegistroTool;
+use App\Models\Empresa;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CrearRegistroToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    private function empresa(string $ruc): Empresa
+    {
+        return Empresa::create(['ruc' => $ruc, 'razon_social' => 'Empresa '.$ruc]);
+    }
+
+    private function usuarioCon(string $rol, ?int $empresaId): User
+    {
+        $user = User::create([
+            'name' => ucfirst($rol),
+            'email' => $rol.'-'.uniqid().'@test.local',
+            'password' => 'secret123',
+            'empresa_id' => $empresaId,
+            'estado' => 'activo',
+        ]);
+        $user->syncRoles($rol);
+
+        return $user;
+    }
+
+    /** @return array<string,string> */
+    private function datosF12(): array
+    {
+        return [
+            'nombre_backup' => 'Backup diario servidor',
+            'fecha_copia' => '2026-06-01',
+            'periodicidad' => 'diaria',
+            'descripcion_contenido' => 'Copia completa de la base de datos',
+        ];
+    }
+
+    public function test_usuario_crea_registro_f12_con_numero_y_audita(): void
+    {
+        $empresa = $this->empresa('20200000001');
+        $user = $this->usuarioCon('usuario', $empresa->id);
+
+        IngestaServer::actingAs($user)
+            ->tool(CrearRegistroTool::class, ['tipo_formato' => 'F12', 'datos' => $this->datosF12()])
+            ->assertOk()
+            ->assertSee('BAK-'); // prefijo de F12
+
+        $this->assertDatabaseHas('registros', [
+            'empresa_id' => $empresa->id,
+            'tipo_formato' => 'F12',
+            'estado' => 'activo',
+            'creado_por' => $user->id,
+        ]);
+        $this->assertDatabaseHas('audit_logs', [
+            'entidad' => 'registros',
+            'accion' => 'crear',
+        ]);
+    }
+
+    public function test_falta_campo_obligatorio_es_rechazado(): void
+    {
+        $user = $this->usuarioCon('usuario', $this->empresa('20200000002')->id);
+        $datos = $this->datosF12();
+        unset($datos['nombre_backup']);
+
+        IngestaServer::actingAs($user)
+            ->tool(CrearRegistroTool::class, ['tipo_formato' => 'F12', 'datos' => $datos])
+            ->assertHasErrors();
+
+        $this->assertDatabaseCount('registros', 0);
+    }
+
+    public function test_opcion_invalida_es_rechazada(): void
+    {
+        $user = $this->usuarioCon('usuario', $this->empresa('20200000003')->id);
+        $datos = $this->datosF12();
+        $datos['periodicidad'] = 'cuando-sea';
+
+        IngestaServer::actingAs($user)
+            ->tool(CrearRegistroTool::class, ['tipo_formato' => 'F12', 'datos' => $datos])
+            ->assertHasErrors();
+    }
+
+    public function test_solo_lectura_no_puede_crear(): void
+    {
+        $user = $this->usuarioCon('solo_lectura', $this->empresa('20200000004')->id);
+
+        IngestaServer::actingAs($user)
+            ->tool(CrearRegistroTool::class, ['tipo_formato' => 'F12', 'datos' => $this->datosF12()])
+            ->assertHasErrors();
+
+        $this->assertDatabaseCount('registros', 0);
+    }
+
+    public function test_super_admin_requiere_empresa_id(): void
+    {
+        $super = $this->usuarioCon('super_admin', null);
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearRegistroTool::class, ['tipo_formato' => 'F12', 'datos' => $this->datosF12()])
+            ->assertHasErrors();
+
+        $empresa = $this->empresa('20200000005');
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearRegistroTool::class, ['tipo_formato' => 'F12', 'datos' => $this->datosF12(), 'empresa_id' => $empresa->id])
+            ->assertOk();
+
+        $this->assertDatabaseHas('registros', ['empresa_id' => $empresa->id, 'tipo_formato' => 'F12']);
+    }
+
+    public function test_formatos_registro_lista_y_describe(): void
+    {
+        $user = $this->usuarioCon('usuario', $this->empresa('20200000006')->id);
+
+        IngestaServer::actingAs($user)
+            ->tool(FormatosRegistroTool::class, [])
+            ->assertOk()
+            ->assertSee('F09'); // el catálogo incluye los 13
+
+        IngestaServer::actingAs($user)
+            ->tool(FormatosRegistroTool::class, ['tipo_formato' => 'F12'])
+            ->assertOk()
+            ->assertSee('nombre_backup'); // describe los campos del formato
+    }
+}

--- a/tests/Feature/Mcp/CrearUsuarioToolTest.php
+++ b/tests/Feature/Mcp/CrearUsuarioToolTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\Servers\IngestaServer;
+use App\Mcp\Tools\CrearUsuarioTool;
+use App\Models\Empresa;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CrearUsuarioToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+    }
+
+    private function empresa(string $ruc): Empresa
+    {
+        return Empresa::create(['ruc' => $ruc, 'razon_social' => 'Empresa '.$ruc]);
+    }
+
+    private function usuarioCon(string $rol, ?int $empresaId): User
+    {
+        $user = User::create([
+            'name' => ucfirst($rol),
+            'email' => $rol.'-'.uniqid().'@test.local',
+            'password' => 'secret123',
+            'empresa_id' => $empresaId,
+            'estado' => 'activo',
+        ]);
+        $user->syncRoles($rol);
+
+        return $user;
+    }
+
+    public function test_admin_empresa_crea_usuario_en_su_empresa_sin_exponer_password(): void
+    {
+        $empresa = $this->empresa('20400000001');
+        $admin = $this->usuarioCon('admin_empresa', $empresa->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearUsuarioTool::class, ['name' => 'Juan Perez', 'email' => 'juan@acme.test', 'rol' => 'usuario'])
+            ->assertOk()
+            ->assertSee('Olvidé mi contraseña'); // no se envió password → debe resetear
+
+        $nuevo = User::where('email', 'juan@acme.test')->first();
+        $this->assertNotNull($nuevo);
+        $this->assertSame($empresa->id, $nuevo->empresa_id);
+        $this->assertTrue($nuevo->hasRole('usuario'));
+    }
+
+    public function test_admin_empresa_no_puede_crear_super_admin(): void
+    {
+        $admin = $this->usuarioCon('admin_empresa', $this->empresa('20400000002')->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearUsuarioTool::class, ['name' => 'Hacker', 'email' => 'hacker@acme.test', 'rol' => 'super_admin'])
+            ->assertHasErrors();
+
+        $this->assertDatabaseMissing('users', ['email' => 'hacker@acme.test']);
+    }
+
+    public function test_admin_empresa_no_puede_crear_en_otra_empresa(): void
+    {
+        $propia = $this->empresa('20400000003');
+        $otra = $this->empresa('20400000004');
+        $admin = $this->usuarioCon('admin_empresa', $propia->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearUsuarioTool::class, ['name' => 'Cross', 'email' => 'cross@acme.test', 'rol' => 'usuario', 'empresa_id' => $otra->id])
+            ->assertOk();
+
+        $this->assertDatabaseHas('users', ['email' => 'cross@acme.test', 'empresa_id' => $propia->id]);
+    }
+
+    public function test_super_admin_crea_admin_de_otra_empresa(): void
+    {
+        $super = $this->usuarioCon('super_admin', null);
+        $empresa = $this->empresa('20400000005');
+
+        IngestaServer::actingAs($super)
+            ->tool(CrearUsuarioTool::class, ['name' => 'Admin X', 'email' => 'adminx@acme.test', 'rol' => 'admin_empresa', 'empresa_id' => $empresa->id])
+            ->assertOk();
+
+        $nuevo = User::where('email', 'adminx@acme.test')->first();
+        $this->assertSame($empresa->id, $nuevo->empresa_id);
+        $this->assertTrue($nuevo->hasRole('admin_empresa'));
+    }
+
+    public function test_email_duplicado_es_rechazado(): void
+    {
+        $admin = $this->usuarioCon('admin_empresa', $this->empresa('20400000006')->id);
+
+        IngestaServer::actingAs($admin)
+            ->tool(CrearUsuarioTool::class, ['name' => 'Dup', 'email' => $admin->email, 'rol' => 'usuario'])
+            ->assertHasErrors();
+    }
+
+    public function test_usuario_normal_no_puede_crear_usuarios(): void
+    {
+        $user = $this->usuarioCon('usuario', $this->empresa('20400000007')->id);
+
+        IngestaServer::actingAs($user)
+            ->tool(CrearUsuarioTool::class, ['name' => 'X', 'email' => 'x@acme.test', 'rol' => 'usuario'])
+            ->assertHasErrors();
+
+        $this->assertDatabaseMissing('users', ['email' => 'x@acme.test']);
+    }
+}


### PR DESCRIPTION
## Fase 1 (parte 1) — Registros de seguridad PSC por MCP

Añade ingesta conversacional de los **13 formatos PSC (F01–F13)** sobre el mismo motor de la Fase 0.

### Tools nuevos
- **`formatos-registro`** — sin args lista los 13 formatos (código, nombre, para qué sirven); con `tipo_formato=<F0x>` describe los **campos exactos** (obligatorios/opcionales + opciones válidas). El cliente lo usa para saber qué enviar.
- **`crear-registro`** — `tipo_formato` + `datos` → crea el registro. El número (`INC-2026-004`, etc.) se genera solo.

### Cómo se mantiene una sola fuente de verdad
`RegistroSchemaService` **introspecta `FormatoFieldsService`** (los componentes Filament de cada formato) y deriva tanto la **descripción de campos** como las **reglas de validación**. Cero duplicación: si cambian los campos en Filament, el MCP queda en sync.

### Seguridad (igual que activos)
- Autoriza por rol: **super_admin / admin_empresa / usuario** (solo_lectura y agente quedan fuera).
- Tenant: cada quien crea en **su** empresa; super_admin debe indicar `empresa_id`.
- Audit automático (`AuditableObserver`) y notificación de incidencias F09 (`RegistroObserver`).

### Extras
- Trait **`ResuelveEmpresa`** compartido (DRY del binding de tenant); `ActivoDigitalIngestaService` refactorizado para usarlo.
- Tool de activos renombrado a **`crear-activo-digital`** (sin el sufijo `-tool`).

### Pruebas
6 tests MCP de registros (F12 happy path + número + audit, falta requerido, opción inválida, solo_lectura rechazado, super_admin requiere empresa_id, catálogo/describe). **Suite: 21 passed.**

> ⚠️ Mergear a `develop` **dispara el deploy a producción** (workflow `deploy.yml`).
> No incluye el trabajo ajeno en curso (PoliticaSeeder/empresa) del working tree.

### Próximo
Fase 1 (parte 2): tools de **equipos** (PCs) y **empresas/usuarios**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)