### PR TITLE
feat(politicas): opción --all para reparar todas las empresas

### DIFF
--- a/app/Console/Commands/RepararDatosPoliticasEmpresa.php
+++ b/app/Console/Commands/RepararDatosPoliticasEmpresa.php
@@ -9,85 +9,71 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
- * Repara las politicas de una empresa que heredaron datos hardcodeados del
- * Estudio Palacios (versiones anteriores del PoliticaSeeder copiaban el texto
- * literal a cada empresa). Reemplaza esos literales por los datos propios de
- * la empresa indicada.
+ * Repara las politicas que heredaron datos hardcodeados del Estudio Palacios
+ * (versiones anteriores del PoliticaSeeder copiaban el texto literal a cada
+ * empresa). Reemplaza esos literales por los datos propios de cada empresa.
  *
  * Es idempotente: tras el primer pase los literales de Palacios ya no existen,
  * por lo que volver a ejecutarlo no cambia nada.
  *
  * Uso:
- *   php artisan politicas:reparar-datos <empresaIdOrRuc> --dry-run   (previsualizar)
- *   php artisan politicas:reparar-datos <empresaIdOrRuc>             (aplicar, pide confirmacion)
- *   php artisan politicas:reparar-datos <empresaIdOrRuc> --force     (aplicar sin preguntar)
+ *   php artisan politicas:reparar-datos <empresaIdOrRuc> --dry-run   (previsualizar una)
+ *   php artisan politicas:reparar-datos <empresaIdOrRuc> --force     (aplicar una sin preguntar)
+ *   php artisan politicas:reparar-datos --all --dry-run             (previsualizar todas)
+ *   php artisan politicas:reparar-datos --all --force              (aplicar a todas sin preguntar)
  */
 class RepararDatosPoliticasEmpresa extends Command
 {
     protected $signature = 'politicas:reparar-datos
-        {empresa : ID o RUC de la empresa cuyas politicas se repararan}
+        {empresa? : ID o RUC de la empresa a reparar (omitir si usas --all)}
+        {--all : Repara TODAS las empresas registradas}
         {--dry-run : Muestra los cambios sin guardarlos}
         {--force : Aplica sin pedir confirmacion}';
 
-    protected $description = 'Reemplaza datos heredados del Estudio Palacios en las politicas de una empresa por los datos propios de esa empresa.';
+    protected $description = 'Reemplaza datos heredados del Estudio Palacios en las politicas por los datos propios de cada empresa (una o --all).';
 
     public function handle(): int
     {
-        $empresa = $this->resolverEmpresa((string) $this->argument('empresa'));
+        $empresas = $this->resolverObjetivo();
 
-        if (! $empresa) {
-            $this->error('No se encontro la empresa indicada (se busca por ID o RUC).');
-
+        if ($empresas === null) {
             return self::FAILURE;
         }
 
-        $this->info("Empresa objetivo: #{$empresa->id} — {$empresa->razon_social} (RUC {$empresa->ruc})");
-
-        foreach (['email' => 'correo', 'direccion' => 'direccion'] as $campo => $etiqueta) {
-            if (blank($empresa->{$campo})) {
-                $this->warn("  ⚠  La empresa no tiene {$etiqueta} registrado; se usara un texto neutro. Considera completar el perfil de la empresa antes de aplicar.");
-            }
-        }
-
-        $reemplazos = $this->mapeoReemplazos($empresa);
-
-        $politicas = Politica::withoutGlobalScopes()
-            ->where('empresa_id', $empresa->id)
-            ->get();
-
-        if ($politicas->isEmpty()) {
-            $this->warn('La empresa no tiene politicas registradas. Nada que hacer.');
-
-            return self::SUCCESS;
-        }
-
-        // Primer pase: calcular cambios sin escribir.
+        // Primer pase: calcular cambios sin escribir, agrupados por empresa.
         $cambios = [];
         $totalReemplazos = 0;
+        $empresasConCambios = 0;
 
-        foreach ($politicas as $politica) {
-            $original = (string) $politica->contenido;
-            $nuevo = strtr($original, $reemplazos);
+        foreach ($empresas as $empresa) {
+            $this->avisarDatosFaltantes($empresa);
 
-            if ($nuevo === $original) {
+            $cambiosEmpresa = $this->calcularCambios($empresa);
+
+            if (empty($cambiosEmpresa)) {
                 continue;
             }
 
-            $n = $this->contarCoincidencias($original, $reemplazos);
-            $totalReemplazos += $n;
-            $cambios[] = ['politica' => $politica, 'nuevo' => $nuevo, 'n' => $n];
+            $empresasConCambios++;
+            $reemplazosEmpresa = array_sum(array_column($cambiosEmpresa, 'n'));
+            $totalReemplazos += $reemplazosEmpresa;
 
-            $this->line("  • [{$politica->slug}] {$politica->titulo} — {$n} reemplazo(s)");
+            $this->line("• #{$empresa->id} {$empresa->razon_social} — " . count($cambiosEmpresa) . " politica(s), {$reemplazosEmpresa} reemplazo(s)");
+            foreach ($cambiosEmpresa as $cambio) {
+                $this->line("    - [{$cambio['politica']->slug}] {$cambio['n']} reemplazo(s)");
+            }
+
+            $cambios = array_merge($cambios, $cambiosEmpresa);
         }
 
         if (empty($cambios)) {
-            $this->info('No se encontraron datos de Palacios en las politicas de esta empresa. Nada que reparar.');
+            $this->info('No se encontraron datos de Palacios en las politicas. Nada que reparar.');
 
             return self::SUCCESS;
         }
 
         $this->newLine();
-        $this->info(count($cambios) . " politica(s) con cambios, {$totalReemplazos} reemplazo(s) en total.");
+        $this->info("{$empresasConCambios} empresa(s), " . count($cambios) . " politica(s) con cambios, {$totalReemplazos} reemplazo(s) en total.");
 
         if ($this->option('dry-run')) {
             $this->comment('DRY-RUN: no se guardo nada.');
@@ -119,10 +105,102 @@ class RepararDatosPoliticasEmpresa extends Command
             return self::FAILURE;
         }
 
-        $this->info('Listo: ' . count($cambios) . ' politica(s) actualizada(s).');
+        $this->info('Listo: ' . count($cambios) . " politica(s) actualizada(s) en {$empresasConCambios} empresa(s).");
         $this->comment('Nota: el contenido se actualizo sin cambiar la "version", por lo que no se notifico a los usuarios ni se creo snapshot de version. Si quieres dejar traza de version, subela manualmente desde el panel.');
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Resuelve las empresas objetivo segun el argumento/--all. Devuelve null
+     * (e imprime el error) si la invocacion es invalida o no hay empresas.
+     *
+     * @return \Illuminate\Support\Collection<int,Empresa>|null
+     */
+    private function resolverObjetivo(): ?\Illuminate\Support\Collection
+    {
+        $todas = (bool) $this->option('all');
+        $identificador = $this->argument('empresa');
+
+        if ($todas && $identificador !== null) {
+            $this->error('Usa una empresa O --all, no ambos.');
+
+            return null;
+        }
+
+        if (! $todas && $identificador === null) {
+            $this->error('Indica una empresa (ID o RUC) o usa --all para reparar todas.');
+
+            return null;
+        }
+
+        if ($todas) {
+            $empresas = Empresa::withoutGlobalScopes()->orderBy('id')->get();
+
+            if ($empresas->isEmpty()) {
+                $this->warn('No hay empresas registradas. Nada que hacer.');
+
+                return null;
+            }
+
+            $this->info("Objetivo: TODAS las empresas ({$empresas->count()}).");
+
+            return $empresas;
+        }
+
+        $empresa = $this->resolverEmpresa((string) $identificador);
+
+        if (! $empresa) {
+            $this->error('No se encontro la empresa indicada (se busca por ID o RUC).');
+
+            return null;
+        }
+
+        $this->info("Empresa objetivo: #{$empresa->id} — {$empresa->razon_social} (RUC {$empresa->ruc})");
+
+        return collect([$empresa]);
+    }
+
+    /**
+     * Calcula los cambios pendientes de una empresa sin escribir.
+     *
+     * @return array<int,array{politica:Politica,nuevo:string,n:int}>
+     */
+    private function calcularCambios(Empresa $empresa): array
+    {
+        $reemplazos = $this->mapeoReemplazos($empresa);
+
+        $politicas = Politica::withoutGlobalScopes()
+            ->where('empresa_id', $empresa->id)
+            ->get();
+
+        $cambios = [];
+
+        foreach ($politicas as $politica) {
+            $original = (string) $politica->contenido;
+            $nuevo = strtr($original, $reemplazos);
+
+            if ($nuevo === $original) {
+                continue;
+            }
+
+            $cambios[] = [
+                'politica' => $politica,
+                'nuevo' => $nuevo,
+                'n' => $this->contarCoincidencias($original, $reemplazos),
+            ];
+        }
+
+        return $cambios;
+    }
+
+    private function avisarDatosFaltantes(Empresa $empresa): void
+    {
+        foreach (['email' => 'correo', 'direccion' => 'direccion'] as $campo => $etiqueta) {
+            if (blank($empresa->{$campo})) {
+                $this->warn("  ⚠  #{$empresa->id} {$empresa->razon_social}: no tiene {$etiqueta} registrado; se usara un texto neutro.");
+            }
+        }
     }
 
     private function resolverEmpresa(string $identificador): ?Empresa

--- a/tests/Feature/PoliticaPersonalizacionTest.php
+++ b/tests/Feature/PoliticaPersonalizacionTest.php
@@ -164,4 +164,60 @@ class PoliticaPersonalizacionTest extends TestCase
 
         $this->assertSame($original, $politica->refresh()->contenido);
     }
+
+    public function test_all_repara_todas_las_empresas(): void
+    {
+        $alfa = $this->empresa();
+        $beta = $this->empresa(['ruc' => '20222222222', 'razon_social' => 'Beta Corp E.I.R.L.', 'email' => 'hola@beta.pe', 'direccion' => 'Jr. Beta 456, Cusco']);
+
+        $polAlfa = $this->crearPolitica($alfa, $this->contenidoHeredadoDePalacios());
+        $polBeta = $this->crearPolitica($beta, $this->contenidoHeredadoDePalacios());
+
+        $this->artisan('politicas:reparar-datos', ['--all' => true, '--force' => true])
+            ->assertSuccessful();
+
+        $contenidoAlfa = $polAlfa->refresh()->contenido;
+        $contenidoBeta = $polBeta->refresh()->contenido;
+
+        $this->assertStringNotContainsString('Palacios', $contenidoAlfa);
+        $this->assertStringNotContainsString('Palacios', $contenidoBeta);
+
+        // Cada empresa recibe SUS datos, no los de la otra.
+        $this->assertStringContainsString('Alfa Legal S.A.C.', $contenidoAlfa);
+        $this->assertStringNotContainsString('Beta Corp', $contenidoAlfa);
+        $this->assertStringContainsString('Beta Corp E.I.R.L.', $contenidoBeta);
+        $this->assertStringNotContainsString('Alfa Legal', $contenidoBeta);
+    }
+
+    public function test_all_y_empresa_son_excluyentes(): void
+    {
+        $empresa = $this->empresa();
+        $politica = $this->crearPolitica($empresa, $this->contenidoHeredadoDePalacios());
+
+        $this->artisan('politicas:reparar-datos', ['empresa' => $empresa->id, '--all' => true, '--force' => true])
+            ->expectsOutputToContain('no ambos')
+            ->assertFailed();
+
+        // No toco nada.
+        $this->assertStringContainsString('Palacios', $politica->refresh()->contenido);
+    }
+
+    public function test_falla_sin_empresa_ni_all(): void
+    {
+        $this->artisan('politicas:reparar-datos')
+            ->expectsOutputToContain('Indica una empresa')
+            ->assertFailed();
+    }
+
+    public function test_all_dry_run_no_persiste(): void
+    {
+        $empresa = $this->empresa();
+        $original = $this->contenidoHeredadoDePalacios();
+        $politica = $this->crearPolitica($empresa, $original);
+
+        $this->artisan('politicas:reparar-datos', ['--all' => true, '--dry-run' => true])
+            ->assertSuccessful();
+
+        $this->assertSame($original, $politica->refresh()->contenido);
+    }
 }


### PR DESCRIPTION
## Contexto

El comando `politicas:reparar-datos` (de #186) reparaba **una** empresa por ejecución. Tras desplegar el fix de aislamiento de datos a un entorno con varias empresas ya sembradas, había que invocarlo una vez por empresa. Esta opción permite repararlas todas de una.

## Cambios

- Nueva opción **`--all`**: repara todas las empresas registradas.
- El argumento `empresa` pasa a ser **opcional**; se exige `empresa` **O** `--all` (mutuamente excluyentes; error claro si faltan ambos o se pasan ambos).
- El plan se calcula **agrupado por empresa**, con **una sola confirmación** y **una sola transacción** (rollback total si algo falla a mitad).
- Mantiene las garantías: idempotente, `saveQuietly` (no cambia versión ni notifica a usuarios).

## Uso

```bash
php artisan politicas:reparar-datos --all --dry-run   # previsualizar todas
php artisan politicas:reparar-datos --all --force     # aplicar a todas
php artisan politicas:reparar-datos <id|ruc> --force  # una sola (igual que antes)
```

## Pruebas

4 tests nuevos en `PoliticaPersonalizacionTest`:
- `--all` repara todas sin filtrar datos entre empresas (cada una recibe los suyos).
- `empresa` + `--all` son excluyentes (falla, no toca nada).
- Falla si no se pasa empresa ni `--all`.
- `--all --dry-run` no persiste.

**Suite completa: 41 passed.**

## Notas

- ⚠️ Mergear a `develop` dispara el deploy a producción (`deploy.yml`).
- Pensado para correr en el servidor tras el deploy: `php artisan politicas:reparar-datos --all --dry-run` y luego `--force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)