### PR TITLE
fix(politicas): aislar datos por empresa (sin filtrar al Estudio Palacios)

### DIFF
--- a/app/Console/Commands/RepararDatosPoliticasEmpresa.php
+++ b/app/Console/Commands/RepararDatosPoliticasEmpresa.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Empresa;
+use App\Models\Politica;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Repara las politicas de una empresa que heredaron datos hardcodeados del
+ * Estudio Palacios (versiones anteriores del PoliticaSeeder copiaban el texto
+ * literal a cada empresa). Reemplaza esos literales por los datos propios de
+ * la empresa indicada.
+ *
+ * Es idempotente: tras el primer pase los literales de Palacios ya no existen,
+ * por lo que volver a ejecutarlo no cambia nada.
+ *
+ * Uso:
+ *   php artisan politicas:reparar-datos <empresaIdOrRuc> --dry-run   (previsualizar)
+ *   php artisan politicas:reparar-datos <empresaIdOrRuc>             (aplicar, pide confirmacion)
+ *   php artisan politicas:reparar-datos <empresaIdOrRuc> --force     (aplicar sin preguntar)
+ */
+class RepararDatosPoliticasEmpresa extends Command
+{
+    protected $signature = 'politicas:reparar-datos
+        {empresa : ID o RUC de la empresa cuyas politicas se repararan}
+        {--dry-run : Muestra los cambios sin guardarlos}
+        {--force : Aplica sin pedir confirmacion}';
+
+    protected $description = 'Reemplaza datos heredados del Estudio Palacios en las politicas de una empresa por los datos propios de esa empresa.';
+
+    public function handle(): int
+    {
+        $empresa = $this->resolverEmpresa((string) $this->argument('empresa'));
+
+        if (! $empresa) {
+            $this->error('No se encontro la empresa indicada (se busca por ID o RUC).');
+
+            return self::FAILURE;
+        }
+
+        $this->info("Empresa objetivo: #{$empresa->id} — {$empresa->razon_social} (RUC {$empresa->ruc})");
+
+        foreach (['email' => 'correo', 'direccion' => 'direccion'] as $campo => $etiqueta) {
+            if (blank($empresa->{$campo})) {
+                $this->warn("  ⚠  La empresa no tiene {$etiqueta} registrado; se usara un texto neutro. Considera completar el perfil de la empresa antes de aplicar.");
+            }
+        }
+
+        $reemplazos = $this->mapeoReemplazos($empresa);
+
+        $politicas = Politica::withoutGlobalScopes()
+            ->where('empresa_id', $empresa->id)
+            ->get();
+
+        if ($politicas->isEmpty()) {
+            $this->warn('La empresa no tiene politicas registradas. Nada que hacer.');
+
+            return self::SUCCESS;
+        }
+
+        // Primer pase: calcular cambios sin escribir.
+        $cambios = [];
+        $totalReemplazos = 0;
+
+        foreach ($politicas as $politica) {
+            $original = (string) $politica->contenido;
+            $nuevo = strtr($original, $reemplazos);
+
+            if ($nuevo === $original) {
+                continue;
+            }
+
+            $n = $this->contarCoincidencias($original, $reemplazos);
+            $totalReemplazos += $n;
+            $cambios[] = ['politica' => $politica, 'nuevo' => $nuevo, 'n' => $n];
+
+            $this->line("  • [{$politica->slug}] {$politica->titulo} — {$n} reemplazo(s)");
+        }
+
+        if (empty($cambios)) {
+            $this->info('No se encontraron datos de Palacios en las politicas de esta empresa. Nada que reparar.');
+
+            return self::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->info(count($cambios) . " politica(s) con cambios, {$totalReemplazos} reemplazo(s) en total.");
+
+        if ($this->option('dry-run')) {
+            $this->comment('DRY-RUN: no se guardo nada.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->option('force') && ! $this->confirm('¿Aplicar estos cambios a la base de datos?')) {
+            $this->comment('Cancelado. No se guardo nada.');
+
+            return self::SUCCESS;
+        }
+
+        DB::beginTransaction();
+
+        try {
+            foreach ($cambios as $cambio) {
+                $cambio['politica']->contenido = $cambio['nuevo'];
+                // saveQuietly: no dispara observers ni notificaciones (solo cambia contenido,
+                // no la version, por lo que no debe avisarse a los usuarios).
+                $cambio['politica']->saveQuietly();
+            }
+
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            $this->error('Error: se revirtieron todos los cambios. ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info('Listo: ' . count($cambios) . ' politica(s) actualizada(s).');
+        $this->comment('Nota: el contenido se actualizo sin cambiar la "version", por lo que no se notifico a los usuarios ni se creo snapshot de version. Si quieres dejar traza de version, subela manualmente desde el panel.');
+
+        return self::SUCCESS;
+    }
+
+    private function resolverEmpresa(string $identificador): ?Empresa
+    {
+        return Empresa::withoutGlobalScopes()
+            ->where(function ($q) use ($identificador) {
+                $q->where('id', $identificador)
+                    ->orWhere('ruc', $identificador);
+            })
+            ->first();
+    }
+
+    private function contarCoincidencias(string $contenido, array $reemplazos): int
+    {
+        $total = 0;
+
+        foreach (array_keys($reemplazos) as $buscar) {
+            $total += substr_count($contenido, $buscar);
+        }
+
+        return $total;
+    }
+
+    /**
+     * Literales heredados del Estudio Palacios (hardcodeados en versiones
+     * anteriores del PoliticaSeeder) mapeados a los datos propios de la empresa.
+     * El lado derecho coincide con lo que produce hoy PoliticaSeeder::getPoliticas().
+     */
+    private function mapeoReemplazos(Empresa $empresa): array
+    {
+        $razon = $empresa->razon_social ?: 'el estudio';
+        $razonUpper = Str::upper($razon);
+        $ruc = $empresa->ruc ?: 'RUC no registrado';
+        $direccion = $empresa->direccion ?: 'direccion no registrada';
+        $email = $empresa->email ?: 'correo corporativo no registrado';
+
+        return [
+            'En el Estudio de Abogados Palacios, la gestion documental'
+                => "En {$razon}, la gestion documental",
+            'Existe correo generico (info@estudiopalacios.com.pe).'
+                => "Existe correo generico ({$email}).",
+            'Dotar al Estudio Palacios Abogados de una sistematica'
+                => "Dotar a {$razon} de una sistematica",
+            '**ESTUDIO PALACIOS ABOGADOS S.A.C.**'
+                => "**{$razonUpper}**",
+            '**{puesto}** en el Estudio Palacios Abogados S.A.C., '
+                => "**{puesto}** en {$razon}, ",
+            'en el ejercicio de mis funciones dentro del Estudio Palacios Abogados S.A.C.'
+                => "en el ejercicio de mis funciones dentro de {$razon}",
+            '(SGSI) del Estudio Palacios Abogados S.A.C., asegurando'
+                => "(SGSI) de {$razon}, asegurando",
+            'areas y personal del Estudio Palacios Abogados S.A.C., incluyendo'
+                => "areas y personal de {$razon}, incluyendo",
+            '<p>El Estudio Palacios Abogados S.A.C. se compromete a proteger'
+                => "<p>{$razon} se compromete a proteger",
+            'Estudio Palacios Abogados SAC | RUC: 20454292295 | Cal. San Pedro #100E, Arequipa | 6 trabajadores'
+                => "{$razon} | RUC: {$ruc} | {$direccion}",
+            'Elaborado por: JC Aranibar / Coordinador SGS. Aprobado por: M Palacios / Gerente General.'
+                => 'Elaborado por: Coordinador SGS. Aprobado por: Gerente General.',
+        ];
+    }
+}

--- a/app/Filament/Pages/Auth/RegisterEmpresa.php
+++ b/app/Filament/Pages/Auth/RegisterEmpresa.php
@@ -146,7 +146,7 @@ class RegisterEmpresa extends RegisterTenant
     {
         $seeder = new PoliticaSeeder;
 
-        foreach ($seeder->getPoliticas() as $data) {
+        foreach ($seeder->getPoliticas($empresa) as $data) {
             Politica::firstOrCreate(
                 ['empresa_id' => $empresa->id, 'slug' => Str::slug($data['titulo'])],
                 array_merge($data, ['empresa_id' => $empresa->id])

--- a/database/seeders/DemoCorpSeeder.php
+++ b/database/seeders/DemoCorpSeeder.php
@@ -139,7 +139,7 @@ class DemoCorpSeeder extends Seeder
 
     private function seedPoliticas(): void
     {
-        $politicas = (new PoliticaSeeder)->getPoliticas();
+        $politicas = (new PoliticaSeeder)->getPoliticas($this->empresa);
         $firmantes = User::firmantes()->where('empresa_id', $this->empresa->id)->where('estado', 'activo')->get();
 
         $count = 0;

--- a/database/seeders/EmpresaSetupSeeder.php
+++ b/database/seeders/EmpresaSetupSeeder.php
@@ -130,7 +130,7 @@ class EmpresaSetupSeeder extends Seeder
     private function createPoliticas(Empresa $empresa): void
     {
         $politicaSeeder = new PoliticaSeeder;
-        $politicas = $politicaSeeder->getPoliticas();
+        $politicas = $politicaSeeder->getPoliticas($empresa);
 
         $count = 0;
 

--- a/database/seeders/PoliticaSeeder.php
+++ b/database/seeders/PoliticaSeeder.php
@@ -18,9 +18,9 @@ class PoliticaSeeder extends Seeder
             return;
         }
 
-        $politicas = $this->getPoliticas();
-
         foreach ($empresas as $empresa) {
+            $politicas = $this->getPoliticas($empresa);
+
             foreach ($politicas as $data) {
                 Politica::firstOrCreate(
                     [
@@ -34,12 +34,12 @@ class PoliticaSeeder extends Seeder
             $this->command->info("  + " . count($politicas) . " politicas creadas para: {$empresa->razon_social}");
         }
 
-        $this->command->info('PoliticaSeeder completado: ' . count($politicas) . ' politicas por empresa.');
+        $this->command->info('PoliticaSeeder completado.');
     }
 
-    public function getPoliticas(): array
+    public function getPoliticas(?Empresa $empresa = null): array
     {
-        return [
+        $politicas = [
             // ──────────────────────────────────────────────────────────
             // 1. POLITICA DE LINEA BASE DE SEGURIDAD (SGSI-PL-0038)
             // ──────────────────────────────────────────────────────────
@@ -48,7 +48,7 @@ class PoliticaSeeder extends Seeder
                 'contenido' => '<h2>Politica de Linea Base de Seguridad</h2><p><strong>Codigo:</strong> SGSI-PL-0038 | <strong>Version:</strong> 1 | <strong>Fecha:</strong> 10/01/2026</p>'
                     . '<h3>1. Introduccion</h3>'
                     . '<p>El estudio de abogados gestiona informacion sensible y confidencial que demanda una proteccion solida frente a amenazas ciberneticas. En este contexto, la politica de ciberseguridad constituye un pilar esencial para asegurar que los sistemas, redes, dispositivos y datos del estudio operen bajo estandares elevados de seguridad. El presente documento define medidas tecnicas, procedimientos y buenas practicas que deben adoptarse para reducir el riesgo de accesos no autorizados, perdida de informacion y otras amenazas que puedan afectar la integridad operativa del estudio.</p>'
-                    . '<p>En el Estudio de Abogados Palacios, la gestion documental se soporta en un Servidor Local para edicion y administracion de documentos, por lo que la politica prioriza la seguridad de accesos, permisos, registros de auditoria y continuidad operativa en esta infraestructura.</p>'
+                    . '<p>En {{razon_social}}, la gestion documental se soporta en un Servidor Local para edicion y administracion de documentos, por lo que la politica prioriza la seguridad de accesos, permisos, registros de auditoria y continuidad operativa en esta infraestructura.</p>'
                     . '<h3>2. Objetivo</h3>'
                     . '<p>Proteger los sistemas y datos criticos del estudio mediante la aplicacion de medidas tecnicas y organizativas minimas, tanto a nivel de hardware como de software. Garantizar que los equipos y aplicaciones utilizados se mantengan actualizados y operen con un desempeno adecuado. Promover la vida util del hardware, asegurando que los dispositivos puedan soportar futuras actualizaciones.</p>'
                     . '<h3>3. Alcance</h3>'
@@ -138,7 +138,7 @@ class PoliticaSeeder extends Seeder
                     . '<li>Gestor de correo interno para contacto frecuente entre personal y con personal externo.</li>'
                     . '<li>Canales adicionales: Software interno, Cartas circulares, Reuniones.</li></ul>'
                     . '<h3>5. Comunicacion Externa</h3>'
-                    . '<ul><li>Correo electronico: Cada cliente posee el correo del personal asignado. Existe correo generico (info@estudiopalacios.com.pe).</li></ul>',
+                    . '<ul><li>Correo electronico: Cada cliente posee el correo del personal asignado. Existe correo generico ({{email}}).</li></ul>',
                 'version' => '1.0',
                 'obligatoria' => false,
                 'activa' => true,
@@ -285,7 +285,7 @@ class PoliticaSeeder extends Seeder
                 'titulo' => 'Procedimiento de Gestion de Riesgos y Oportunidades',
                 'contenido' => '<h2>Procedimiento de Gestion de Riesgos y Oportunidades</h2><p><strong>Codigo:</strong> SGSI-PR-04 | <strong>Version:</strong> 02 | <strong>Fecha:</strong> 06.01.2025</p>'
                     . '<h3>1. Objetivo</h3>'
-                    . '<p>Dotar al Estudio Palacios Abogados de una sistematica de gestion de riesgos y oportunidades para asegurar que el SGSI pueda lograr sus resultados previstos, aumentar los efectos deseables, prevenir o reducir efectos indeseados, lograr la mejora continua y evaluar la eficacia de las acciones.</p>'
+                    . '<p>Dotar a {{razon_social}} de una sistematica de gestion de riesgos y oportunidades para asegurar que el SGSI pueda lograr sus resultados previstos, aumentar los efectos deseables, prevenir o reducir efectos indeseados, lograr la mejora continua y evaluar la eficacia de las acciones.</p>'
                     . '<h3>2. Alcance</h3>'
                     . '<p>Toda la organizacion. Determina las cuestiones externas e internas pertinentes para su proposito y direccion estrategica.</p>'
                     . '<h3>3. Proceso</h3>'
@@ -465,13 +465,13 @@ class PoliticaSeeder extends Seeder
             [
                 'titulo' => 'Acuerdo de Confidencialidad (NDA)',
                 'contenido' => "## Acuerdo de Confidencialidad y No Divulgacion\n\n"
-                    . "**ESTUDIO PALACIOS ABOGADOS S.A.C.**\n\n"
+                    . "**{{razon_social_upper}}**\n\n"
                     . "Yo, **{nombre_completo}**, identificado(a) con DNI N° **{dni}**, domiciliado(a) en **{direccion}**, "
-                    . "telefono **{telefono}**, que ocupo el puesto de **{puesto}** en el Estudio Palacios Abogados S.A.C., "
+                    . "telefono **{telefono}**, que ocupo el puesto de **{puesto}** en {{razon_social}}, "
                     . "declaro y me comprometo a lo siguiente:\n\n"
                     . "### 1. Objeto del Acuerdo\n"
                     . "El presente acuerdo tiene por objeto proteger la informacion confidencial a la que tenga acceso "
-                    . "en el ejercicio de mis funciones dentro del Estudio Palacios Abogados S.A.C.\n\n"
+                    . "en el ejercicio de mis funciones dentro de {{razon_social}}\n\n"
                     . "### 2. Definicion de Informacion Confidencial\n"
                     . "Se considera informacion confidencial toda aquella informacion, sea oral, escrita, electronica "
                     . "o en cualquier otro formato, que incluya pero no se limite a:\n"
@@ -571,11 +571,11 @@ class PoliticaSeeder extends Seeder
                 'titulo' => 'Manual del Sistema de Gestion de Seguridad de la Informacion',
                 'contenido' => '<h2>Manual del Sistema de Gestion de Seguridad de la Informacion</h2><p><strong>Codigo:</strong> SGSI-MA-01 | <strong>Version:</strong> 02 | <strong>Fecha:</strong> 06.01.2025</p>'
                     . '<h3>1. Objetivo</h3>'
-                    . '<p>Establecer, implementar, mantener y mejorar continuamente el Sistema de Gestion de Seguridad de la Informacion (SGSI) del Estudio Palacios Abogados S.A.C., asegurando la confidencialidad, integridad y disponibilidad de la informacion.</p>'
+                    . '<p>Establecer, implementar, mantener y mejorar continuamente el Sistema de Gestion de Seguridad de la Informacion (SGSI) de {{razon_social}}, asegurando la confidencialidad, integridad y disponibilidad de la informacion.</p>'
                     . '<h3>2. Alcance</h3>'
-                    . '<p>El SGSI aplica a todos los procesos, areas y personal del Estudio Palacios Abogados S.A.C., incluyendo la informacion en formato fisico y digital, los sistemas de informacion, la infraestructura tecnologica y las comunicaciones.</p>'
+                    . '<p>El SGSI aplica a todos los procesos, areas y personal de {{razon_social}}, incluyendo la informacion en formato fisico y digital, los sistemas de informacion, la infraestructura tecnologica y las comunicaciones.</p>'
                     . '<h3>3. Politica de Seguridad de la Informacion</h3>'
-                    . '<p>El Estudio Palacios Abogados S.A.C. se compromete a proteger el recurso informacion de una amplia gama de amenazas, con el fin de asegurar la continuidad del negocio, minimizar el dano y cumplir su mision y objetivos estrategicos.</p>'
+                    . '<p>{{razon_social}} se compromete a proteger el recurso informacion de una amplia gama de amenazas, con el fin de asegurar la continuidad del negocio, minimizar el dano y cumplir su mision y objetivos estrategicos.</p>'
                     . '<h3>4. Estructura Organizacional del SGSI</h3>'
                     . '<ul><li><strong>Gerente General:</strong> Responsable de la aprobacion y revision del SGSI.</li>'
                     . '<li><strong>Coordinador SGS:</strong> Responsable de la implementacion, mantenimiento y mejora continua del SGSI.</li>'
@@ -713,7 +713,7 @@ class PoliticaSeeder extends Seeder
                 'titulo' => 'Programa Anual de Capacitaciones SGSI',
                 'contenido' => '<h2>Programa Anual de Capacitaciones SGSI</h2><p><strong>Codigo:</strong> SGSI-PGR-001 | <strong>Version:</strong> 1 | <strong>Fecha:</strong> 05.01.2024</p>'
                     . '<h3>Datos del Empleador</h3>'
-                    . '<p>Estudio Palacios Abogados SAC | RUC: 20454292295 | Cal. San Pedro #100E, Arequipa | 6 trabajadores</p>'
+                    . '<p>{{razon_social}} | RUC: {{ruc}} | {{direccion}}</p>'
                     . '<h3>Compromiso de la Politica</h3>'
                     . '<p>Proteger el recurso informacion de una amplia gama de amenazas, con el fin de asegurar la continuidad del negocio, minimizar el dano y cumplir su mision y objetivos estrategicos.</p>'
                     . '<h3>Objetivo General</h3>'
@@ -784,13 +784,47 @@ class PoliticaSeeder extends Seeder
                     . '<tr><td>Comunicaciones con clientes</td><td>Intercepcion o manipulacion</td><td>No uso de canales cifrados</td><td>Alto</td><td>Alto</td><td>Critico</td><td>Cifrado, Seguridad en las comunicaciones</td></tr>'
                     . '</tbody></table>'
                     . '<h3>Responsable</h3>'
-                    . '<p>Elaborado por: JC Aranibar / Coordinador SGS. Aprobado por: M Palacios / Gerente General.</p>',
+                    . '<p>Elaborado por: Coordinador SGS. Aprobado por: Gerente General.</p>',
                 'version' => '1.0',
                 'obligatoria' => false,
                 'activa' => true,
                 'es_nda' => false,
                 'vigencia_meses' => null,
             ],
+        ];
+
+        return $this->personalizar($politicas, $empresa);
+    }
+
+    /**
+     * Sustituye los datos de la empresa en el contenido de cada politica.
+     * Evita que un estudio herede datos identificatorios de otro.
+     */
+    private function personalizar(array $politicas, ?Empresa $empresa): array
+    {
+        $tokens = $this->tokensEmpresa($empresa);
+
+        return array_map(function (array $data) use ($tokens) {
+            $data['contenido'] = strtr($data['contenido'], $tokens);
+
+            return $data;
+        }, $politicas);
+    }
+
+    /**
+     * Tokens {{...}} disponibles en las plantillas de politicas, resueltos
+     * con los datos de la empresa (o un valor neutro si no estan registrados).
+     */
+    private function tokensEmpresa(?Empresa $empresa): array
+    {
+        $razonSocial = $empresa?->razon_social ?: 'el estudio';
+
+        return [
+            '{{razon_social}}' => $razonSocial,
+            '{{razon_social_upper}}' => \Illuminate\Support\Str::upper($razonSocial),
+            '{{ruc}}' => $empresa?->ruc ?: 'RUC no registrado',
+            '{{direccion}}' => $empresa?->direccion ?: 'direccion no registrada',
+            '{{email}}' => $empresa?->email ?: 'correo corporativo no registrado',
         ];
     }
 }

--- a/tests/Feature/PoliticaPersonalizacionTest.php
+++ b/tests/Feature/PoliticaPersonalizacionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Empresa;
+use App\Models\Politica;
+use Database\Seeders\PoliticaSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Cubre el aislamiento de datos por empresa en las politicas:
+ * - PoliticaSeeder::getPoliticas() sustituye los tokens {{...}} por los datos
+ *   de la empresa y nunca deja datos del Estudio Palacios en otra empresa.
+ * - El comando politicas:reparar-datos repara empresas que ya heredaron los
+ *   literales hardcodeados de versiones anteriores del seeder.
+ */
+class PoliticaPersonalizacionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function empresa(array $overrides = []): Empresa
+    {
+        return Empresa::create(array_merge([
+            'ruc' => '20111111111',
+            'razon_social' => 'Alfa Legal S.A.C.',
+            'direccion' => 'Av. Alfa 123, Lima',
+            'email' => 'contacto@alfa.pe',
+        ], $overrides));
+    }
+
+    private function contenidoConcatenado(array $politicas): string
+    {
+        return implode("\n", array_column($politicas, 'contenido'));
+    }
+
+    public function test_seeder_personaliza_politicas_con_los_datos_de_la_empresa(): void
+    {
+        $empresa = $this->empresa();
+
+        $contenido = $this->contenidoConcatenado((new PoliticaSeeder)->getPoliticas($empresa));
+
+        // Datos propios de la empresa presentes.
+        $this->assertStringContainsString('Alfa Legal S.A.C.', $contenido);
+        $this->assertStringContainsString('ALFA LEGAL S.A.C.', $contenido); // {{razon_social_upper}} en el NDA
+        $this->assertStringContainsString('20111111111', $contenido);
+        $this->assertStringContainsString('Av. Alfa 123, Lima', $contenido);
+        $this->assertStringContainsString('contacto@alfa.pe', $contenido);
+
+        // No quedan tokens sin resolver (los placeholders {var} de una sola
+        // llave del NDA son intencionales; los {{...}} de empresa no deben quedar).
+        $this->assertStringNotContainsString('{{', $contenido);
+    }
+
+    public function test_seeder_no_filtra_datos_del_estudio_palacios_a_otra_empresa(): void
+    {
+        $empresa = $this->empresa();
+
+        $contenido = $this->contenidoConcatenado((new PoliticaSeeder)->getPoliticas($empresa));
+
+        foreach (['Palacios', '20454292295', 'estudiopalacios.com.pe', 'San Pedro', 'Aranibar'] as $rastro) {
+            $this->assertStringNotContainsString($rastro, $contenido, "Se filtro el dato '{$rastro}' del Estudio Palacios.");
+        }
+    }
+
+    public function test_seeder_usa_textos_neutros_cuando_no_hay_empresa(): void
+    {
+        $contenido = $this->contenidoConcatenado((new PoliticaSeeder)->getPoliticas(null));
+
+        $this->assertStringContainsString('el estudio', $contenido);
+        $this->assertStringNotContainsString('{{', $contenido);
+        $this->assertStringNotContainsString('Palacios', $contenido);
+    }
+
+    /**
+     * Contenido tal como lo guardaban versiones anteriores del seeder: con los
+     * literales del Estudio Palacios incrustados. Incluye los 11 literales
+     * exactos que repara el comando, para verificar que ninguno sobrevive.
+     */
+    private function contenidoHeredadoDePalacios(): string
+    {
+        return '<h2>Manual</h2>'
+            . '<p>En el Estudio de Abogados Palacios, la gestion documental se soporta en un Servidor Local.</p>'
+            . '<p>Existe correo generico (info@estudiopalacios.com.pe).</p>'
+            . '<p>Dotar al Estudio Palacios Abogados de una sistematica de gestion de riesgos.</p>'
+            . '<p>**ESTUDIO PALACIOS ABOGADOS S.A.C.**</p>'
+            . '<p>que ocupo el puesto de **{puesto}** en el Estudio Palacios Abogados S.A.C., declaro.</p>'
+            . '<p>en el ejercicio de mis funciones dentro del Estudio Palacios Abogados S.A.C.</p>'
+            . '<p>El SGSI (SGSI) del Estudio Palacios Abogados S.A.C., asegurando la confidencialidad.</p>'
+            . '<p>aplica a todas las areas y personal del Estudio Palacios Abogados S.A.C., incluyendo lo fisico.</p>'
+            . '<p>El Estudio Palacios Abogados S.A.C. se compromete a proteger la informacion.</p>'
+            . '<p>Estudio Palacios Abogados SAC | RUC: 20454292295 | Cal. San Pedro #100E, Arequipa | 6 trabajadores</p>'
+            . '<p>Elaborado por: JC Aranibar / Coordinador SGS. Aprobado por: M Palacios / Gerente General.</p>';
+    }
+
+    private function crearPolitica(Empresa $empresa, string $contenido): Politica
+    {
+        return Politica::create([
+            'empresa_id' => $empresa->id,
+            'titulo' => 'Politica heredada',
+            'slug' => 'politica-heredada-' . $empresa->id,
+            'contenido' => $contenido,
+            'version' => '1.0',
+            'obligatoria' => false,
+            'activa' => true,
+        ]);
+    }
+
+    public function test_comando_reemplaza_los_datos_de_palacios_por_los_de_la_empresa(): void
+    {
+        $empresa = $this->empresa();
+        $politica = $this->crearPolitica($empresa, $this->contenidoHeredadoDePalacios());
+
+        $this->artisan('politicas:reparar-datos', ['empresa' => $empresa->id, '--force' => true])
+            ->assertSuccessful();
+
+        $contenido = $politica->refresh()->contenido;
+
+        $this->assertStringNotContainsString('Palacios', $contenido);
+        $this->assertStringNotContainsString('20454292295', $contenido);
+        $this->assertStringNotContainsString('San Pedro', $contenido);
+        $this->assertStringNotContainsString('Aranibar', $contenido);
+
+        $this->assertStringContainsString('Alfa Legal S.A.C.', $contenido);
+        $this->assertStringContainsString('ALFA LEGAL S.A.C.', $contenido);
+        $this->assertStringContainsString('20111111111', $contenido);
+        $this->assertStringContainsString('Av. Alfa 123, Lima', $contenido);
+    }
+
+    public function test_comando_es_idempotente(): void
+    {
+        $empresa = $this->empresa();
+        $politica = $this->crearPolitica($empresa, $this->contenidoHeredadoDePalacios());
+
+        $this->artisan('politicas:reparar-datos', ['empresa' => $empresa->id, '--force' => true])->assertSuccessful();
+        $primerPase = $politica->refresh()->contenido;
+
+        $this->artisan('politicas:reparar-datos', ['empresa' => $empresa->id, '--force' => true])
+            ->expectsOutputToContain('Nada que reparar')
+            ->assertSuccessful();
+
+        $this->assertSame($primerPase, $politica->refresh()->contenido);
+    }
+
+    public function test_comando_resuelve_empresa_por_ruc(): void
+    {
+        $empresa = $this->empresa();
+        $politica = $this->crearPolitica($empresa, $this->contenidoHeredadoDePalacios());
+
+        $this->artisan('politicas:reparar-datos', ['empresa' => $empresa->ruc, '--force' => true])
+            ->assertSuccessful();
+
+        $this->assertStringNotContainsString('Palacios', $politica->refresh()->contenido);
+    }
+
+    public function test_dry_run_no_persiste_cambios(): void
+    {
+        $empresa = $this->empresa();
+        $original = $this->contenidoHeredadoDePalacios();
+        $politica = $this->crearPolitica($empresa, $original);
+
+        $this->artisan('politicas:reparar-datos', ['empresa' => $empresa->id, '--dry-run' => true])
+            ->assertSuccessful();
+
+        $this->assertSame($original, $politica->refresh()->contenido);
+    }
+}


### PR DESCRIPTION
## Problema

Versiones anteriores del `PoliticaSeeder` **copiaban literalmente** los datos del Estudio Palacios (razón social, RUC, dirección, correo corporativo, firmantes) dentro del contenido de las políticas de **todas** las empresas. Esto filtraba datos identificatorios de una empresa a otra — un fallo de aislamiento de tenant.

## Solución

- **`PoliticaSeeder::getPoliticas(?Empresa)`** ahora parametriza el contenido con tokens `{{razon_social}}`, `{{razon_social_upper}}`, `{{ruc}}`, `{{direccion}}`, `{{email}}`, resueltos por empresa (o un texto neutro si el dato no está registrado).
- **`RegisterEmpresa`**, **`DemoCorpSeeder`** y **`EmpresaSetupSeeder`** pasan la empresa al generar sus políticas.
- **Comando nuevo** `php artisan politicas:reparar-datos <empresa|ruc> [--dry-run|--force]` para reparar empresas **ya creadas** que heredaron los literales de Palacios. Es **idempotente** y usa `saveQuietly` (no cambia la versión ni notifica a los usuarios).

## Pruebas

`tests/Feature/PoliticaPersonalizacionTest.php` — 7 casos / 31 asserts:
- Seeder personaliza con los datos de la empresa y no deja tokens `{{...}}` sin resolver.
- Seeder no filtra datos del Estudio Palacios a otra empresa.
- Fallback neutro cuando no hay empresa.
- Comando: reemplaza los 11 literales, idempotencia, resuelve por RUC, `--dry-run` no persiste.

**Suite completa: 37 passed.**

## Notas

- Independiente del PR #185 (MCP); no hay solapamiento de archivos.
- ⚠️ Mergear a `develop` dispara el deploy a producción (`deploy.yml`).
- Tras desplegar, correr `politicas:reparar-datos` por cada empresa existente que ya tenga políticas sembradas con los datos de Palacios (usar `--dry-run` primero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)