### PR TITLE
feat(activos-digitales): Baúl de Contraseñas — vista transversal de credenciales

### DIFF
--- a/app/Filament/Pages/AuditoriaBaul.php
+++ b/app/Filament/Pages/AuditoriaBaul.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Filament\Forms\Components\DatePicker;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Auditoria del Baul: registro de "quien revelo o copio que credencial".
+ *
+ * Solo para roles de gestion (super_admin, admin_empresa). Lee del log
+ * inmutable audit_logs las acciones 'credencial_revelada' y 'credencial_copiada',
+ * acotadas a la empresa (tenant) actual.
+ */
+class AuditoriaBaul extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedClipboardDocumentList;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Activos Digitales';
+
+    protected static ?string $title = 'Auditoría del Baúl';
+
+    protected static ?string $navigationLabel = 'Auditoría del Baúl';
+
+    protected static ?string $slug = 'baul-contrasenas/auditoria';
+
+    protected static ?int $navigationSort = 3;
+
+    protected string $view = 'filament.pages.auditoria-baul';
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole(['super_admin', 'admin_empresa']) ?? false;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                AuditLog::query()
+                    ->whereIn('accion', ['credencial_revelada', 'credencial_copiada'])
+                    ->where('empresa_id', Filament::getTenant()?->id)
+                    ->with('usuario')
+            )
+            ->columns([
+                TextColumn::make('created_at')
+                    ->label('Fecha')
+                    ->dateTime('d/m/Y H:i:s')
+                    ->sortable(),
+                TextColumn::make('usuario')
+                    ->label('Usuario')
+                    // Se usa el nombre denormalizado del log ('por'): es estable aunque el
+                    // actor sea de otra empresa (super_admin) o se elimine despues. La
+                    // relacion ->usuario queda como respaldo para registros antiguos.
+                    ->getStateUsing(fn (AuditLog $record): string => $record->datos_nuevos['por']
+                        ?? $record->usuario?->name
+                        ?? '— (usuario eliminado)'),
+                TextColumn::make('accion')
+                    ->label('Acción')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'credencial_revelada' => 'warning',
+                        'credencial_copiada' => 'info',
+                        default => 'gray',
+                    })
+                    ->icon(fn (string $state): string => match ($state) {
+                        'credencial_revelada' => 'heroicon-o-eye',
+                        'credencial_copiada' => 'heroicon-o-clipboard',
+                        default => 'heroicon-o-question-mark-circle',
+                    })
+                    ->formatStateUsing(fn (string $state): string => match ($state) {
+                        'credencial_revelada' => 'Reveló',
+                        'credencial_copiada' => 'Copió',
+                        default => $state,
+                    }),
+                TextColumn::make('cuenta')
+                    ->label('Cuenta')
+                    ->getStateUsing(fn (AuditLog $record): string => $record->datos_nuevos['activo'] ?? '—'),
+                TextColumn::make('etiqueta')
+                    ->label('Credencial')
+                    ->getStateUsing(fn (AuditLog $record): string => $record->datos_nuevos['etiqueta'] ?? '—'),
+                TextColumn::make('campo')
+                    ->label('Campo')
+                    ->badge()
+                    ->getStateUsing(fn (AuditLog $record): ?string => $record->datos_nuevos['campo'] ?? null)
+                    ->placeholder('—'),
+                TextColumn::make('ip')
+                    ->label('IP')
+                    ->toggleable(),
+                TextColumn::make('user_agent')
+                    ->label('Navegador')
+                    ->limit(40)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('accion')
+                    ->label('Acción')
+                    ->options([
+                        'credencial_revelada' => 'Revelaciones',
+                        'credencial_copiada' => 'Copias',
+                    ]),
+                SelectFilter::make('usuario_id')
+                    ->label('Usuario')
+                    ->searchable()
+                    // Opciones construidas sin tenant-scope: incluye actores de otra
+                    // empresa (super_admin) que de otro modo quedarian fuera del filtro.
+                    ->options(fn (): array => User::query()
+                        ->withoutGlobalScopes()
+                        ->whereIn('id', AuditLog::query()
+                            ->whereIn('accion', ['credencial_revelada', 'credencial_copiada'])
+                            ->where('empresa_id', Filament::getTenant()?->id)
+                            ->distinct()
+                            ->pluck('usuario_id')
+                            ->filter())
+                        ->pluck('name', 'id')
+                        ->all()),
+                Filter::make('rango')
+                    ->schema([
+                        DatePicker::make('desde')->label('Desde'),
+                        DatePicker::make('hasta')->label('Hasta'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when($data['desde'] ?? null, fn (Builder $q, $d) => $q->whereDate('created_at', '>=', $d))
+                        ->when($data['hasta'] ?? null, fn (Builder $q, $d) => $q->whereDate('created_at', '<=', $d))),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->emptyStateHeading('Sin accesos registrados')
+            ->emptyStateDescription('Aquí se registra cada vez que alguien revela o copia una contraseña del Baúl.')
+            ->emptyStateIcon(Heroicon::OutlinedClipboardDocumentList);
+    }
+}

--- a/app/Filament/Pages/BaulContrasenas.php
+++ b/app/Filament/Pages/BaulContrasenas.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Enums\TipoActivoDigital;
+use App\Models\ActivoDigital;
+use App\Models\ActivoDigitalCredencial;
+use App\Services\AuditService;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\HtmlString;
+use Livewire\Component;
+
+/**
+ * Baul de Contrasenas: una vista transversal y buscable de TODAS las
+ * credenciales de activos digitales que el usuario tiene permitido ver,
+ * sin tener que entrar cuenta por cuenta.
+ *
+ * Reutiliza la infraestructura de seguridad existente:
+ *  - Cifrado en reposo (cast 'encrypted' en ActivoDigitalCredencial).
+ *  - Autorizacion por ActivoDigitalCredencialPolicy::view() y el scope
+ *    ActivoDigitalCredencial::visiblesPara() (aislamiento por empresa + responsables).
+ *  - Auditoria de cada revelado/copiado via AuditService.
+ */
+class BaulContrasenas extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedKey;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Activos Digitales';
+
+    protected static ?string $title = 'Baúl de Contraseñas';
+
+    protected static ?string $navigationLabel = 'Baúl de Contraseñas';
+
+    protected static ?string $slug = 'baul-contrasenas';
+
+    protected static ?int $navigationSort = 2;
+
+    protected string $view = 'filament.pages.baul-contrasenas';
+
+    /**
+     * Accede quien pueda ver al menos una credencial: super_admin y
+     * admin_empresa siempre; un usuario no-admin solo si es responsable
+     * de al menos una cuenta (vera unicamente las suyas).
+     */
+    public static function canAccess(): bool
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->hasRole(['super_admin', 'admin_empresa'])) {
+            return true;
+        }
+
+        return ActivoDigital::whereHas('responsables', fn (Builder $q) => $q->whereKey($user->id))->exists();
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                ActivoDigitalCredencial::query()
+                    ->visiblesPara(auth()->user(), Filament::getTenant()?->id)
+                    ->with('activoDigital')
+            )
+            ->columns([
+                TextColumn::make('activoDigital.nombre')
+                    ->label('Cuenta')
+                    ->weight('medium')
+                    ->description(fn (ActivoDigitalCredencial $record): ?string => $record->activoDigital?->codigo_interno)
+                    ->searchable(),
+                TextColumn::make('activoDigital.tipo')
+                    ->label('Tipo')
+                    ->badge()
+                    ->icon(fn ($state): ?string => $state instanceof TipoActivoDigital ? $state->icon() : null)
+                    ->formatStateUsing(fn ($state): string => $state instanceof TipoActivoDigital ? $state->label() : (string) $state),
+                TextColumn::make('etiqueta')
+                    ->label('Credencial')
+                    ->searchable(),
+                TextColumn::make('usuario')
+                    ->label('Usuario')
+                    // Nunca se imprime el valor real: solo se indica si existe.
+                    ->formatStateUsing(fn ($state): string => filled($state) ? '••••••••' : '—'),
+                TextColumn::make('password')
+                    ->label('Contraseña')
+                    ->state('••••••••'),
+                TextColumn::make('activoDigital.proveedor')
+                    ->label('Proveedor')
+                    ->searchable()
+                    ->toggleable(),
+                TextColumn::make('activoDigital.codigo_interno')
+                    ->label('Código')
+                    ->searchable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->label('Actualizada')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('tipo')
+                    ->label('Tipo de cuenta')
+                    ->options(TipoActivoDigital::options())
+                    ->query(fn (Builder $query, array $data): Builder => $query->when(
+                        $data['value'] ?? null,
+                        fn (Builder $q, $tipo) => $q->whereHas(
+                            'activoDigital',
+                            fn (Builder $a) => $a->where('tipo', $tipo)
+                        )
+                    )),
+            ])
+            ->recordActions([
+                Action::make('revelar')
+                    ->label('Ver')
+                    ->icon('heroicon-o-eye')
+                    ->color('warning')
+                    ->visible(fn (ActivoDigitalCredencial $record): bool => auth()->user()?->can('view', $record) ?? false)
+                    ->modalHeading('Credenciales')
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Cerrar')
+                    // El log se registra al montar la accion (una vez por apertura);
+                    // modalContent puede re-renderizarse y duplicaria el registro.
+                    ->mountUsing(fn (ActivoDigitalCredencial $record) => static::auditarRevelacion($record))
+                    ->modalContent(fn (ActivoDigitalCredencial $record): HtmlString => static::contenidoRevelado($record)),
+                Action::make('copiarUsuario')
+                    ->label('Usuario')
+                    ->icon('heroicon-o-clipboard-document')
+                    ->color('gray')
+                    ->visible(fn (ActivoDigitalCredencial $record): bool => filled($record->usuario) && (auth()->user()?->can('view', $record) ?? false))
+                    ->action(fn (ActivoDigitalCredencial $record, Component $livewire) => static::copiarCampo($record, 'usuario', 'Usuario', $livewire)),
+                Action::make('copiarPassword')
+                    ->label('Copiar')
+                    ->icon('heroicon-o-clipboard')
+                    ->color('primary')
+                    ->visible(fn (ActivoDigitalCredencial $record): bool => filled($record->password) && (auth()->user()?->can('view', $record) ?? false))
+                    ->action(fn (ActivoDigitalCredencial $record, Component $livewire) => static::copiarCampo($record, 'password', 'Contraseña', $livewire)),
+            ])
+            ->defaultSort('updated_at', 'desc')
+            ->emptyStateHeading('Sin contraseñas disponibles')
+            ->emptyStateDescription('Aquí aparecerán, cifradas, todas las credenciales de las cuentas a las que tienes acceso.')
+            ->emptyStateIcon(Heroicon::OutlinedKey);
+    }
+
+    /**
+     * Registra en auditoria que se revelaron las credenciales (una vez por apertura).
+     */
+    protected static function auditarRevelacion(ActivoDigitalCredencial $record): void
+    {
+        AuditService::log(
+            accion: 'credencial_revelada',
+            entidad: 'ActivoDigitalCredencial',
+            entidadId: $record->id,
+            datosNuevos: static::datosAcceso($record),
+            empresaId: $record->activoDigital?->empresa_id,
+        );
+    }
+
+    /**
+     * Renderiza los valores descifrados para el modal de revelado.
+     */
+    protected static function contenidoRevelado(ActivoDigitalCredencial $record): HtmlString
+    {
+        $row = fn (string $label, ?string $value): string => '<div class="py-2 border-b border-gray-100 dark:border-gray-800">'
+            .'<p class="text-xs font-medium text-gray-500">'.e($label).'</p>'
+            .'<p class="text-sm text-gray-900 dark:text-gray-100 font-mono break-all">'.(filled($value) ? e($value) : '—').'</p></div>';
+
+        $cuenta = $record->activoDigital?->nombre;
+
+        return new HtmlString(
+            ($cuenta ? $row('Cuenta', $cuenta) : '')
+            .$row('Etiqueta', $record->etiqueta)
+            .$row('Usuario / correo', $record->usuario)
+            .$row('Contraseña', $record->password)
+            .$row('2FA / TOTP seed', $record->dato_2fa)
+            .$row('Códigos de recuperación', $record->recovery)
+            .$row('Notas', $record->notas)
+        );
+    }
+
+    /**
+     * Copia un campo sensible al portapapeles del cliente:
+     *  - Reverifica la autorizacion en el servidor (defensa en profundidad).
+     *  - Audita el acceso (accion 'credencial_copiada').
+     *  - Despacha el valor descifrado a Alpine, que lo escribe en el
+     *    portapapeles y lo borra a los ~20s (ver baul-contrasenas.blade.php).
+     */
+    protected static function copiarCampo(ActivoDigitalCredencial $record, string $campo, string $etiquetaCampo, Component $livewire): void
+    {
+        if (! (auth()->user()?->can('view', $record) ?? false)) {
+            Notification::make()->title('No autorizado')->danger()->send();
+
+            return;
+        }
+
+        $valor = (string) ($record->{$campo} ?? '');
+
+        if ($valor === '') {
+            Notification::make()->title('Sin valor que copiar')->warning()->send();
+
+            return;
+        }
+
+        AuditService::log(
+            accion: 'credencial_copiada',
+            entidad: 'ActivoDigitalCredencial',
+            entidadId: $record->id,
+            datosNuevos: ['campo' => $campo] + static::datosAcceso($record),
+            empresaId: $record->activoDigital?->empresa_id,
+        );
+
+        $livewire->dispatch('baul-copiar', valor: $valor, etiqueta: $etiquetaCampo);
+
+        Notification::make()
+            ->title('Copiado al portapapeles')
+            ->body($etiquetaCampo.' · se limpiará automáticamente en 20 segundos.')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Metadatos comunes para auditar el acceso a una credencial.
+     * Incluye el nombre del actor (denormalizado) para que el registro
+     * sea legible aunque luego se elimine el usuario o cambie de empresa.
+     *
+     * @return array<string, mixed>
+     */
+    protected static function datosAcceso(ActivoDigitalCredencial $record): array
+    {
+        return [
+            'etiqueta' => $record->etiqueta,
+            'activo' => $record->activoDigital?->nombre,
+            'activo_digital_id' => $record->activo_digital_id,
+            'por' => auth()->user()?->name,
+        ];
+    }
+}

--- a/app/Filament/Pages/BaulContrasenas.php
+++ b/app/Filament/Pages/BaulContrasenas.php
@@ -69,6 +69,19 @@ class BaulContrasenas extends Page implements HasTable
         return ActivoDigital::whereHas('responsables', fn (Builder $q) => $q->whereKey($user->id))->exists();
     }
 
+    /**
+     * Permite llegar pre-filtrado desde la busqueda global (Ctrl/Cmd+K):
+     * /baul-contrasenas?q=<cuenta> precarga el buscador de la tabla.
+     */
+    public function mount(): void
+    {
+        $q = request()->query('q');
+
+        if (is_string($q) && $q !== '') {
+            $this->tableSearch = $q;
+        }
+    }
+
     public function table(Table $table): Table
     {
         return $table

--- a/app/Filament/Resources/ActivosDigitales/RelationManagers/CredencialesRelationManager.php
+++ b/app/Filament/Resources/ActivosDigitales/RelationManagers/CredencialesRelationManager.php
@@ -108,15 +108,23 @@ class CredencialesRelationManager extends RelationManager
                     ->modalHeading('Credenciales')
                     ->modalSubmitAction(false)
                     ->modalCancelActionLabel('Cerrar')
-                    ->modalContent(function (ActivoDigitalCredencial $record): HtmlString {
-                        // Registrar el acceso a credenciales sensibles en auditoria
+                    // El log se registra al montar la accion (una sola vez por apertura);
+                    // modalContent puede re-renderizarse y duplicaria el registro.
+                    ->mountUsing(function (ActivoDigitalCredencial $record): void {
                         AuditService::log(
                             accion: 'credencial_revelada',
                             entidad: 'ActivoDigitalCredencial',
                             entidadId: $record->id,
-                            datosNuevos: ['etiqueta' => $record->etiqueta, 'activo_digital_id' => $record->activo_digital_id],
+                            datosNuevos: [
+                                'etiqueta' => $record->etiqueta,
+                                'activo' => $record->activoDigital?->nombre,
+                                'activo_digital_id' => $record->activo_digital_id,
+                                'por' => auth()->user()?->name,
+                            ],
+                            empresaId: $record->activoDigital?->empresa_id,
                         );
-
+                    })
+                    ->modalContent(function (ActivoDigitalCredencial $record): HtmlString {
                         $row = fn (string $label, ?string $value): string => '<div class="py-2 border-b border-gray-100 dark:border-gray-800">'
                             . '<p class="text-xs font-medium text-gray-500">' . e($label) . '</p>'
                             . '<p class="text-sm text-gray-900 dark:text-gray-100 font-mono break-all">' . (filled($value) ? e($value) : '—') . '</p></div>';

--- a/app/Filament/Resources/Baul/CredencialBaulResource.php
+++ b/app/Filament/Resources/Baul/CredencialBaulResource.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Filament\Resources\Baul;
+
+use App\Enums\TipoActivoDigital;
+use App\Filament\Pages\BaulContrasenas;
+use App\Models\ActivoDigitalCredencial;
+use Filament\Facades\Filament;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Resource "solo busqueda": no aparece en navegacion ni tiene paginas propias.
+ * Su unico fin es exponer las credenciales en la busqueda global (Ctrl/Cmd+K)
+ * para encontrar una cuenta por nombre/etiqueta/proveedor y aterrizar en el
+ * Baul de Contrasenas ya filtrado.
+ *
+ * Seguridad:
+ *  - getGlobalSearchEloquentQuery() acota a lo que el usuario puede ver
+ *    (empresa + responsables) via el scope visiblesPara(): nunca filtra
+ *    credenciales de otras empresas ni de cuentas ajenas.
+ *  - Solo se busca/expone por campos NO sensibles (nombre de cuenta, etiqueta,
+ *    proveedor, codigo). El usuario/contrasena cifrados nunca se buscan ni se
+ *    muestran en los resultados.
+ */
+class CredencialBaulResource extends Resource
+{
+    protected static ?string $model = ActivoDigitalCredencial::class;
+
+    protected static ?string $recordTitleAttribute = 'etiqueta';
+
+    // Encabezado del grupo de resultados en la búsqueda global.
+    protected static ?string $modelLabel = 'Contraseña';
+
+    protected static ?string $pluralModelLabel = 'Baúl de Contraseñas';
+
+    protected static ?string $slug = 'baul-credenciales-buscar';
+
+    /**
+     * El aislamiento por empresa lo hace getGlobalSearchEloquentQuery() via
+     * visiblesPara(). Se desactiva el tenant-scope automatico de Filament
+     * porque ActivoDigitalCredencial no tiene relacion `empresa` directa
+     * (su empresa es transitiva a traves de activoDigital).
+     */
+    protected static bool $isScopedToTenant = false;
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return false;
+    }
+
+    public static function getPages(): array
+    {
+        return [];
+    }
+
+    /** El acceso a la busqueda es el mismo que al Baul. */
+    public static function canAccess(): bool
+    {
+        return BaulContrasenas::canAccess();
+    }
+
+    /** @return array<string> */
+    public static function getGloballySearchableAttributes(): array
+    {
+        return [
+            'etiqueta',
+            'activoDigital.nombre',
+            'activoDigital.proveedor',
+            'activoDigital.codigo_interno',
+        ];
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string
+    {
+        $cuenta = $record->activoDigital?->nombre ?? 'Cuenta';
+
+        return $cuenta.' — '.$record->etiqueta;
+    }
+
+    /** @return array<string, string> */
+    public static function getGlobalSearchResultDetails(Model $record): array
+    {
+        $tipo = $record->activoDigital?->tipo;
+
+        return [
+            'Tipo' => $tipo instanceof TipoActivoDigital ? $tipo->label() : '—',
+            'Proveedor' => $record->activoDigital?->proveedor ?: '—',
+            'Código' => $record->activoDigital?->codigo_interno ?? '—',
+        ];
+    }
+
+    public static function getGlobalSearchResultUrl(Model $record): ?string
+    {
+        // Lleva al Baul pre-filtrado por la cuenta para ver/copiar sus contrasenas.
+        return BaulContrasenas::getUrl(['q' => $record->activoDigital?->nombre]);
+    }
+
+    public static function getGlobalSearchEloquentQuery(): Builder
+    {
+        return ActivoDigitalCredencial::query()
+            ->visiblesPara(auth()->user(), Filament::getTenant()?->id)
+            ->with('activoDigital');
+    }
+}

--- a/app/Models/ActivoDigitalCredencial.php
+++ b/app/Models/ActivoDigitalCredencial.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -45,5 +46,30 @@ class ActivoDigitalCredencial extends Model
     public function activoDigital(): BelongsTo
     {
         return $this->belongsTo(ActivoDigital::class, 'activo_digital_id');
+    }
+
+    /**
+     * Limita la consulta a las credenciales que un usuario puede ver en el
+     * Baul de Contrasenas. Refleja exactamente ActivoDigitalCredencialPolicy::view():
+     *
+     * - El filtro por empresa (tenant) es explicito y siempre aplica, asi que
+     *   ni siquiera un super_admin cruza datos entre empresas en esta vista.
+     * - Los roles de gestion (super_admin, admin_empresa) ven todas las cuentas
+     *   de la empresa; el resto solo las cuentas de las que son responsables.
+     * - El whereHas sobre activoDigital arrastra los global scopes del activo
+     *   (EmpresaScope + SoftDeletes), por lo que no aparecen credenciales de
+     *   cuentas eliminadas ni de otras empresas.
+     */
+    public function scopeVisiblesPara(Builder $query, User $user, ?int $empresaId): Builder
+    {
+        return $query->whereHas('activoDigital', function (Builder $q) use ($user, $empresaId): void {
+            if ($empresaId !== null) {
+                $q->where('activos_digitales.empresa_id', $empresaId);
+            }
+
+            if (! $user->hasRole(['super_admin', 'admin_empresa'])) {
+                $q->whereHas('responsables', fn (Builder $r) => $r->whereKey($user->id));
+            }
+        });
     }
 }

--- a/app/Services/AuditService.php
+++ b/app/Services/AuditService.php
@@ -12,10 +12,13 @@ class AuditService
         ?int $entidadId = null,
         ?array $datosAnteriores = null,
         ?array $datosNuevos = null,
+        ?int $empresaId = null,
     ): AuditLog {
         return AuditLog::create([
             'usuario_id' => auth()->id(),
-            'empresa_id' => auth()->user()?->empresa_id,
+            // Permite atribuir el log a la empresa de la entidad afectada (no la del actor):
+            // util cuando un super_admin opera sobre datos de una empresa distinta a la suya.
+            'empresa_id' => $empresaId ?? auth()->user()?->empresa_id,
             'accion' => $accion,
             'entidad' => $entidad,
             'entidad_id' => $entidadId,

--- a/resources/views/filament/pages/auditoria-baul.blade.php
+++ b/resources/views/filament/pages/auditoria-baul.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/resources/views/filament/pages/baul-contrasenas.blade.php
+++ b/resources/views/filament/pages/baul-contrasenas.blade.php
@@ -1,0 +1,30 @@
+<x-filament-panels::page>
+    {{--
+        Recibe el valor descifrado despachado por la accion "Copiar" (servidor),
+        lo escribe en el portapapeles y lo limpia a los ~20s (best-effort: el
+        navegador solo permite limpiar si la pestana sigue enfocada).
+    --}}
+    <div
+        x-data="{
+            limpiar: null,
+            async copiar(valor) {
+                if (! navigator.clipboard) {
+                    new FilamentNotification().title('Tu navegador no permite copiar automáticamente').warning().send();
+                    return;
+                }
+                try {
+                    await navigator.clipboard.writeText(valor);
+                    clearTimeout(this.limpiar);
+                    this.limpiar = setTimeout(() => {
+                        navigator.clipboard.writeText('').catch(() => {});
+                    }, 20000);
+                } catch (e) {
+                    new FilamentNotification().title('No se pudo copiar al portapapeles').danger().send();
+                }
+            }
+        }"
+        x-on:baul-copiar.window="copiar($event.detail.valor)"
+    >
+        {{ $this->table }}
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/BaulContrasenasTest.php
+++ b/tests/Feature/BaulContrasenasTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Pages\AuditoriaBaul;
+use App\Filament\Pages\BaulContrasenas;
+use App\Models\ActivoDigital;
+use App\Models\ActivoDigitalCredencial;
+use App\Models\Empresa;
+use App\Models\User;
+use App\Services\AuditService;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BaulContrasenasTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Empresa $empresaA;
+
+    private Empresa $empresaB;
+
+    private User $superAdmin;
+
+    private User $adminA;
+
+    private User $usuarioResponsable; // responsable solo de la cuenta A1
+
+    private User $usuarioSinAcceso;   // de empresa A, sin responsabilidad
+
+    private ActivoDigital $activoA1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->empresaA = Empresa::create(['ruc' => '20100000001', 'razon_social' => 'Empresa A']);
+        $this->empresaB = Empresa::create(['ruc' => '20100000002', 'razon_social' => 'Empresa B']);
+
+        $this->superAdmin = $this->usuario('super_admin', null);
+        $this->adminA = $this->usuario('admin_empresa', $this->empresaA->id);
+        $this->usuarioResponsable = $this->usuario('usuario', $this->empresaA->id);
+        $this->usuarioSinAcceso = $this->usuario('usuario', $this->empresaA->id);
+
+        // Empresa A: dos cuentas con credencial. Empresa B: una cuenta.
+        $this->activoA1 = $this->activoConCredencial($this->empresaA->id, 'Cuenta A1', 'Demo*A1clave');
+        $this->activoConCredencial($this->empresaA->id, 'Cuenta A2', 'Demo*A2clave');
+        $this->activoConCredencial($this->empresaB->id, 'Cuenta B1', 'Demo*B1clave');
+
+        // El usuario "responsable" solo gestiona la cuenta A1.
+        $this->activoA1->responsables()->attach($this->usuarioResponsable->id);
+    }
+
+    private function usuario(string $rol, ?int $empresaId): User
+    {
+        $user = User::create([
+            'name' => ucfirst($rol),
+            'email' => $rol.'-'.uniqid().'@test.local',
+            'password' => 'secret123',
+            'empresa_id' => $empresaId,
+            'estado' => 'activo',
+        ]);
+        $user->syncRoles($rol);
+
+        return $user;
+    }
+
+    private function activoConCredencial(int $empresaId, string $nombre, string $password): ActivoDigital
+    {
+        // Se crea sin sesion activa: el EmpresaScope no filtra y el empresa_id es explicito.
+        $activo = ActivoDigital::create([
+            'empresa_id' => $empresaId,
+            'nombre' => $nombre,
+            'tipo' => 'suscripcion_saas',
+        ]);
+
+        $activo->credenciales()->create([
+            'etiqueta' => 'Administrador',
+            'usuario' => 'admin@empresa'.$empresaId.'.test',
+            'password' => $password,
+        ]);
+
+        return $activo;
+    }
+
+    /** @return Collection<int, ActivoDigitalCredencial> */
+    private function visibles(User $user, ?int $empresaId): Collection
+    {
+        return ActivoDigitalCredencial::visiblesPara($user, $empresaId)->get();
+    }
+
+    public function test_super_admin_ve_todas_las_credenciales_pero_acotadas_al_tenant(): void
+    {
+        $this->actingAs($this->superAdmin);
+
+        $this->assertCount(2, $this->visibles($this->superAdmin, $this->empresaA->id));
+        $this->assertCount(1, $this->visibles($this->superAdmin, $this->empresaB->id));
+    }
+
+    public function test_admin_empresa_solo_ve_las_de_su_empresa(): void
+    {
+        $this->actingAs($this->adminA);
+
+        $this->assertCount(2, $this->visibles($this->adminA, $this->empresaA->id));
+
+        // No puede ver otra empresa ni aunque se le pase el id de la empresa ajena.
+        $this->assertCount(0, $this->visibles($this->adminA, $this->empresaB->id));
+    }
+
+    public function test_usuario_responsable_solo_ve_las_cuentas_a_su_cargo(): void
+    {
+        $this->actingAs($this->usuarioResponsable);
+
+        $visibles = $this->visibles($this->usuarioResponsable, $this->empresaA->id);
+
+        $this->assertCount(1, $visibles);
+        $this->assertSame($this->activoA1->id, $visibles->first()->activo_digital_id);
+    }
+
+    public function test_usuario_sin_responsabilidad_no_ve_ninguna_credencial(): void
+    {
+        $this->actingAs($this->usuarioSinAcceso);
+
+        $this->assertCount(0, $this->visibles($this->usuarioSinAcceso, $this->empresaA->id));
+    }
+
+    public function test_acceso_al_baul_por_rol_y_responsabilidad(): void
+    {
+        $this->actingAs($this->superAdmin);
+        $this->assertTrue(BaulContrasenas::canAccess());
+
+        $this->actingAs($this->adminA);
+        $this->assertTrue(BaulContrasenas::canAccess());
+
+        $this->actingAs($this->usuarioResponsable);
+        $this->assertTrue(BaulContrasenas::canAccess());
+
+        $this->actingAs($this->usuarioSinAcceso);
+        $this->assertFalse(BaulContrasenas::canAccess());
+    }
+
+    public function test_auditoria_del_baul_solo_para_administradores(): void
+    {
+        $this->actingAs($this->superAdmin);
+        $this->assertTrue(AuditoriaBaul::canAccess());
+
+        $this->actingAs($this->adminA);
+        $this->assertTrue(AuditoriaBaul::canAccess());
+
+        $this->actingAs($this->usuarioResponsable);
+        $this->assertFalse(AuditoriaBaul::canAccess());
+
+        $this->actingAs($this->usuarioSinAcceso);
+        $this->assertFalse(AuditoriaBaul::canAccess());
+    }
+
+    public function test_revelar_muestra_el_secreto_y_lo_audita_en_la_empresa_de_la_credencial(): void
+    {
+        // El super_admin no tiene empresa propia; aun asi el log debe atribuirse a la empresa A.
+        $this->actingAs($this->superAdmin);
+
+        $credencial = $this->activoA1->credenciales()->first();
+
+        // El contenido del modal muestra el valor descifrado (render puro, sin auditar).
+        $contenido = new \ReflectionMethod(BaulContrasenas::class, 'contenidoRevelado');
+        $contenido->setAccessible(true);
+        $this->assertStringContainsString('Demo*A1clave', (string) $contenido->invoke(null, $credencial));
+
+        // La auditoria se registra al montar la accion (una sola vez por apertura).
+        $auditar = new \ReflectionMethod(BaulContrasenas::class, 'auditarRevelacion');
+        $auditar->setAccessible(true);
+        $auditar->invoke(null, $credencial);
+
+        // Queda auditado y atribuido a la empresa de la credencial (no a la del actor).
+        $this->assertDatabaseHas('audit_logs', [
+            'accion' => 'credencial_revelada',
+            'entidad' => 'ActivoDigitalCredencial',
+            'entidad_id' => $credencial->id,
+            'empresa_id' => $this->empresaA->id,
+        ]);
+
+        // Conserva el nombre del actor de forma denormalizada (sobrevive al tenant-scoping).
+        $log = \App\Models\AuditLog::where('entidad_id', $credencial->id)->latest('id')->first();
+        $this->assertSame($this->superAdmin->name, $log->datos_nuevos['por']);
+    }
+
+    public function test_audit_service_permite_atribuir_empresa_explicita(): void
+    {
+        $this->actingAs($this->adminA); // empresa A
+
+        AuditService::log(accion: 'prueba_empresa_explicita', empresaId: $this->empresaB->id);
+        $this->assertDatabaseHas('audit_logs', [
+            'accion' => 'prueba_empresa_explicita',
+            'empresa_id' => $this->empresaB->id,
+        ]);
+
+        // Sin override, usa la empresa del actor.
+        AuditService::log(accion: 'prueba_empresa_actor');
+        $this->assertDatabaseHas('audit_logs', [
+            'accion' => 'prueba_empresa_actor',
+            'empresa_id' => $this->empresaA->id,
+        ]);
+    }
+}

--- a/tests/Feature/BaulContrasenasTest.php
+++ b/tests/Feature/BaulContrasenasTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Filament\Pages\AuditoriaBaul;
 use App\Filament\Pages\BaulContrasenas;
+use App\Filament\Resources\Baul\CredencialBaulResource;
 use App\Models\ActivoDigital;
 use App\Models\ActivoDigitalCredencial;
 use App\Models\Empresa;
@@ -203,5 +204,48 @@ class BaulContrasenasTest extends TestCase
             'accion' => 'prueba_empresa_actor',
             'empresa_id' => $this->empresaA->id,
         ]);
+    }
+
+    public function test_busqueda_global_acceso_igual_que_el_baul(): void
+    {
+        $this->actingAs($this->superAdmin);
+        $this->assertTrue(CredencialBaulResource::canAccess());
+
+        $this->actingAs($this->usuarioResponsable);
+        $this->assertTrue(CredencialBaulResource::canAccess());
+
+        $this->actingAs($this->usuarioSinAcceso);
+        $this->assertFalse(CredencialBaulResource::canAccess());
+    }
+
+    public function test_busqueda_global_respeta_responsables(): void
+    {
+        // El responsable solo encuentra credenciales de las cuentas a su cargo.
+        $this->actingAs($this->usuarioResponsable);
+        $visibles = CredencialBaulResource::getGlobalSearchEloquentQuery()->get();
+        $this->assertCount(1, $visibles);
+        $this->assertSame($this->activoA1->id, $visibles->first()->activo_digital_id);
+
+        // Quien no es responsable de ninguna cuenta no encuentra nada.
+        $this->actingAs($this->usuarioSinAcceso);
+        $this->assertCount(0, CredencialBaulResource::getGlobalSearchEloquentQuery()->get());
+    }
+
+    public function test_busqueda_global_nunca_expone_secretos(): void
+    {
+        // Los campos cifrados no son buscables (no se puede buscar por contraseña/usuario/2FA).
+        $buscables = CredencialBaulResource::getGloballySearchableAttributes();
+        foreach (['password', 'usuario', 'dato_2fa', 'recovery', 'notas'] as $sensible) {
+            $this->assertNotContains($sensible, $buscables);
+            $this->assertNotContains("activoDigital.{$sensible}", $buscables);
+        }
+
+        // Ni el título ni los detalles del resultado contienen el secreto descifrado.
+        $credencial = $this->activoA1->credenciales()->first();
+        $titulo = CredencialBaulResource::getGlobalSearchResultTitle($credencial);
+        $detalles = implode(' ', CredencialBaulResource::getGlobalSearchResultDetails($credencial));
+
+        $this->assertStringNotContainsString('Demo*A1clave', (string) $titulo);
+        $this->assertStringNotContainsString('Demo*A1clave', $detalles);
     }
 }


### PR DESCRIPTION
## Qué hace

Un componente tipo **Bitwarden/1Password**: una sola vista buscable con **todas las contraseñas** de los activos digitales que el usuario puede ver, en vez de entrar cuenta por cuenta. Reutiliza la infraestructura segura existente (cifrado `encrypted`, `ActivoDigitalCredencialPolicy`, `AuditService`, `EmpresaScope`).

## Componentes

- **Baúl de Contraseñas** (`app/Filament/Pages/BaulContrasenas.php`): tabla transversal de credenciales, búsqueda por cuenta/proveedor/etiqueta (**nunca** por el secreto cifrado), filtro por tipo. Acciones por fila: **Ver** (modal con valores descifrados, auditado) y **Copiar** usuario/contraseña al portapapeles (auditado, auto-limpieza ~20 s vía Alpine). Secretos siempre enmascarados (`••••`).
- **Auditoría del Baúl** (`app/Filament/Pages/AuditoriaBaul.php`, solo super_admin/admin_empresa): quién reveló/copió qué credencial, acotado al tenant.
- **`ActivoDigitalCredencial::scopeVisiblesPara()`**: frontera de acceso testeable (empresa + responsables), refleja `Policy::view()`.
- **`AuditService::log(empresaId:)`**: atribuye el acceso a la empresa de la credencial (correcto incluso para super_admin).

## Seguridad

- Las contraseñas no aparecen nunca en la tabla ni en la búsqueda.
- Cada revelado/copiado **reverifica permisos en el servidor** y se audita con IP, user-agent y nombre del actor.
- Acceso: super_admin / admin_empresa (su empresa) / usuario responsable (solo sus cuentas) — idéntico a la Policy ya existente.

## Pruebas

- `tests/Feature/BaulContrasenasTest.php` (8 tests): visibilidad por rol/tenant/responsable, `canAccess` de ambas páginas, atribución de empresa y de actor.
- Suite completa: **23 passed**. Verificado además en navegador (revelar, copiar al portapapeles con el valor real, auditoría).

## Notas

- Stack real es **Filament 5.4 / Laravel 12** (no Filament 3 como dice CLAUDE.md); el código sigue las APIs de F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)